### PR TITLE
[sdk/python] Add FlameSessionContext for custom session IDs (RFE350)

### DIFF
--- a/e2e/tests/test_runner.py
+++ b/e2e/tests/test_runner.py
@@ -14,7 +14,7 @@ limitations under the License.
 import pytest
 import flamepy
 from flamepy import runner
-from flamepy.runner import FlameSessionContext
+from flamepy.runner import SessionContext
 import os
 import tempfile
 from pathlib import Path
@@ -487,15 +487,15 @@ def test_runner_close_idempotent(check_package_config, check_flmrun_app):
 
 
 # =============================================================================
-# FlameSessionContext Tests (RFE350)
+# SessionContext Tests (RFE350)
 # =============================================================================
 
 
-def test_flame_session_context_with_class(check_package_config, check_flmrun_app):
-    """Test Case 26: Test FlameSessionContext with a class."""
+def test_session_context_with_class(check_package_config, check_flmrun_app):
+    """Test Case 26: Test SessionContext with a class."""
     # Define a class with custom session context
     class ServiceWithContext:
-        _flame_session_context = FlameSessionContext(
+        _session_context = SessionContext(
             session_id="test-class-session-001",
             application_name="test-class-app"
         )
@@ -517,11 +517,11 @@ def test_flame_session_context_with_class(check_package_config, check_flmrun_app
         assert value == 42, f"Expected 42, got {value}"
 
 
-def test_flame_session_context_with_instance(check_package_config, check_flmrun_app):
-    """Test Case 27: Test FlameSessionContext with an instance (object)."""
+def test_session_context_with_instance(check_package_config, check_flmrun_app):
+    """Test Case 27: Test SessionContext with an instance (object)."""
     # Create an instance and attach context
     counter = Counter()
-    counter._flame_session_context = FlameSessionContext(
+    counter._session_context = SessionContext(
         session_id="test-instance-session-001",
         application_name="test-instance-app"
     )
@@ -541,13 +541,13 @@ def test_flame_session_context_with_instance(check_package_config, check_flmrun_
         assert value == 10, f"Expected 10, got {value}"
 
 
-def test_flame_session_context_with_function(check_package_config, check_flmrun_app):
-    """Test Case 28: Test FlameSessionContext with a function."""
+def test_session_context_with_function(check_package_config, check_flmrun_app):
+    """Test Case 28: Test SessionContext with a function."""
     # Create a function and attach context
     def my_sum(a: int, b: int) -> int:
         return a + b
 
-    my_sum._flame_session_context = FlameSessionContext(
+    my_sum._session_context = SessionContext(
         session_id="test-func-session-001",
         application_name="test-func-app"
     )
@@ -566,10 +566,10 @@ def test_flame_session_context_with_function(check_package_config, check_flmrun_
         assert value == 30, f"Expected 30, got {value}"
 
 
-def test_flame_session_context_no_session_id(check_package_config, check_flmrun_app):
-    """Test Case 29: Test FlameSessionContext with session_id=None (auto-generate)."""
+def test_session_context_no_session_id(check_package_config, check_flmrun_app):
+    """Test Case 29: Test SessionContext with session_id=None (auto-generate)."""
     class ServiceWithPartialContext:
-        _flame_session_context = FlameSessionContext(
+        _session_context = SessionContext(
             application_name="partial-ctx-app"
             # session_id is None, should auto-generate
         )
@@ -591,9 +591,9 @@ def test_flame_session_context_no_session_id(check_package_config, check_flmrun_
         assert value == "hello", f"Expected 'hello', got {value}"
 
 
-def test_flame_session_context_without_context(check_package_config, check_flmrun_app):
-    """Test Case 30: Test that services without FlameSessionContext still work (backward compatibility)."""
-    # Standard class without _flame_session_context
+def test_session_context_without_context(check_package_config, check_flmrun_app):
+    """Test Case 30: Test that services without SessionContext still work (backward compatibility)."""
+    # Standard class without _session_context
     class PlainService:
         def multiply(self, x: int, y: int) -> int:
             return x * y
@@ -612,11 +612,11 @@ def test_flame_session_context_without_context(check_package_config, check_flmru
         assert value == 56, f"Expected 56, got {value}"
 
 
-def test_flame_session_context_invalid_type_ignored(check_package_config, check_flmrun_app):
-    """Test Case 31: Test that invalid _flame_session_context type is ignored with warning."""
+def test_session_context_invalid_type_ignored(check_package_config, check_flmrun_app):
+    """Test Case 31: Test that invalid _session_context type is ignored with warning."""
     class ServiceWithInvalidContext:
         # Invalid type - should be ignored
-        _flame_session_context = {"session_id": "invalid"}
+        _session_context = {"session_id": "invalid"}
 
         def add(self, a: int, b: int) -> int:
             return a + b
@@ -636,42 +636,42 @@ def test_flame_session_context_invalid_type_ignored(check_package_config, check_
         assert value == 8, f"Expected 8, got {value}"
 
 
-def test_flame_session_context_validation_empty_string():
-    """Test Case 32: Test FlameSessionContext validation - empty session_id."""
+def test_session_context_validation_empty_string():
+    """Test Case 32: Test SessionContext validation - empty session_id."""
     with pytest.raises(ValueError) as exc_info:
-        FlameSessionContext(session_id="")
+        SessionContext(session_id="")
 
     assert "cannot be empty" in str(exc_info.value)
 
 
-def test_flame_session_context_validation_too_long():
-    """Test Case 33: Test FlameSessionContext validation - session_id too long."""
+def test_session_context_validation_too_long():
+    """Test Case 33: Test SessionContext validation - session_id too long."""
     with pytest.raises(ValueError) as exc_info:
-        FlameSessionContext(session_id="x" * 129)
+        SessionContext(session_id="x" * 129)
 
     assert "too long" in str(exc_info.value)
 
 
-def test_flame_session_context_validation_invalid_type():
-    """Test Case 34: Test FlameSessionContext validation - invalid session_id type."""
+def test_session_context_validation_invalid_type():
+    """Test Case 34: Test SessionContext validation - invalid session_id type."""
     with pytest.raises(ValueError) as exc_info:
-        FlameSessionContext(session_id=12345)  # type: ignore
+        SessionContext(session_id=12345)  # type: ignore
 
     assert "must be a string" in str(exc_info.value)
 
 
-def test_flame_session_context_validation_invalid_app_name():
-    """Test Case 35: Test FlameSessionContext validation - invalid application_name type."""
+def test_session_context_validation_invalid_app_name():
+    """Test Case 35: Test SessionContext validation - invalid application_name type."""
     with pytest.raises(ValueError) as exc_info:
-        FlameSessionContext(application_name=12345)  # type: ignore
+        SessionContext(application_name=12345)  # type: ignore
 
     assert "must be a string" in str(exc_info.value)
 
 
-def test_flame_session_context_valid_creation():
-    """Test Case 36: Test FlameSessionContext valid creation."""
+def test_session_context_valid_creation():
+    """Test Case 36: Test SessionContext valid creation."""
     # Test with all fields
-    ctx1 = FlameSessionContext(
+    ctx1 = SessionContext(
         session_id="valid-session-123",
         application_name="my-app"
     )
@@ -679,34 +679,34 @@ def test_flame_session_context_valid_creation():
     assert ctx1.application_name == "my-app"
 
     # Test with only session_id
-    ctx2 = FlameSessionContext(session_id="only-session")
+    ctx2 = SessionContext(session_id="only-session")
     assert ctx2.session_id == "only-session"
     assert ctx2.application_name is None
 
     # Test with only application_name
-    ctx3 = FlameSessionContext(application_name="only-app")
+    ctx3 = SessionContext(application_name="only-app")
     assert ctx3.session_id is None
     assert ctx3.application_name == "only-app"
 
     # Test with no fields (all defaults)
-    ctx4 = FlameSessionContext()
+    ctx4 = SessionContext()
     assert ctx4.session_id is None
     assert ctx4.application_name is None
 
 
-def test_flame_session_context_max_length():
-    """Test Case 37: Test FlameSessionContext with max length session_id (128 chars)."""
+def test_session_context_max_length():
+    """Test Case 37: Test SessionContext with max length session_id (128 chars)."""
     max_session_id = "x" * 128
-    ctx = FlameSessionContext(session_id=max_session_id)
+    ctx = SessionContext(session_id=max_session_id)
     assert ctx.session_id == max_session_id
     assert len(ctx.session_id) == 128
 
 
-def test_flame_session_context_dynamic_class(check_package_config, check_flmrun_app):
-    """Test Case 38: Test FlameSessionContext with dynamically created class."""
+def test_session_context_dynamic_class(check_package_config, check_flmrun_app):
+    """Test Case 38: Test SessionContext with dynamically created class."""
     def create_service_class(session_id: str):
         class DynamicService:
-            _flame_session_context = FlameSessionContext(session_id=session_id)
+            _session_context = SessionContext(session_id=session_id)
 
             def get_id(self) -> str:
                 return session_id

--- a/sdk/python/src/flamepy/runner/__init__.py
+++ b/sdk/python/src/flamepy/runner/__init__.py
@@ -13,10 +13,10 @@ limitations under the License.
 
 from .runner import ObjectFuture, ObjectFutureIterator, Runner, RunnerService
 from .runpy import FlameRunpyService
-from .types import FlameSessionContext, RunnerContext, RunnerRequest
+from .types import SessionContext, RunnerContext, RunnerRequest
 
 __all__ = [
-    "FlameSessionContext",
+    "SessionContext",
     "ObjectFuture",
     "ObjectFutureIterator",
     "Runner",

--- a/sdk/python/src/flamepy/runner/runner.py
+++ b/sdk/python/src/flamepy/runner/runner.py
@@ -32,7 +32,7 @@ from flamepy.core.types import (
 )
 from flamepy.runner.storage import StorageBackend, create_storage_backend
 from flamepy.runner.types import (
-    FlameSessionContext,
+    SessionContext,
     RunnerContext,
     RunnerRequest,
 )
@@ -135,8 +135,8 @@ class RunnerService:
                  The associated service must be flamepy.runner.runpy.
             execution_object: The Python execution object to be managed and
                              exposed as a remote service. Can be a class, instance,
-                             or function. If the object has a `_flame_session_context`
-                             attribute of type FlameSessionContext, its session_id
+                             or function. If the object has a `_session_context`
+                             attribute of type SessionContext, its session_id
                              will be used instead of auto-generating one.
             stateful: If True, persist the execution object state back to flame-cache
                      after each task. If False, do not persist state.
@@ -147,17 +147,17 @@ class RunnerService:
         self._execution_object = execution_object
         self._function_wrapper = None  # For callable functions
 
-        # Extract custom session_id from FlameSessionContext if present
+        # Extract custom session_id from SessionContext if present
         custom_session_id = None
-        if hasattr(execution_object, "_flame_session_context"):
-            ctx = getattr(execution_object, "_flame_session_context")
-            if isinstance(ctx, FlameSessionContext):
+        if hasattr(execution_object, "_session_context"):
+            ctx = getattr(execution_object, "_session_context")
+            if isinstance(ctx, SessionContext):
                 custom_session_id = ctx.session_id
                 if ctx.application_name:
-                    logger.debug(f"FlameSessionContext application_name: {ctx.application_name}")
+                    logger.debug(f"SessionContext application_name: {ctx.application_name}")
             else:
                 logger.warning(
-                    f"_flame_session_context attribute found but is not FlameSessionContext "
+                    f"_session_context attribute found but is not SessionContext "
                     f"(got {type(ctx).__name__}), ignoring"
                 )
 

--- a/sdk/python/src/flamepy/runner/types.py
+++ b/sdk/python/src/flamepy/runner/types.py
@@ -17,11 +17,11 @@ from typing import Any, Dict, Optional, Tuple
 
 
 @dataclass
-class FlameSessionContext:
+class SessionContext:
     """Context for customizing Flame session creation in Runner.service().
 
     Users can attach this context to their execution objects (classes, instances,
-    or functions) via the `_flame_session_context` attribute to customize session
+    or functions) via the `_session_context` attribute to customize session
     behavior, particularly the session ID.
 
     Attributes:
@@ -34,7 +34,7 @@ class FlameSessionContext:
 
     Example with a class:
         >>> class MyService:
-        ...     _flame_session_context = FlameSessionContext(
+        ...     _session_context = SessionContext(
         ...         session_id="my-session-001",
         ...         application_name="my-app"
         ...     )
@@ -43,19 +43,19 @@ class FlameSessionContext:
 
     Example with an instance:
         >>> obj = MyClass()
-        >>> obj._flame_session_context = FlameSessionContext(session_id="instance-001")
+        >>> obj._session_context = SessionContext(session_id="instance-001")
 
     Example with a function:
         >>> def my_func(x):
         ...     return x * 2
-        >>> my_func._flame_session_context = FlameSessionContext(session_id="func-001")
+        >>> my_func._session_context = SessionContext(session_id="func-001")
     """
 
     session_id: Optional[str] = None
     application_name: Optional[str] = None
 
     def __post_init__(self) -> None:
-        """Validate FlameSessionContext fields."""
+        """Validate SessionContext fields."""
         if self.session_id is not None:
             if not isinstance(self.session_id, str):
                 raise ValueError(f"session_id must be a string, got {type(self.session_id)}")


### PR DESCRIPTION
## Summary

This PR introduces FlameSessionContext, a new feature that allows users to specify custom session IDs when creating services via Runner.service(). This enables better traceability, deterministic testing, and external system integration.

## Changes

- **SDK Implementation**: Added FlameSessionContext dataclass with session_id and application_name fields
- **Detection Logic**: RunnerService.__init__() now checks for _flame_session_context attribute on execution objects
- **Design Document**: Added RFE350 design document with full specification
- **E2E Tests**: Added 13 new tests covering all usage patterns

## Testing

- Added 13 new E2E tests for FlameSessionContext
- All existing tests remain passing (backward compatible)