### PR TITLE
[executor_manager] Move process stdout/stderr logs to top_dir

### DIFF
--- a/executor_manager/src/shims/host_shim.rs
+++ b/executor_manager/src/shims/host_shim.rs
@@ -227,11 +227,9 @@ impl HostShim {
         // Spawn child process
         let mut cmd = tokio::process::Command::new(&command);
 
-        // Use app_dir for logs and temp files (per-instance isolation)
+        // Use app_dir for temp files (per-instance isolation)
         let app_work_dir = work_dir.app_dir();
-        // Use process_dir for the actual process working directory
-        // - User-specified: runs in top_dir (to find pyproject.toml, etc.)
-        // - Auto-generated: runs in app_dir
+        // Use process_dir for actual process working directory and stdout/stderr logs
         let process_work_dir = work_dir.process_dir();
 
         // Setup working directory and tmp (per-instance)
@@ -254,7 +252,7 @@ impl HostShim {
             .read(true)
             .write(true)
             .truncate(true)
-            .open(app_work_dir.join(format!("{}.out", executor.id)))
+            .open(process_work_dir.join(format!("{}.out", executor.id)))
             .map_err(|e| FlameError::Internal(format!("failed to open stdout log file: {e}")))?;
 
         let log_err = OpenOptions::new()
@@ -262,7 +260,7 @@ impl HostShim {
             .read(true)
             .write(true)
             .truncate(true)
-            .open(app_work_dir.join(format!("{}.err", executor.id)))
+            .open(process_work_dir.join(format!("{}.err", executor.id)))
             .map_err(|e| FlameError::Internal(format!("failed to open stderr log file: {e}")))?;
 
         let child = cmd

--- a/executor_manager/src/shims/mod.rs
+++ b/executor_manager/src/shims/mod.rs
@@ -36,8 +36,8 @@ pub type ShimPtr = Arc<Mutex<dyn Shim>>;
 
 /// Represents the executor's working directory with cleanup management.
 /// Directory structure:
-///   top_dir/                     - Process working directory (user-specified or auto-generated)
-///   top_dir/work/<app_name>/     - App-specific directory for logs, tmp, cache
+///   top_dir/                     - Process working directory, stdout/stderr logs
+///   top_dir/work/<app_name>/     - App-specific directory for tmp, cache
 ///   top_dir/work/<executor_id>.sock - Socket for gRPC communication
 /// Cleanup:
 ///   - top_dir: cleaned up only if auto-generated
@@ -106,7 +106,7 @@ impl ExecutorWorkDir {
         })
     }
 
-    /// Returns the application working directory path (for logs, tmp, cache).
+    /// Returns the application working directory path (for tmp, cache).
     pub fn app_dir(&self) -> &Path {
         &self.app_dir
     }

--- a/sdk/python/src/flamepy/runner/runpy.py
+++ b/sdk/python/src/flamepy/runner/runpy.py
@@ -187,22 +187,25 @@ class FlameRunpyService(FlameService):
             except Exception as e:
                 raise RuntimeError(f"Failed to create storage backend: {e}")
 
-            # Get the working directory and tmp directory
-            working_dir = os.getcwd()
-            tmp_dir = os.path.join(working_dir, "tmp")
+            tmp_dir = os.environ.get("TMP", os.path.join(os.getcwd(), "tmp"))
             os.makedirs(tmp_dir, exist_ok=True)
 
             local_package_path = os.path.join(tmp_dir, filename)
-            try:
-                self._storage_backend.download(filename, local_package_path)
-                logger.info(f"Downloaded package to: {local_package_path}")
-            except Exception as e:
-                logger.error(f"Failed to download package from storage: {e}")
-                raise RuntimeError(f"Failed to download package from storage: {e}")
+            extract_dir = os.path.join(tmp_dir, f"extracted_{filename.split('.')[0]}")
 
-            logger.info("Package is an archive file, extracting...")
-            extract_dir = os.path.join(working_dir, f"extracted_{os.path.basename(local_package_path).split('.')[0]}")
-            extracted_dir = self._extract_archive(local_package_path, extract_dir)
+            if os.path.exists(extract_dir):
+                logger.info(f"Package already extracted at: {extract_dir}, skipping download")
+                extracted_dir = extract_dir
+            else:
+                try:
+                    self._storage_backend.download(filename, local_package_path)
+                    logger.info(f"Downloaded package to: {local_package_path}")
+                except Exception as e:
+                    logger.error(f"Failed to download package from storage: {e}")
+                    raise RuntimeError(f"Failed to download package from storage: {e}")
+
+                logger.info("Package is an archive file, extracting...")
+                extracted_dir = self._extract_archive(local_package_path, extract_dir)
 
             install_path = extracted_dir
         else:


### PR DESCRIPTION
## Summary
- Move process stdout/stderr log files (.out/.err) from app_dir to top_dir for easier access
- Previously: `top_dir/work/{app_name}/{executor_id}.out`
- Now: `top_dir/{executor_id}.out`

This makes it easier to find and inspect logs without navigating into the nested work directory.