### PR TITLE
[sdk/rust] Fix init_logger failing when RUST_LOG is not set

### DIFF
--- a/sdk/rust/src/apis/mod.rs
+++ b/sdk/rust/src/apis/mod.rs
@@ -211,7 +211,7 @@ impl From<rpc::ExecutorState> for ExecutorState {
 }
 
 pub fn init_logger() -> Result<(), FlameError> {
-    let filter = tracing_subscriber::EnvFilter::try_from_default_env()?
+    let filter = tracing_subscriber::EnvFilter::from_default_env()
         .add_directive("h2=error".parse()?)
         .add_directive("hyper_util=error".parse()?)
         .add_directive("tower=error".parse()?);


### PR DESCRIPTION
## Summary

- Fix `flmping` and other CLI tools failing with `InvalidConfig("environment variable not found")` when `RUST_LOG` is not set
- Use `from_default_env()` instead of `try_from_default_env()` to provide a default filter when `RUST_LOG` environment variable is missing

## Root Cause

`EnvFilter::try_from_default_env()` returns `FromEnvError` when `RUST_LOG` is not set, which was being converted to `InvalidConfig` error via the `From<FromEnvError>` impl, causing confusing error messages.

## Testing

```shell
# Before: fails without RUST_LOG
$ ./target/debug/flmping
Error: InvalidConfig("environment variable not found")

# After: works without RUST_LOG
$ ./target/debug/flmping
Session <flmping-nGVmVA> was created in <9 ms>, start to run <10> tasks in the session:
...
```