### PR TITLE
[docker] Add git to flame-executor-manager image

### DIFF
--- a/docker/Dockerfile.fem
+++ b/docker/Dockerfile.fem
@@ -23,7 +23,7 @@ RUN /usr/local/cargo/bin/flmadm install \
 
 FROM ubuntu:24.04
 
-RUN apt-get update && apt-get install -y python3-pip && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y python3-pip git && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /usr/local/flame/work
 


### PR DESCRIPTION
## Summary

Add git to flame-executor-manager Docker image to support downloading dependencies via git (e.g., `uv` with git dependencies in pyproject.toml).