### PR TITLE
[sdk/python] Enhance Runner API with auto-start and fail_if_exists

### DIFF
--- a/sdk/python/src/flamepy/core/client.py
+++ b/sdk/python/src/flamepy/core/client.py
@@ -97,7 +97,7 @@ def list_applications() -> List[Application]:
     return conn.list_applications()
 
 
-def get_application(name: str) -> Application:
+def get_application(name: str) -> Optional[Application]:
     conn = ConnectionInstance.instance()
     return conn.get_application(name)
 
@@ -282,8 +282,8 @@ class Connection:
         except grpc.RpcError as e:
             raise FlameError(FlameErrorCode.INTERNAL, f"failed to list applications: {e.details()}")
 
-    def get_application(self, name: str) -> Application:
-        """Get an application by name."""
+    def get_application(self, name: str) -> Optional[Application]:
+        """Get an application by name. Returns None if not found."""
         request = GetApplicationRequest(name=name)
 
         try:
@@ -319,6 +319,8 @@ class Connection:
             )
 
         except grpc.RpcError as e:
+            if e.code() == grpc.StatusCode.NOT_FOUND:
+                return None
             raise FlameError(FlameErrorCode.INTERNAL, f"failed to get application: {e.details()}")
 
     def create_session(self, attrs: SessionAttributes) -> "Session":

--- a/sdk/python/src/flamepy/core/types.py
+++ b/sdk/python/src/flamepy/core/types.py
@@ -76,6 +76,8 @@ class FlameErrorCode(IntEnum):
     INVALID_STATE = 1
     INVALID_ARGUMENT = 2
     INTERNAL = 3
+    ALREADY_EXISTS = 4
+    NOT_FOUND = 5
 
 
 class FlameError(Exception):


### PR DESCRIPTION
## Summary

Enhances the `Runner` class API with improved lifecycle management and better handling of existing applications.

## Changes

### Runner API Enhancements

- **Auto-start behavior**: Runner now starts automatically in `__init__` - no need for context manager or explicit start
- **`fail_if_exists` parameter**: Controls behavior when application already exists
  - `False` (default): Skip registration silently if app exists
  - `True`: Raise `FlameError` with `ALREADY_EXISTS` code
- **Refactored `__enter__`**: Now calls internal `_start()` method
- **Refactored `__exit__`**: Now calls public `close()` method
- **Public `close()` method**: Can be called explicitly for non-context-manager usage

### New Error Codes

Added to `FlameErrorCode`:
- `ALREADY_EXISTS = 4`
- `NOT_FOUND = 5`

## Usage

```python
# Simple usage - starts automatically, skips if exists
rr = runner.Runner("my-app")
service = rr.service(my_func)
result = service(1, 2).get()
rr.close()

# Context manager still works
with runner.Runner("my-app") as rr:
    service = rr.service(my_func)

# Fail if application already exists
rr = runner.Runner("my-app", fail_if_exists=True)  # Raises if exists
```

## New E2E Tests

- `test_runner_auto_start`: Verify auto-start behavior
- `test_runner_explicit_close`: Verify explicit close() works
- `test_runner_fail_if_exists_true`: Verify error on existing app
- `test_runner_fail_if_exists_false`: Verify skip on existing app  
- `test_runner_close_idempotent`: Verify close() is safe to call multiple times