### PR TITLE
feat(storage): implement filesystem-based storage engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1620,6 +1620,7 @@ dependencies = [
  "chrono",
  "clap",
  "common",
+ "crc32fast",
  "futures",
  "jsonschema",
  "prost",

--- a/ci/flame-cluster-local.yaml
+++ b/ci/flame-cluster-local.yaml
@@ -4,7 +4,7 @@ cluster:
   endpoint: "http://127.0.0.1:30080"
   slot: "cpu=1,mem=1g"
   policy: priority
-  storage: sqlite://flame.db
+  storage: fs://data/
   schedule_interval: 100           # Scheduler loop interval in milliseconds (default: 500)
 executors:
   shim: host

--- a/ci/flame-cluster.yaml
+++ b/ci/flame-cluster.yaml
@@ -4,7 +4,7 @@ cluster:
   endpoint: "http://flame-session-manager:8080"
   slot: "cpu=1,mem=1g"
   policy: priority
-  storage: sqlite://flame.db
+  storage: fs://data/
   schedule_interval: 100           # Scheduler loop interval in milliseconds (default: 500)
 executors:
   shim: host

--- a/docs/designs/RFE209-filesystem-storage/FS.md
+++ b/docs/designs/RFE209-filesystem-storage/FS.md
@@ -1,0 +1,458 @@
+---
+Issue: #209
+Author: bob
+Date: 2025-01-15
+---
+
+# Design Document: Filesystem-Based Storage Engine (Single-File Architecture)
+
+## 1. Motivation
+
+**Background:**
+
+The current `flame-session-manager` uses SQLite (and optionally PostgreSQL) as the storage backend. While robust, database overhead (WAL, locking, serialization) limits throughput for high-frequency task workloads. The previous directory-per-task design was rejected due to excessive inode usage and filesystem metadata overhead.
+
+**Target:**
+
+Implement a high-performance `filesystem` storage engine that:
+1.  Uses a **single-file architecture** per session for tasks to minimize filesystem metadata operations.
+2.  Uses **fixed-size records** for task metadata to allow O(1) random access.
+3.  Uses **append-only** files for variable-length data (inputs/outputs) to maximize write throughput.
+4.  Relies on **in-memory locks** (provided by the Session Manager) rather than file locks.
+
+**Success Criteria:**
+- Task creation throughput significantly higher than SQLite.
+- Minimal inode usage (constant files per session, regardless of task count).
+- Zero data loss under normal operation.
+
+## 2. Function Specification
+
+**Configuration:**
+
+```yaml
+cluster:
+  # Absolute path (triple slash)
+  storage: "fs:///var/lib/flame"
+
+  # Relative to FLAME_HOME (double slash, recommended)
+  storage: "fs://data"  # Resolves to ${FLAME_HOME}/data
+```
+
+**URL Schemes:**
+
+All three schemes (`filesystem://`, `file://`, `fs://`) follow the same path resolution:
+- Triple slash (e.g., `fs:///data`) → Absolute path (`/data`)
+- Double slash (e.g., `fs://data`) → Relative to `${FLAME_HOME}` (defaults to `/usr/local/flame`)
+
+**Scope:**
+
+- **In Scope:**
+  - `tasks.bin`: Fixed-size metadata storage.
+  - `inputs.bin`: Append-only input storage.
+  - `outputs.bin`: Append-only output storage.
+  - Session and Application metadata (JSON).
+  - Recovery on startup.
+
+- **Out of Scope:**
+  - **Events & Messages**: These are NOT stored by the storage engine. They are handled by the internal `EventManager` (`crate::events` in `flame-session-manager`).
+  - Distributed access: Single-node only.
+
+- **Limitations:**
+  - Single-process only; no cross-process file locking.
+  - Append-only data files cannot reclaim space from deleted tasks.
+  - Maximum file sizes limited by underlying filesystem (typically 16TB+).
+
+- **Concurrency:**
+  - The filesystem engine uses a `RwLock<HashMap<SessionID, Mutex>>` for concurrency control.
+  - `lock_ssn!(ssn_id)`: Acquires read lock on the map, then locks the session mutex. Used for all task operations (`create_task`, `get_task`, `find_tasks`, `retry_task`, `update_task_state`, `update_task_result`).
+  - `lock_app!()`: Acquires write lock on the map, blocking all session operations. Used for cross-session operations (`create_session`, `delete_session`, `unregister_application`, `update_application`).
+  - Session locks are created in `create_session` and removed in `delete_session`.
+
+**Feature Interaction:**
+
+- **Related Features:**
+  - `EventManager` (`crate::events`): Handles task events and messages separately from storage.
+  - Existing `sqlite` and `postgres` storage engines: Alternative backends with different trade-offs.
+
+- **Updates Required:**
+  - `storage::Engine` trait: No changes required; this implementation conforms to existing trait.
+  - Configuration parser: Must recognize `filesystem://`, `file://`, and `fs://` URI schemes.
+
+- **Integration Points:**
+  - Storage engine is instantiated by Session Manager based on configuration.
+  - Task reconstruction aggregates data from storage engine + EventManager.
+  - Recovery process is invoked on Session Manager startup.
+
+- **Compatibility:**
+  - **Backward Compatible**: Existing SQLite/PostgreSQL configurations continue to work unchanged.
+  - **Migration Path**: No automatic migration from SQLite to filesystem. Users must start fresh or manually export/import.
+
+- **Breaking Changes:** None. This is a new, opt-in storage backend.
+
+## 3. Implementation Detail
+
+### Architecture
+
+Instead of creating a directory for every task, we use three files per session to store all task data.
+
+```mermaid
+flowchart TB
+    subgraph SessionDir["Session Directory"]
+        Meta["metadata (JSON)"]
+        Tasks["tasks.bin (Fixed Records)"]
+        Inputs["inputs.bin (Append-Only)"]
+        Outputs["outputs.bin (Append-Only)"]
+    end
+    
+    Meta --- SessionDir
+    Tasks --- SessionDir
+    Inputs --- SessionDir
+    Outputs --- SessionDir
+```
+
+### Directory Structure
+
+```
+<work_dir>/
+└── data/
+    ├── sessions/
+    │   └── <session_id>/
+    │       ├── metadata          # Session metadata (JSON)
+    │       ├── tasks.bin         # TaskMetadata records (Index = Task ID)
+    │       ├── inputs.bin        # Concatenated input data
+    │       └── outputs.bin       # Concatenated output data
+    └── applications/
+        └── <app_name>/
+            └── metadata          # Application metadata (JSON)
+```
+
+### Data Structures
+
+**Task Metadata (Fixed-Size Binary):**
+
+We use `serde` + `bincode` for serialization. We rely on `bincode`'s predictable sizing for fixed-width types to ensure O(1) random access. The struct uses `u64` for IDs and offsets to support large datasets.
+
+```rust
+use serde::{Serialize, Deserialize};
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct TaskMetadata {
+    pub id: u64,                    // 8 bytes - Task ID (Index in file)
+    pub version: u32,               // 4 bytes - Optimistic locking
+    pub checksum: u32,              // 4 bytes - CRC32 of the record (calculated via crc32fast)
+    pub state: u8,                  // 1 byte - TaskState enum
+    pub creation_time: i64,         // 8 bytes - Unix timestamp
+    pub completion_time: i64,       // 8 bytes - Unix timestamp
+    
+    // Input Location (in inputs.bin)
+    pub input_offset: u64,          // 8 bytes
+    pub input_len: u64,             // 8 bytes
+    
+    // Output Location (in outputs.bin)
+    pub output_offset: u64,         // 8 bytes
+    pub output_len: u64,            // 8 bytes
+}
+// Total size: Sum of fields (approx 61 bytes, depending on bincode overhead/padding)
+// Note: We verify the serialized size at runtime to ensure it is constant.
+```
+
+**Serialization Strategy:**
+- **Library:** `bincode` with `fixint` encoding to ensure fixed-size integers.
+- **Checksum:** `crc32fast` crate used to calculate CRC32 checksums for data integrity.
+- **Alignment:** `bincode` handles endianness and alignment automatically. We do not manually pad the struct, but we assert that `bincode::serialized_size` is constant for any instance.
+
+**Session Metadata (JSON):**
+Standard JSON format (unchanged).
+
+
+### Algorithms
+
+**1. Task Creation (Append):**
+*   **Context**: Caller holds session lock.
+*   **Step 1**: Determine new Task ID (current file size of `tasks.bin` / RECORD_SIZE).
+*   **Step 2**: Append input data to `inputs.bin`. Record `input_offset` (file end before write) and `input_len`.
+*   **Step 3**: Construct `TaskMetadata` with the new ID, input location.
+*   **Step 4**: Calculate `checksum` using `crc32fast::Hasher`.
+*   **Step 5**: Serialize `TaskMetadata` using `bincode::serialize`.
+*   **Step 6**: Append serialized bytes to `tasks.bin`.
+*   **Step 7**: Flush/Sync (optional based on durability config).
+
+**2. Task Update (Random Write):**
+*   **Context**: Caller holds session lock.
+*   **Step 1**: Calculate offset in `tasks.bin`: `offset = task_id * RECORD_SIZE`.
+*   **Step 2**: If updating output:
+    *   Append data to `outputs.bin`.
+    *   Update `output_offset` and `output_len` in metadata struct.
+*   **Step 3**: Update other fields (state, completion_time).
+*   **Step 4**: Recalculate `checksum`.
+*   **Step 5**: Serialize updated `TaskMetadata`.
+*   **Step 6**: Write serialized bytes to `tasks.bin` at calculated offset (using `pwrite` or `seek+write`).
+
+
+**3. Task Retrieval (Random Read):**
+*   **Step 1**: Read `RECORD_SIZE` bytes from `tasks.bin` at `offset = task_id * RECORD_SIZE`.
+*   **Step 2**: Deserialize using `bincode::deserialize`.
+*   **Step 3**: Validate `checksum`. If mismatch, return `Corrupted` error.
+*   **Step 4**: If input needed, read from `inputs.bin` using `input_offset` and `input_len`.
+*   **Step 5**: If output needed, read from `outputs.bin` using `output_offset` and `output_len`.
+
+**4. Task Reconstruction (Aggregator Logic):**
+To reconstruct a full `Task` object compatible with `common/src/apis.rs`, we aggregate data from the storage engine (Source of Truth) and the `EventManager` (Supplementary).
+
+```rust
+fn reconstruct_task(session_id, task_id, storage_engine, event_manager) -> Result<Task, Error> {
+    // 1. Fetch Primary Data from Filesystem Storage (Source of Truth)
+    // This MUST succeed. If this fails, the task does not exist or is corrupted.
+    let metadata = storage_engine.read_metadata(session_id, task_id)?;
+    let input_data = storage_engine.read_input(session_id, task_id).optional();
+    let output_data = storage_engine.read_output(session_id, task_id).optional();
+
+    // 2. Initialize Task Object
+    let mut task = Task {
+        id: metadata.id,
+        ssn_id: metadata.ssn_id,
+        version: metadata.version,
+        state: metadata.state,
+        creation_time: metadata.creation_time,
+        completion_time: metadata.completion_time,
+        input: input_data,
+        output: output_data,
+        events: Vec::new(),  // Placeholder
+    };
+
+    // 3. Fetch Supplementary Data from EventManager (Best Effort)
+    match event_manager.get_events(session_id, task_id) {
+        Ok(events) => task.events = events,
+        Err(e) => {
+            // Graceful degradation: Log warning but return Task with empty events
+            log::warn!("Failed to fetch events for task {}: {}", task_id, e);
+            task.events = Vec::new(); 
+        }
+    }
+
+    Ok(task)
+}
+```
+
+**5. Recovery:**
+*   Scan `sessions/` directory.
+*   Read `tasks.bin` sequentially to rebuild in-memory state.
+*   **Partial Write Recovery**: If `tasks.bin` size is not a multiple of `RECORD_SIZE`, truncate to the nearest multiple (discard partial record).
+*   **Cross-File Consistency**: For each task, verify `input_offset + input_len <= inputs.bin.size`. If invalid, mark task as `Corrupted` or discard.
+*   **Checksum Validation**: Verify `checksum` for each record. If invalid, mark task as `Corrupted`.
+
+### Concurrency & Locking
+
+*   **Single-Process Only**: This engine is designed for **single-process** usage. It does **not** support multiple processes accessing the same session directory concurrently. No cross-process file locking (e.g., `flock`) is implemented.
+*   **Memory Locks**: The `flame-session-manager` guarantees that operations on a specific session are serialized via in-memory locks (e.g., `RwLock<Session>`).
+*   **Atomic Appends**: For `inputs.bin` and `outputs.bin`, we rely on append-only behavior.
+*   **Metadata Integrity**: `tasks.bin` updates are fixed-size writes.
+
+
+### System Considerations
+
+**Performance:**
+- **Latency**: O(1) task lookup via fixed-size records and direct offset calculation.
+- **Throughput**: Sequential I/O for task creation (append-only) maximizes disk bandwidth.
+- **Optimization**: Batch writes can be buffered in memory before flushing to reduce syscall overhead.
+- **Benchmarks**: Target >10x throughput improvement over SQLite for task creation workloads.
+
+**Scalability:**
+- **Horizontal**: Not supported; single-node only by design.
+- **Vertical**: Scales with disk I/O capacity and memory for file handles.
+- **Capacity Limits**: 
+  - Tasks per session: Limited by `u64` ID space (~18 quintillion) and filesystem size limits.
+  - Sessions: Limited by filesystem inode count (4 files per session).
+  - Data size: `u64` offsets support exabyte-scale files; practical limit is filesystem (typically 16TB+).
+
+**Reliability:**
+- **Availability**: Single-node; availability equals host uptime.
+- **Fault Tolerance**: 
+  - CRC32 checksums detect corruption on read.
+  - Partial write recovery truncates incomplete records on startup.
+  - Cross-file consistency validation marks orphaned data as corrupted.
+- **Error Recovery**: Corrupted tasks are marked and skipped; healthy tasks remain accessible.
+- **Failure Modes**:
+  - Disk full: Write operations fail with I/O error; existing data preserved.
+  - Power loss: Partial writes detected and truncated on recovery.
+  - Bit rot: Detected via checksum validation.
+
+**Resource Usage:**
+- **Memory**: Minimal; only file handles and small buffers. No in-memory caching of task data.
+- **CPU**: Low; serialization/deserialization is fast with `bincode`. CRC32 calculation is hardware-accelerated on modern CPUs.
+- **Disk**: 
+  - Fixed overhead: ~61 bytes per task in `tasks.bin`.
+  - Variable: Input/output sizes depend on workload.
+  - No WAL or journal overhead (unlike SQLite).
+- **Network**: None; local filesystem only.
+
+**Security:**
+- **Authentication/Authorization**: Delegated to Session Manager; storage engine trusts caller.
+- **Data Protection**: 
+  - Files inherit filesystem permissions (recommend `0600` for session directories).
+  - No encryption at rest (out of scope; use filesystem-level encryption if needed).
+- **Threat Model**:
+  - Assumes trusted local environment.
+  - No protection against malicious local users with filesystem access.
+
+**Observability:**
+- **Logging**: 
+  - INFO: Session creation/deletion, recovery completion.
+  - WARN: Checksum mismatches, partial write recovery, cross-file inconsistencies.
+  - ERROR: I/O failures, unrecoverable corruption.
+- **Metrics** (recommended for future implementation):
+  - `fs_storage_tasks_created_total`: Counter of tasks created.
+  - `fs_storage_tasks_corrupted_total`: Counter of corrupted tasks detected.
+  - `fs_storage_recovery_duration_seconds`: Histogram of recovery time.
+  - `fs_storage_file_size_bytes`: Gauge of file sizes per session.
+- **Tracing**: Not implemented; add span IDs to logs if distributed tracing is needed.
+
+**Operational:**
+- **Deployment**: No special requirements; works on any POSIX-compliant filesystem.
+- **Maintenance**: 
+  - Periodic backup of `<work_dir>/data/` recommended.
+  - No compaction needed for `tasks.bin`; append-only files grow indefinitely.
+- **Disaster Recovery**: 
+  - Restore from backup to recover sessions.
+  - No point-in-time recovery (unlike database WAL).
+
+### Dependencies
+
+**External Dependencies:**
+
+| Crate | Version | Purpose |
+|-------|---------|---------|
+| `serde` | ^1.0 | Serialization framework |
+| `bincode` | ^1.3 | Binary serialization with fixed-size encoding |
+| `crc32fast` | ^1.3 | Hardware-accelerated CRC32 checksums |
+
+**Internal Dependencies:**
+
+| Component | Purpose |
+|-----------|---------|
+| `flame-session-manager` | Provides session-level locking and invokes storage engine |
+| `EventManager` (`crate::events`) | Handles task events separately from storage |
+| `storage::Engine` trait | Interface this implementation conforms to |
+| `common::apis::Task` | Task struct definition for reconstruction |
+
+**Version Requirements:**
+- Rust: 1.70+ (for stable async traits if needed)
+- Filesystem: POSIX-compliant (Linux ext4, XFS recommended; macOS APFS supported)
+
+
+## 4. Use Cases
+
+**UC1: High-Throughput Submission**
+*   Client submits 1000 tasks.
+*   Engine appends 1000 inputs to `inputs.bin`.
+*   Engine appends 1000 records to `tasks.bin`.
+*   **Benefit**: Sequential I/O, no directory creation overhead.
+
+**UC2: Task Completion**
+*   Executor finishes Task #50.
+*   Engine appends result to `outputs.bin`.
+*   Engine updates record #50 in `tasks.bin` (seek to `50 * RECORD_SIZE`, write record).
+*   **Benefit**: Minimal seek overhead, data locality.
+
+**UC3: Restart/Crash**
+*   System restarts.
+*   Engine reads `tasks.bin` sequentially.
+*   Reconstructs state for all tasks instantly without traversing thousands of directories.
+*   Validates integrity via checksums and file length checks.
+
+## 5. Engine Trait Implementation
+
+This section details how the `storage::Engine` trait methods map to the filesystem architecture.
+
+### `create_session(&self, session: Session) -> Result<(), Error>`
+1.  **Path Resolution**: Resolve path `data/sessions/<session.id>`.
+2.  **Directory Creation**: Create directory using `fs::create_dir_all`.
+3.  **Metadata Write**: Serialize `session` struct to JSON.
+4.  **Atomic Write**: Write JSON to `metadata.tmp`, then rename to `metadata`.
+5.  **File Initialization**: Create empty `tasks.bin`, `inputs.bin`, `outputs.bin` if they don't exist.
+
+### `create_task(&self, task: Task) -> Result<(), Error>`
+1.  **Locking**: Assumes caller holds session lock.
+2.  **Input Handling**:
+    *   Open `inputs.bin` in append mode.
+    *   Get current file size as `input_offset`.
+    *   Write `task.input` bytes.
+    *   Calculate `input_len`.
+3.  **Metadata Construction**:
+    *   Calculate `task_id` = `tasks.bin` size / `RECORD_SIZE`.
+    *   Create `TaskMetadata` struct with `id`, `state`, `input_offset`, `input_len`.
+    *   Calculate CRC32 checksum.
+4.  **Metadata Write**:
+    *   Serialize `TaskMetadata`.
+    *   Append to `tasks.bin`.
+5.  **Sync**: Call `fs::sync_data` on both files if durability is required.
+
+### `update_task(&self, task: Task) -> Result<(), Error>`
+1.  **Validation**: Check if `task.id` exists (file size check).
+2.  **Output Handling** (if `task.output` is present):
+    *   Open `outputs.bin` in append mode.
+    *   Get current file size as `output_offset`.
+    *   Write `task.output` bytes.
+    *   Update `output_offset` and `output_len` in metadata.
+3.  **Metadata Update**:
+    *   Read existing metadata at `offset = task.id * RECORD_SIZE`.
+    *   Update fields: `state`, `completion_time`, `version`.
+    *   Recalculate checksum.
+    *   Serialize to `RECORD_SIZE` bytes.
+4.  **Write Back**:
+    *   Open `tasks.bin` in write mode (not append).
+    *   Seek to `offset`.
+    *   Write bytes.
+
+### `find_task(&self, session_id: SessionID, task_id: TaskID) -> Result<Option<Task>, Error>`
+1.  **Path Resolution**: Open `data/sessions/<session_id>/tasks.bin`.
+2.  **Seek & Read**:
+    *   Calculate `offset = task_id * RECORD_SIZE`.
+    *   Seek to `offset`.
+    *   Read `RECORD_SIZE` bytes.
+3.  **Deserialization**:
+    *   Deserialize to `TaskMetadata`.
+    *   Verify checksum.
+4.  **Data Fetch**:
+    *   Read input from `inputs.bin` using `input_offset/len`.
+    *   Read output from `outputs.bin` using `output_offset/len`.
+5.  **Reconstruction**:
+    *   Call `reconstruct_task` (see Algorithms section) to combine with events.
+
+### `delete_session(&self, session_id: SessionID) -> Result<(), Error>`
+1.  **Path Resolution**: Resolve path `data/sessions/<session_id>`.
+2.  **Recursive Delete**: Call `fs::remove_dir_all`.
+
+### `list_sessions(&self) -> Result<Vec<Session>, Error>`
+1.  **Directory Scan**: Read `data/sessions/` directory.
+2.  **Metadata Read**: For each subdirectory, read `metadata` JSON file.
+3.  **Deserialization**: Parse JSON to `Session` struct.
+4.  **Aggregation**: Return vector of sessions.
+
+## 6. Risks & Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| **File Corruption** | Added `checksum` (CRC32) to `TaskMetadata` to detect bit rot or partial writes. |
+| **Partial Writes** | On startup, check if `tasks.bin` size is multiple of `RECORD_SIZE`. Truncate excess bytes. |
+| **Cross-File Inconsistency** | Validate offsets against file sizes on startup. Mark invalid tasks as corrupted. |
+| **Large Files** | `u64` offsets support exabytes. Filesystem limits apply (usually 16TB+). |
+| **Concurrency Bugs** | Strictly enforce "Session Manager must lock session before calling Engine". Single-process only. |
+| **Alignment Issues** | Mitigated by using `serde` + `bincode` instead of `packed` structs. |
+
+## 7. References
+
+**Related Documents:**
+- Issue #21: Original feature request for filesystem storage
+- `flame-session-manager` architecture documentation
+- `storage::Engine` trait definition in `session-manager/src/storage/mod.rs`
+
+**External References:**
+- [bincode documentation](https://docs.rs/bincode/latest/bincode/)
+- [crc32fast documentation](https://docs.rs/crc32fast/latest/crc32fast/)
+- [serde documentation](https://serde.rs/)
+
+**Implementation References:**
+- `session-manager/src/storage/filesystem.rs` (to be created)
+- `session-manager/src/storage/mod.rs` (Engine trait)
+- `common/src/apis.rs` (Task struct definition)

--- a/flmadm/src/managers/config.rs
+++ b/flmadm/src/managers/config.rs
@@ -43,7 +43,7 @@ cluster:
   endpoint: "http://127.0.0.1:8080"
   slot: "cpu=1,mem=2g"
   policy: proportion
-  storage: "sqlite://{prefix}/data/sessions.db"
+  storage: "fs://{prefix}/data"
 executors:
   shim: host
   limits:

--- a/session_manager/Cargo.toml
+++ b/session_manager/Cargo.toml
@@ -34,6 +34,9 @@ jsonschema = { workspace = true }
 
 uuid = { workspace = true }
 
+# Filesystem storage engine dependencies
+crc32fast = "1.3"
+
 [dev-dependencies]
 tokio-test = "*"
 rand = { workspace = true }

--- a/session_manager/src/storage/engine/filesystem.rs
+++ b/session_manager/src/storage/engine/filesystem.rs
@@ -1,0 +1,1449 @@
+/*
+Copyright 2023 The Flame Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Filesystem-based storage engine implementation.
+//!
+//! This module implements a high-performance storage engine that uses the filesystem
+//! directly instead of a database. It uses a single-file architecture per session
+//! for tasks to minimize filesystem metadata operations.
+//!
+//! # Architecture
+//!
+//! ```text
+//! <work_dir>/data/
+//! ├── sessions/<session_id>/
+//! │   ├── metadata          # Session metadata (JSON)
+//! │   ├── tasks.bin         # TaskMetadata records (fixed-size, indexed by Task ID)
+//! │   ├── inputs.bin        # Concatenated input data (append-only)
+//! │   └── outputs.bin       # Concatenated output data (append-only)
+//! └── applications/<app_name>/
+//!     └── metadata          # Application metadata (JSON)
+//! ```
+//!
+//! # Design Decisions
+//!
+//! - **Fixed-size task metadata**: Enables O(1) random access by task ID
+//! - **Append-only data files**: Maximizes write throughput for inputs/outputs
+//! - **No file locks**: Relies on in-memory locks in the Session Manager
+//! - **CRC32 checksums**: Detects corruption on read
+
+use std::collections::HashMap;
+use std::io::SeekFrom;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use bincode::{Decode, Encode};
+use bytes::Bytes;
+use chrono::{DateTime, Duration, Utc};
+use serde::{Deserialize, Serialize};
+use tokio::fs;
+use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
+use tokio::sync::{Mutex, RwLock};
+
+use common::apis::{
+    Application, ApplicationAttributes, ApplicationID, ApplicationSchema, ApplicationState,
+    Session, SessionAttributes, SessionID, SessionState, SessionStatus, Task, TaskGID, TaskID,
+    TaskInput, TaskOutput, TaskResult, TaskState,
+};
+use common::{FlameError, FLAME_HOME};
+
+use crate::storage::engine::{Engine, EnginePtr};
+
+/// Task metadata stored in tasks.bin with fixed-size records.
+///
+/// Uses `bincode` with `fixint` encoding to ensure constant serialized size.
+/// The checksum is calculated using `crc32fast` for data integrity.
+#[derive(Encode, Decode, Debug, Clone, Default)]
+struct TaskMetadata {
+    /// Task ID (index in file)
+    pub id: u64,
+    /// Optimistic locking version
+    pub version: u32,
+    /// CRC32 checksum of the record (excluding this field)
+    pub checksum: u32,
+    /// Task state (TaskState enum as u8)
+    pub state: u8,
+    /// Unix timestamp of creation
+    pub creation_time: i64,
+    /// Unix timestamp of completion (0 if not completed)
+    pub completion_time: i64,
+    /// Offset in inputs.bin where input data starts
+    pub input_offset: u64,
+    /// Length of input data in bytes
+    pub input_len: u64,
+    /// Offset in outputs.bin where output data starts
+    pub output_offset: u64,
+    /// Length of output data in bytes
+    pub output_len: u64,
+}
+
+/// Session metadata stored as JSON.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+struct SessionMetadata {
+    pub id: String,
+    pub application: String,
+    pub slots: u32,
+    pub version: u32,
+    pub state: i32,
+    pub creation_time: i64,
+    pub completion_time: Option<i64>,
+    pub min_instances: u32,
+    pub max_instances: Option<u32>,
+    /// Offset in common_data file (if any)
+    pub common_data_len: u64,
+}
+
+/// Application metadata stored as JSON.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+struct ApplicationMetadata {
+    pub name: String,
+    pub version: u32,
+    pub state: i32,
+    pub creation_time: i64,
+    pub image: Option<String>,
+    pub description: Option<String>,
+    pub labels: Vec<String>,
+    pub command: Option<String>,
+    pub arguments: Vec<String>,
+    pub environments: std::collections::HashMap<String, String>,
+    pub working_directory: Option<String>,
+    pub max_instances: u32,
+    pub delay_release_seconds: i64,
+    pub schema: Option<ApplicationSchemaMetadata>,
+    pub url: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+struct ApplicationSchemaMetadata {
+    pub input: Option<String>,
+    pub output: Option<String>,
+    pub common_data: Option<String>,
+}
+
+/// Bincode configuration for fixed-size encoding.
+fn bincode_config() -> impl bincode::config::Config {
+    bincode::config::standard()
+        .with_fixed_int_encoding()
+        .with_little_endian()
+}
+
+/// Calculate the fixed record size for TaskMetadata.
+fn task_record_size() -> usize {
+    // Calculate the serialized size of a default TaskMetadata
+    let meta = TaskMetadata::default();
+    bincode::encode_to_vec(&meta, bincode_config())
+        .expect("Failed to calculate record size")
+        .len()
+}
+
+/// Calculate CRC32 checksum for task metadata (excluding the checksum field itself).
+fn calculate_checksum(meta: &TaskMetadata) -> u32 {
+    let mut hasher = crc32fast::Hasher::new();
+    hasher.update(&meta.id.to_le_bytes());
+    hasher.update(&meta.version.to_le_bytes());
+    hasher.update(&[meta.state]);
+    hasher.update(&meta.creation_time.to_le_bytes());
+    hasher.update(&meta.completion_time.to_le_bytes());
+    hasher.update(&meta.input_offset.to_le_bytes());
+    hasher.update(&meta.input_len.to_le_bytes());
+    hasher.update(&meta.output_offset.to_le_bytes());
+    hasher.update(&meta.output_len.to_le_bytes());
+    hasher.finalize()
+}
+
+macro_rules! lock_ssn {
+    ($self:expr, $ssn_id:expr) => {{
+        let locks = $self.locks.read().await;
+        let ssn_lock = locks
+            .get($ssn_id)
+            .ok_or_else(|| FlameError::NotFound(format!("Session lock not found: {}", $ssn_id)))?
+            .clone();
+        drop(locks);
+        Ok::<_, FlameError>(ssn_lock.lock_owned().await)
+    }};
+}
+
+macro_rules! lock_app {
+    ($self:expr) => {
+        $self.locks.write().await
+    };
+}
+
+/// Filesystem-based storage engine.
+pub struct FilesystemEngine {
+    base_path: PathBuf,
+    record_size: usize,
+    locks: RwLock<HashMap<String, Arc<Mutex<()>>>>,
+}
+
+impl FilesystemEngine {
+    /// Create a new filesystem engine from a URL.
+    ///
+    /// URL format: `filesystem://<path>` or `file://<path>`
+    pub async fn new_ptr(url: &str) -> Result<EnginePtr, FlameError> {
+        let path = Self::parse_url(url)?;
+
+        // Create base directories
+        let sessions_path = path.join("sessions");
+        let applications_path = path.join("applications");
+
+        fs::create_dir_all(&sessions_path).await.map_err(|e| {
+            FlameError::Storage(format!("Failed to create sessions directory: {e}"))
+        })?;
+        fs::create_dir_all(&applications_path).await.map_err(|e| {
+            FlameError::Storage(format!("Failed to create applications directory: {e}"))
+        })?;
+
+        let record_size = task_record_size();
+        tracing::info!(
+            "Filesystem storage engine initialized at {:?} with record size {}",
+            path,
+            record_size
+        );
+
+        Ok(Arc::new(FilesystemEngine {
+            base_path: path,
+            record_size,
+            locks: RwLock::new(HashMap::new()),
+        }))
+    }
+
+    /// Parse the storage URL to extract the base path.
+    fn parse_url(url: &str) -> Result<PathBuf, FlameError> {
+        let path = if let Some(p) = url.strip_prefix("filesystem://") {
+            p
+        } else if let Some(p) = url.strip_prefix("file://") {
+            p
+        } else if let Some(p) = url.strip_prefix("fs://") {
+            p
+        } else {
+            return Err(FlameError::InvalidConfig(format!(
+                "Invalid filesystem URL: {url}. Expected filesystem://, file://, or fs:// prefix"
+            )));
+        };
+
+        if path.starts_with('/') {
+            Ok(PathBuf::from(path))
+        } else {
+            let flame_home =
+                std::env::var(FLAME_HOME).unwrap_or_else(|_| "/usr/local/flame".to_string());
+            Ok(PathBuf::from(flame_home).join(path))
+        }
+    }
+
+    fn session_path(&self, session_id: &str) -> PathBuf {
+        self.base_path.join("sessions").join(session_id)
+    }
+
+    fn application_path(&self, app_name: &str) -> PathBuf {
+        self.base_path.join("applications").join(app_name)
+    }
+
+    /// Read session metadata from disk.
+    async fn read_session_metadata(&self, session_id: &str) -> Result<SessionMetadata, FlameError> {
+        let path = self.session_path(session_id).join("metadata");
+        let content = fs::read_to_string(&path).await.map_err(|e| {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                FlameError::NotFound(format!("Session {session_id} not found: {e}"))
+            } else {
+                FlameError::Storage(format!(
+                    "Failed to read session metadata for {session_id}: {e}"
+                ))
+            }
+        })?;
+        serde_json::from_str(&content)
+            .map_err(|e| FlameError::Storage(format!("Failed to parse session metadata: {e}")))
+    }
+
+    /// Write session metadata to disk atomically.
+    async fn write_session_metadata(
+        &self,
+        session_id: &str,
+        meta: &SessionMetadata,
+    ) -> Result<(), FlameError> {
+        let session_dir = self.session_path(session_id);
+        let path = session_dir.join("metadata");
+        let tmp_path = session_dir.join("metadata.tmp");
+
+        let content = serde_json::to_string_pretty(meta).map_err(|e| {
+            FlameError::Storage(format!("Failed to serialize session metadata: {e}"))
+        })?;
+
+        // Write to temp file first
+        fs::write(&tmp_path, &content)
+            .await
+            .map_err(|e| FlameError::Storage(format!("Failed to write session metadata: {e}")))?;
+
+        // Atomic rename
+        fs::rename(&tmp_path, &path)
+            .await
+            .map_err(|e| FlameError::Storage(format!("Failed to rename session metadata: {e}")))?;
+
+        Ok(())
+    }
+
+    /// Read application metadata from disk.
+    async fn read_application_metadata(
+        &self,
+        app_name: &str,
+    ) -> Result<ApplicationMetadata, FlameError> {
+        let path = self.application_path(app_name).join("metadata");
+        let content = fs::read_to_string(&path).await.map_err(|e| {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                FlameError::NotFound(format!("Application {app_name} not found: {e}"))
+            } else {
+                FlameError::Storage(format!(
+                    "Failed to read application metadata for {app_name}: {e}"
+                ))
+            }
+        })?;
+        serde_json::from_str(&content)
+            .map_err(|e| FlameError::Storage(format!("Failed to parse application metadata: {e}")))
+    }
+
+    /// Write application metadata to disk atomically.
+    async fn write_application_metadata(
+        &self,
+        app_name: &str,
+        meta: &ApplicationMetadata,
+    ) -> Result<(), FlameError> {
+        let app_dir = self.application_path(app_name);
+        fs::create_dir_all(&app_dir).await.map_err(|e| {
+            FlameError::Storage(format!("Failed to create application directory: {e}"))
+        })?;
+
+        let path = app_dir.join("metadata");
+        let tmp_path = app_dir.join("metadata.tmp");
+
+        let content = serde_json::to_string_pretty(meta).map_err(|e| {
+            FlameError::Storage(format!("Failed to serialize application metadata: {e}"))
+        })?;
+
+        // Write to temp file first
+        fs::write(&tmp_path, &content).await.map_err(|e| {
+            FlameError::Storage(format!("Failed to write application metadata: {e}"))
+        })?;
+
+        // Atomic rename
+        fs::rename(&tmp_path, &path).await.map_err(|e| {
+            FlameError::Storage(format!("Failed to rename application metadata: {e}"))
+        })?;
+
+        Ok(())
+    }
+
+    /// Read task metadata from tasks.bin.
+    async fn read_task_metadata(
+        &self,
+        session_id: &str,
+        task_id: TaskID,
+    ) -> Result<TaskMetadata, FlameError> {
+        if task_id < 1 {
+            return Err(FlameError::NotFound(format!(
+                "Invalid task ID: {task_id} (must be >= 1)"
+            )));
+        }
+
+        let path = self.session_path(session_id).join("tasks.bin");
+
+        let mut file = tokio::fs::OpenOptions::new()
+            .read(true)
+            .open(&path)
+            .await
+            .map_err(|e| FlameError::NotFound(format!("Tasks file not found: {e}")))?;
+
+        let offset = (task_id as u64 - 1) * self.record_size as u64;
+        file.seek(SeekFrom::Start(offset))
+            .await
+            .map_err(|e| FlameError::Storage(format!("Failed to seek to task {task_id}: {e}")))?;
+
+        let mut buffer = vec![0u8; self.record_size];
+        file.read_exact(&mut buffer)
+            .await
+            .map_err(|e| FlameError::NotFound(format!("Task {task_id} not found: {e}")))?;
+
+        let (meta, _): (TaskMetadata, _) = bincode::decode_from_slice(&buffer, bincode_config())
+            .map_err(|e| {
+                FlameError::Storage(format!("Failed to deserialize task metadata: {e}"))
+            })?;
+
+        // Verify checksum
+        let expected_checksum = calculate_checksum(&meta);
+        if meta.checksum != expected_checksum {
+            return Err(FlameError::Storage(format!(
+                "Task {task_id} checksum mismatch: expected {expected_checksum}, got {}",
+                meta.checksum
+            )));
+        }
+
+        Ok(meta)
+    }
+
+    /// Write task metadata to tasks.bin at the specified offset.
+    async fn write_task_metadata(
+        &self,
+        session_id: &str,
+        meta: &TaskMetadata,
+    ) -> Result<(), FlameError> {
+        let path = self.session_path(session_id).join("tasks.bin");
+
+        let mut file = tokio::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&path)
+            .await
+            .map_err(|e| FlameError::Storage(format!("Failed to open tasks file: {e}")))?;
+
+        let offset = (meta.id - 1) * self.record_size as u64;
+        file.seek(SeekFrom::Start(offset))
+            .await
+            .map_err(|e| FlameError::Storage(format!("Failed to seek to task {}: {e}", meta.id)))?;
+
+        let buffer = bincode::encode_to_vec(meta, bincode_config())
+            .map_err(|e| FlameError::Storage(format!("Failed to serialize task metadata: {e}")))?;
+
+        file.write_all(&buffer)
+            .await
+            .map_err(|e| FlameError::Storage(format!("Failed to write task metadata: {e}")))?;
+
+        file.sync_data()
+            .await
+            .map_err(|e| FlameError::Storage(format!("Failed to sync task metadata: {e}")))?;
+
+        Ok(())
+    }
+
+    /// Append data to a file and return the offset where it was written.
+    async fn append_data(
+        &self,
+        session_id: &str,
+        filename: &str,
+        data: &[u8],
+    ) -> Result<u64, FlameError> {
+        let path = self.session_path(session_id).join(filename);
+
+        let mut file = tokio::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .append(true)
+            .open(&path)
+            .await
+            .map_err(|e| FlameError::Storage(format!("Failed to open {filename}: {e}")))?;
+
+        // Get current file size (this is where we'll write)
+        let offset = file.seek(SeekFrom::End(0)).await.map_err(|e| {
+            FlameError::Storage(format!("Failed to seek to end of {filename}: {e}"))
+        })?;
+
+        file.write_all(data)
+            .await
+            .map_err(|e| FlameError::Storage(format!("Failed to write to {filename}: {e}")))?;
+
+        file.sync_data()
+            .await
+            .map_err(|e| FlameError::Storage(format!("Failed to sync {filename}: {e}")))?;
+
+        Ok(offset)
+    }
+
+    /// Read data from a file at the specified offset and length.
+    async fn read_data(
+        &self,
+        session_id: &str,
+        filename: &str,
+        offset: u64,
+        len: u64,
+    ) -> Result<Vec<u8>, FlameError> {
+        if len == 0 {
+            return Ok(Vec::new());
+        }
+
+        let path = self.session_path(session_id).join(filename);
+
+        let mut file = tokio::fs::OpenOptions::new()
+            .read(true)
+            .open(&path)
+            .await
+            .map_err(|e| FlameError::Storage(format!("Failed to open {filename}: {e}")))?;
+
+        file.seek(SeekFrom::Start(offset))
+            .await
+            .map_err(|e| FlameError::Storage(format!("Failed to seek in {filename}: {e}")))?;
+
+        let mut buffer = vec![0u8; len as usize];
+        file.read_exact(&mut buffer)
+            .await
+            .map_err(|e| FlameError::Storage(format!("Failed to read from {filename}: {e}")))?;
+
+        Ok(buffer)
+    }
+
+    /// Get the number of tasks in a session by checking the tasks.bin file size.
+    async fn get_task_count(&self, session_id: &str) -> Result<u64, FlameError> {
+        let path = self.session_path(session_id).join("tasks.bin");
+
+        match fs::metadata(&path).await {
+            Ok(metadata) => Ok(metadata.len() / self.record_size as u64),
+            Err(_) => Ok(0),
+        }
+    }
+
+    /// Read common data for a session.
+    async fn read_common_data(
+        &self,
+        session_id: &str,
+        len: u64,
+    ) -> Result<Option<Bytes>, FlameError> {
+        if len == 0 {
+            return Ok(None);
+        }
+
+        let path = self.session_path(session_id).join("common_data.bin");
+        match fs::read(&path).await {
+            Ok(data) => Ok(Some(Bytes::from(data))),
+            Err(_) => Ok(None),
+        }
+    }
+
+    /// Write common data for a session.
+    async fn write_common_data(&self, session_id: &str, data: &[u8]) -> Result<(), FlameError> {
+        let path = self.session_path(session_id).join("common_data.bin");
+        fs::write(&path, data)
+            .await
+            .map_err(|e| FlameError::Storage(format!("Failed to write common data: {e}")))?;
+        Ok(())
+    }
+
+    /// Convert TaskMetadata to Task.
+    async fn task_from_metadata(
+        &self,
+        session_id: &str,
+        meta: &TaskMetadata,
+    ) -> Result<Task, FlameError> {
+        let input = if meta.input_len > 0 {
+            let data = self
+                .read_data(session_id, "inputs.bin", meta.input_offset, meta.input_len)
+                .await?;
+            Some(Bytes::from(data))
+        } else {
+            None
+        };
+
+        let output = if meta.output_len > 0 {
+            let data = self
+                .read_data(
+                    session_id,
+                    "outputs.bin",
+                    meta.output_offset,
+                    meta.output_len,
+                )
+                .await?;
+            Some(Bytes::from(data))
+        } else {
+            None
+        };
+
+        let state = TaskState::try_from(meta.state as i32)?;
+        let completion_time = if meta.completion_time > 0 {
+            DateTime::from_timestamp(meta.completion_time, 0)
+        } else {
+            None
+        };
+
+        Ok(Task {
+            id: meta.id as TaskID,
+            ssn_id: session_id.to_string(),
+            version: meta.version,
+            input,
+            output,
+            creation_time: DateTime::from_timestamp(meta.creation_time, 0)
+                .ok_or_else(|| FlameError::Storage("Invalid creation time".to_string()))?,
+            completion_time,
+            events: Vec::new(), // Events are handled by EventManager
+            state,
+        })
+    }
+
+    /// Convert SessionMetadata to Session.
+    async fn session_from_metadata(&self, meta: &SessionMetadata) -> Result<Session, FlameError> {
+        let state = SessionState::try_from(meta.state)?;
+        let common_data = self
+            .read_common_data(&meta.id, meta.common_data_len)
+            .await?;
+        let completion_time = meta
+            .completion_time
+            .and_then(|t| DateTime::from_timestamp(t, 0));
+
+        Ok(Session {
+            id: meta.id.clone(),
+            application: meta.application.clone(),
+            slots: meta.slots,
+            version: meta.version,
+            common_data,
+            tasks: std::collections::HashMap::new(),
+            tasks_index: std::collections::HashMap::new(),
+            creation_time: DateTime::from_timestamp(meta.creation_time, 0)
+                .ok_or_else(|| FlameError::Storage("Invalid creation time".to_string()))?,
+            completion_time,
+            events: Vec::new(),
+            status: SessionStatus { state },
+            min_instances: meta.min_instances,
+            max_instances: meta.max_instances,
+        })
+    }
+
+    /// Convert ApplicationMetadata to Application.
+    fn application_from_metadata(meta: &ApplicationMetadata) -> Result<Application, FlameError> {
+        let state = ApplicationState::try_from(meta.state)?;
+        let schema = meta.schema.as_ref().map(|s| ApplicationSchema {
+            input: s.input.clone(),
+            output: s.output.clone(),
+            common_data: s.common_data.clone(),
+        });
+
+        Ok(Application {
+            name: meta.name.clone(),
+            version: meta.version,
+            state,
+            creation_time: DateTime::from_timestamp(meta.creation_time, 0)
+                .ok_or_else(|| FlameError::Storage("Invalid creation time".to_string()))?,
+            image: meta.image.clone(),
+            description: meta.description.clone(),
+            labels: meta.labels.clone(),
+            command: meta.command.clone(),
+            arguments: meta.arguments.clone(),
+            environments: meta.environments.clone(),
+            working_directory: meta.working_directory.clone(),
+            max_instances: meta.max_instances,
+            delay_release: Duration::seconds(meta.delay_release_seconds),
+            schema,
+            url: meta.url.clone(),
+        })
+    }
+
+    /// Check if an application exists and is enabled.
+    async fn check_application_enabled(&self, app_name: &str) -> Result<(), FlameError> {
+        let meta = self.read_application_metadata(app_name).await?;
+        if meta.state != ApplicationState::Enabled as i32 {
+            return Err(FlameError::InvalidState(format!(
+                "Application {app_name} is not enabled"
+            )));
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Engine for FilesystemEngine {
+    async fn register_application(
+        &self,
+        name: String,
+        attr: ApplicationAttributes,
+    ) -> Result<Application, FlameError> {
+        let schema = attr.schema.map(|s| ApplicationSchemaMetadata {
+            input: s.input,
+            output: s.output,
+            common_data: s.common_data,
+        });
+
+        let meta = ApplicationMetadata {
+            name: name.clone(),
+            version: 1,
+            state: ApplicationState::Enabled as i32,
+            creation_time: Utc::now().timestamp(),
+            image: attr.image,
+            description: attr.description,
+            labels: attr.labels,
+            command: attr.command,
+            arguments: attr.arguments,
+            environments: attr.environments,
+            working_directory: attr.working_directory,
+            max_instances: attr.max_instances,
+            delay_release_seconds: attr.delay_release.num_seconds(),
+            schema,
+            url: attr.url,
+        };
+
+        self.write_application_metadata(&name, &meta).await?;
+        Self::application_from_metadata(&meta)
+    }
+
+    async fn unregister_application(&self, name: String) -> Result<(), FlameError> {
+        let _guard = lock_app!(self);
+
+        let sessions_dir = self.base_path.join("sessions");
+        if let Ok(mut entries) = fs::read_dir(&sessions_dir).await {
+            while let Ok(Some(entry)) = entries.next_entry().await {
+                let session_id = entry.file_name().to_string_lossy().to_string();
+                if let Ok(meta) = self.read_session_metadata(&session_id).await {
+                    if meta.application == name && meta.state == SessionState::Open as i32 {
+                        return Err(FlameError::Storage(format!(
+                            "Cannot unregister application '{}': has open sessions",
+                            name
+                        )));
+                    }
+                }
+            }
+        }
+
+        let app_dir = self.application_path(&name);
+        fs::remove_dir_all(&app_dir).await.map_err(|e| {
+            FlameError::Storage(format!("Failed to delete application '{}': {e}", name))
+        })?;
+
+        Ok(())
+    }
+
+    async fn update_application(
+        &self,
+        name: String,
+        attr: ApplicationAttributes,
+    ) -> Result<Application, FlameError> {
+        let _guard = lock_app!(self);
+
+        let mut meta = self.read_application_metadata(&name).await?;
+
+        let sessions_dir = self.base_path.join("sessions");
+        if let Ok(mut entries) = fs::read_dir(&sessions_dir).await {
+            while let Ok(Some(entry)) = entries.next_entry().await {
+                let session_id = entry.file_name().to_string_lossy().to_string();
+                if let Ok(ssn_meta) = self.read_session_metadata(&session_id).await {
+                    if ssn_meta.application == name && ssn_meta.state == SessionState::Open as i32 {
+                        return Err(FlameError::Storage(format!(
+                            "Cannot update application '{}': has open sessions",
+                            name
+                        )));
+                    }
+                }
+            }
+        }
+
+        let schema = attr.schema.map(|s| ApplicationSchemaMetadata {
+            input: s.input,
+            output: s.output,
+            common_data: s.common_data,
+        });
+
+        meta.version += 1;
+        meta.image = attr.image;
+        meta.description = attr.description;
+        meta.labels = attr.labels;
+        meta.command = attr.command;
+        meta.arguments = attr.arguments;
+        meta.environments = attr.environments;
+        meta.working_directory = attr.working_directory;
+        meta.max_instances = attr.max_instances;
+        meta.delay_release_seconds = attr.delay_release.num_seconds();
+        meta.schema = schema;
+        meta.url = attr.url;
+
+        self.write_application_metadata(&name, &meta).await?;
+        Self::application_from_metadata(&meta)
+    }
+
+    async fn get_application(&self, id: ApplicationID) -> Result<Application, FlameError> {
+        let meta = self.read_application_metadata(&id).await?;
+        Self::application_from_metadata(&meta)
+    }
+
+    async fn find_application(&self) -> Result<Vec<Application>, FlameError> {
+        let mut apps = Vec::new();
+        let apps_dir = self.base_path.join("applications");
+
+        if let Ok(mut entries) = fs::read_dir(&apps_dir).await {
+            while let Ok(Some(entry)) = entries.next_entry().await {
+                let app_name = entry.file_name().to_string_lossy().to_string();
+                if let Ok(meta) = self.read_application_metadata(&app_name).await {
+                    if let Ok(app) = Self::application_from_metadata(&meta) {
+                        apps.push(app);
+                    }
+                }
+            }
+        }
+
+        Ok(apps)
+    }
+
+    async fn create_session(&self, attr: SessionAttributes) -> Result<Session, FlameError> {
+        self.check_application_enabled(&attr.application).await?;
+
+        {
+            let mut locks = lock_app!(self);
+            locks.insert(attr.id.clone(), Arc::new(Mutex::new(())));
+        }
+
+        let session_dir = self.session_path(&attr.id);
+        fs::create_dir_all(&session_dir)
+            .await
+            .map_err(|e| FlameError::Storage(format!("Failed to create session directory: {e}")))?;
+
+        let common_data_len = if let Some(ref data) = attr.common_data {
+            self.write_common_data(&attr.id, data).await?;
+            data.len() as u64
+        } else {
+            0
+        };
+
+        let meta = SessionMetadata {
+            id: attr.id.clone(),
+            application: attr.application.clone(),
+            slots: attr.slots,
+            version: 1,
+            state: SessionState::Open as i32,
+            creation_time: Utc::now().timestamp(),
+            completion_time: None,
+            min_instances: attr.min_instances,
+            max_instances: attr.max_instances,
+            common_data_len,
+        };
+
+        self.write_session_metadata(&attr.id, &meta).await?;
+
+        let tasks_path = session_dir.join("tasks.bin");
+        let inputs_path = session_dir.join("inputs.bin");
+        let outputs_path = session_dir.join("outputs.bin");
+
+        fs::write(&tasks_path, &[])
+            .await
+            .map_err(|e| FlameError::Storage(format!("Failed to create tasks.bin: {e}")))?;
+        fs::write(&inputs_path, &[])
+            .await
+            .map_err(|e| FlameError::Storage(format!("Failed to create inputs.bin: {e}")))?;
+        fs::write(&outputs_path, &[])
+            .await
+            .map_err(|e| FlameError::Storage(format!("Failed to create outputs.bin: {e}")))?;
+
+        self.session_from_metadata(&meta).await
+    }
+
+    async fn get_session(&self, id: SessionID) -> Result<Session, FlameError> {
+        let meta = self.read_session_metadata(&id).await?;
+        self.session_from_metadata(&meta).await
+    }
+
+    async fn open_session(
+        &self,
+        id: SessionID,
+        spec: Option<SessionAttributes>,
+    ) -> Result<Session, FlameError> {
+        // Try to get existing session
+        match self.read_session_metadata(&id).await {
+            Ok(meta) => {
+                // Session exists - validate state
+                if meta.state != SessionState::Open as i32 {
+                    return Err(FlameError::InvalidState(format!(
+                        "Session {id} is not open"
+                    )));
+                }
+
+                // If spec provided, validate it matches
+                if let Some(ref attr) = spec {
+                    if meta.application != attr.application {
+                        return Err(FlameError::InvalidConfig(format!(
+                            "Session {id} spec mismatch: application differs"
+                        )));
+                    }
+                    if meta.slots != attr.slots {
+                        return Err(FlameError::InvalidConfig(format!(
+                            "Session {id} spec mismatch: slots differs"
+                        )));
+                    }
+                }
+
+                self.session_from_metadata(&meta).await
+            }
+            Err(_) => {
+                // Session doesn't exist
+                match spec {
+                    Some(attr) => self.create_session(attr).await,
+                    None => Err(FlameError::NotFound(format!("Session {id} not found"))),
+                }
+            }
+        }
+    }
+
+    async fn close_session(&self, id: SessionID) -> Result<Session, FlameError> {
+        let mut meta = self.read_session_metadata(&id).await?;
+
+        let task_count = self.get_task_count(&id).await?;
+        for task_id in 1..=task_count {
+            if let Ok(task_meta) = self.read_task_metadata(&id, task_id as TaskID).await {
+                let state = match TaskState::try_from(task_meta.state as i32) {
+                    Ok(s) => s,
+                    Err(e) => {
+                        tracing::warn!(
+                            "Task {}/{} has corrupted state ({}): {}, treating as incomplete",
+                            id,
+                            task_id,
+                            task_meta.state,
+                            e
+                        );
+                        return Err(FlameError::Storage(
+                            "Cannot close session with corrupted task state".to_string(),
+                        ));
+                    }
+                };
+                if state != TaskState::Succeed && state != TaskState::Failed {
+                    return Err(FlameError::Storage(
+                        "Cannot close session with open tasks".to_string(),
+                    ));
+                }
+            }
+        }
+
+        meta.state = SessionState::Closed as i32;
+        meta.completion_time = Some(Utc::now().timestamp());
+        meta.version += 1;
+
+        self.write_session_metadata(&id, &meta).await?;
+        self.session_from_metadata(&meta).await
+    }
+
+    async fn delete_session(&self, id: SessionID) -> Result<Session, FlameError> {
+        let meta = self.read_session_metadata(&id).await?;
+
+        if meta.state != SessionState::Closed as i32 {
+            return Err(FlameError::Storage(
+                "Cannot delete open session".to_string(),
+            ));
+        }
+
+        let task_count = self.get_task_count(&id).await?;
+        for task_id in 1..=task_count {
+            if let Ok(task_meta) = self.read_task_metadata(&id, task_id as TaskID).await {
+                let state = match TaskState::try_from(task_meta.state as i32) {
+                    Ok(s) => s,
+                    Err(e) => {
+                        tracing::warn!(
+                            "Task {}/{} has corrupted state ({}): {}, treating as incomplete",
+                            id,
+                            task_id,
+                            task_meta.state,
+                            e
+                        );
+                        return Err(FlameError::Storage(
+                            "Cannot delete session with corrupted task state".to_string(),
+                        ));
+                    }
+                };
+                if state != TaskState::Succeed && state != TaskState::Failed {
+                    return Err(FlameError::Storage(
+                        "Cannot delete session with open tasks".to_string(),
+                    ));
+                }
+            }
+        }
+
+        let session = self.session_from_metadata(&meta).await?;
+
+        let session_dir = self.session_path(&id);
+        fs::remove_dir_all(&session_dir)
+            .await
+            .map_err(|e| FlameError::Storage(format!("Failed to delete session: {e}")))?;
+
+        {
+            let mut locks = lock_app!(self);
+            locks.remove(&id);
+        }
+
+        Ok(session)
+    }
+
+    async fn find_session(&self) -> Result<Vec<Session>, FlameError> {
+        let mut sessions = Vec::new();
+        let sessions_dir = self.base_path.join("sessions");
+
+        if let Ok(mut entries) = fs::read_dir(&sessions_dir).await {
+            while let Ok(Some(entry)) = entries.next_entry().await {
+                let session_id = entry.file_name().to_string_lossy().to_string();
+                if let Ok(meta) = self.read_session_metadata(&session_id).await {
+                    if let Ok(session) = self.session_from_metadata(&meta).await {
+                        sessions.push(session);
+                    }
+                }
+            }
+        }
+
+        Ok(sessions)
+    }
+
+    async fn create_task(
+        &self,
+        ssn_id: SessionID,
+        input: Option<TaskInput>,
+    ) -> Result<Task, FlameError> {
+        let ssn_meta = self.read_session_metadata(&ssn_id).await?;
+        if ssn_meta.state != SessionState::Open as i32 {
+            return Err(FlameError::InvalidState(
+                "Cannot create task in closed session".to_string(),
+            ));
+        }
+
+        let _guard = lock_ssn!(self, &ssn_id)?;
+
+        let task_count = self.get_task_count(&ssn_id).await?;
+        let task_id = task_count + 1;
+
+        let (input_offset, input_len) = if let Some(ref data) = input {
+            let offset = self.append_data(&ssn_id, "inputs.bin", data).await?;
+            (offset, data.len() as u64)
+        } else {
+            (0, 0)
+        };
+
+        let mut meta = TaskMetadata {
+            id: task_id,
+            version: 1,
+            checksum: 0,
+            state: TaskState::Pending as u8,
+            creation_time: Utc::now().timestamp(),
+            completion_time: 0,
+            input_offset,
+            input_len,
+            output_offset: 0,
+            output_len: 0,
+        };
+
+        meta.checksum = calculate_checksum(&meta);
+
+        self.write_task_metadata(&ssn_id, &meta).await?;
+
+        self.task_from_metadata(&ssn_id, &meta).await
+    }
+
+    async fn get_task(&self, gid: TaskGID) -> Result<Task, FlameError> {
+        let _guard = lock_ssn!(self, &gid.ssn_id)?;
+        let meta = self.read_task_metadata(&gid.ssn_id, gid.task_id).await?;
+        self.task_from_metadata(&gid.ssn_id, &meta).await
+    }
+
+    async fn retry_task(&self, gid: TaskGID) -> Result<Task, FlameError> {
+        let _guard = lock_ssn!(self, &gid.ssn_id)?;
+
+        let mut meta = self.read_task_metadata(&gid.ssn_id, gid.task_id).await?;
+
+        meta.state = TaskState::Pending as u8;
+        meta.version += 1;
+        meta.checksum = calculate_checksum(&meta);
+
+        self.write_task_metadata(&gid.ssn_id, &meta).await?;
+        self.task_from_metadata(&gid.ssn_id, &meta).await
+    }
+
+    async fn delete_task(&self, gid: TaskGID) -> Result<Task, FlameError> {
+        // In append-only filesystem architecture, physical deletion is not supported.
+        // The task data remains in the append-only files (inputs.bin, outputs.bin).
+        // Callers should use close_session + delete_session to clean up entire sessions.
+        Err(FlameError::Storage(format!(
+            "Task deletion not supported in filesystem storage engine (task {}/{}). \
+             Use session deletion to clean up completed sessions.",
+            gid.ssn_id, gid.task_id
+        )))
+    }
+
+    async fn update_task_state(
+        &self,
+        gid: TaskGID,
+        task_state: TaskState,
+        _message: Option<String>,
+    ) -> Result<Task, FlameError> {
+        let _guard = lock_ssn!(self, &gid.ssn_id)?;
+
+        let mut meta = self.read_task_metadata(&gid.ssn_id, gid.task_id).await?;
+
+        meta.state = task_state as u8;
+        meta.version += 1;
+
+        if task_state == TaskState::Succeed || task_state == TaskState::Failed {
+            meta.completion_time = Utc::now().timestamp();
+        }
+
+        meta.checksum = calculate_checksum(&meta);
+
+        self.write_task_metadata(&gid.ssn_id, &meta).await?;
+        self.task_from_metadata(&gid.ssn_id, &meta).await
+    }
+
+    async fn update_task_result(
+        &self,
+        gid: TaskGID,
+        task_result: TaskResult,
+    ) -> Result<Task, FlameError> {
+        let _guard = lock_ssn!(self, &gid.ssn_id)?;
+
+        let mut meta = self.read_task_metadata(&gid.ssn_id, gid.task_id).await?;
+
+        if let Some(ref output) = task_result.output {
+            let offset = self.append_data(&gid.ssn_id, "outputs.bin", output).await?;
+            meta.output_offset = offset;
+            meta.output_len = output.len() as u64;
+        }
+
+        meta.state = task_result.state as u8;
+        meta.version += 1;
+
+        if task_result.state == TaskState::Succeed || task_result.state == TaskState::Failed {
+            meta.completion_time = Utc::now().timestamp();
+        }
+
+        meta.checksum = calculate_checksum(&meta);
+
+        self.write_task_metadata(&gid.ssn_id, &meta).await?;
+        self.task_from_metadata(&gid.ssn_id, &meta).await
+    }
+
+    async fn find_tasks(&self, ssn_id: SessionID) -> Result<Vec<Task>, FlameError> {
+        let _guard = lock_ssn!(self, &ssn_id)?;
+
+        let mut tasks = Vec::new();
+        let task_count = self.get_task_count(&ssn_id).await?;
+
+        for task_id in 1..=task_count {
+            if let Ok(meta) = self.read_task_metadata(&ssn_id, task_id as TaskID).await {
+                if let Ok(task) = self.task_from_metadata(&ssn_id, &meta).await {
+                    tasks.push(task);
+                }
+            }
+        }
+
+        Ok(tasks)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    async fn create_test_engine() -> (FilesystemEngine, TempDir) {
+        let temp_dir = TempDir::new().unwrap();
+        let url = format!("filesystem://{}", temp_dir.path().display());
+        let _engine_ptr = FilesystemEngine::new_ptr(&url).await.unwrap();
+
+        let engine = FilesystemEngine {
+            base_path: temp_dir.path().to_path_buf(),
+            record_size: task_record_size(),
+            locks: RwLock::new(HashMap::new()),
+        };
+
+        (engine, temp_dir)
+    }
+
+    #[tokio::test]
+    async fn test_record_size_is_constant() {
+        let size1 = task_record_size();
+        let size2 = task_record_size();
+        assert_eq!(size1, size2);
+
+        // Verify different metadata values produce same size
+        let meta1 = TaskMetadata::default();
+        let meta2 = TaskMetadata {
+            id: u64::MAX,
+            version: u32::MAX,
+            checksum: u32::MAX,
+            state: 255,
+            creation_time: i64::MAX,
+            completion_time: i64::MAX,
+            input_offset: u64::MAX,
+            input_len: u64::MAX,
+            output_offset: u64::MAX,
+            output_len: u64::MAX,
+        };
+
+        let buf1 = bincode::encode_to_vec(&meta1, bincode_config()).unwrap();
+        let buf2 = bincode::encode_to_vec(&meta2, bincode_config()).unwrap();
+
+        assert_eq!(buf1.len(), buf2.len());
+    }
+
+    #[tokio::test]
+    async fn test_checksum_calculation() {
+        let meta = TaskMetadata {
+            id: 1,
+            version: 1,
+            checksum: 0,
+            state: TaskState::Pending as u8,
+            creation_time: 1234567890,
+            completion_time: 0,
+            input_offset: 0,
+            input_len: 100,
+            output_offset: 0,
+            output_len: 0,
+        };
+
+        let checksum1 = calculate_checksum(&meta);
+        let checksum2 = calculate_checksum(&meta);
+
+        assert_eq!(checksum1, checksum2);
+
+        // Different metadata should produce different checksum
+        let meta2 = TaskMetadata { id: 2, ..meta };
+
+        let checksum3 = calculate_checksum(&meta2);
+        assert_ne!(checksum1, checksum3);
+    }
+
+    #[tokio::test]
+    async fn test_url_parsing() {
+        std::env::set_var("FLAME_HOME", "/opt/flame");
+
+        let path1 = FilesystemEngine::parse_url("filesystem:///var/lib/flame").unwrap();
+        assert_eq!(path1, PathBuf::from("/var/lib/flame"));
+
+        let path2 = FilesystemEngine::parse_url("file:///tmp/flame").unwrap();
+        assert_eq!(path2, PathBuf::from("/tmp/flame"));
+
+        let path3 = FilesystemEngine::parse_url("fs:///data").unwrap();
+        assert_eq!(path3, PathBuf::from("/data"));
+
+        let path4 = FilesystemEngine::parse_url("fs://data").unwrap();
+        assert_eq!(path4, PathBuf::from("/opt/flame/data"));
+
+        let path5 = FilesystemEngine::parse_url("filesystem://data/sessions").unwrap();
+        assert_eq!(path5, PathBuf::from("/opt/flame/data/sessions"));
+
+        let path6 = FilesystemEngine::parse_url("file://storage").unwrap();
+        assert_eq!(path6, PathBuf::from("/opt/flame/storage"));
+
+        std::env::remove_var("FLAME_HOME");
+
+        let err = FilesystemEngine::parse_url("sqlite:///tmp/flame.db");
+        assert!(err.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_application_lifecycle() {
+        let (engine, _temp_dir) = create_test_engine().await;
+
+        // Register application
+        let attr = ApplicationAttributes {
+            image: Some("test-image".to_string()),
+            description: Some("Test application".to_string()),
+            labels: vec!["test".to_string()],
+            command: Some("/bin/test".to_string()),
+            arguments: vec!["--arg1".to_string()],
+            environments: std::collections::HashMap::new(),
+            working_directory: Some("/tmp".to_string()),
+            max_instances: 10,
+            delay_release: Duration::seconds(60),
+            schema: None,
+            url: None,
+        };
+
+        let app = engine
+            .register_application("test-app".to_string(), attr.clone())
+            .await
+            .unwrap();
+        assert_eq!(app.name, "test-app");
+        assert_eq!(app.state, ApplicationState::Enabled);
+
+        // Get application
+        let app2 = engine
+            .get_application("test-app".to_string())
+            .await
+            .unwrap();
+        assert_eq!(app2.name, "test-app");
+
+        // Find applications
+        let apps = engine.find_application().await.unwrap();
+        assert_eq!(apps.len(), 1);
+
+        // Update application
+        let updated_attr = ApplicationAttributes {
+            description: Some("Updated description".to_string()),
+            ..attr
+        };
+        let app3 = engine
+            .update_application("test-app".to_string(), updated_attr)
+            .await
+            .unwrap();
+        assert_eq!(app3.description, Some("Updated description".to_string()));
+        assert_eq!(app3.version, 2);
+
+        // Unregister application
+        engine
+            .unregister_application("test-app".to_string())
+            .await
+            .unwrap();
+
+        // Verify it's gone
+        let result = engine.get_application("test-app".to_string()).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_session_lifecycle() {
+        let (engine, _temp_dir) = create_test_engine().await;
+
+        // First register an application
+        let app_attr = ApplicationAttributes {
+            image: None,
+            description: None,
+            labels: vec![],
+            command: Some("/bin/test".to_string()),
+            arguments: vec![],
+            environments: std::collections::HashMap::new(),
+            working_directory: None,
+            max_instances: 10,
+            delay_release: Duration::seconds(0),
+            schema: None,
+            url: None,
+        };
+        engine
+            .register_application("test-app".to_string(), app_attr)
+            .await
+            .unwrap();
+
+        // Create session
+        let ssn_attr = SessionAttributes {
+            id: "test-session".to_string(),
+            application: "test-app".to_string(),
+            slots: 1,
+            common_data: Some(Bytes::from("test data")),
+            min_instances: 0,
+            max_instances: None,
+        };
+
+        let session = engine.create_session(ssn_attr).await.unwrap();
+        assert_eq!(session.id, "test-session");
+        assert_eq!(session.status.state, SessionState::Open);
+
+        // Get session
+        let session2 = engine
+            .get_session("test-session".to_string())
+            .await
+            .unwrap();
+        assert_eq!(session2.id, "test-session");
+
+        // Find sessions
+        let sessions = engine.find_session().await.unwrap();
+        assert_eq!(sessions.len(), 1);
+
+        // Close session (should work since no tasks)
+        let closed = engine
+            .close_session("test-session".to_string())
+            .await
+            .unwrap();
+        assert_eq!(closed.status.state, SessionState::Closed);
+
+        // Delete session
+        let deleted = engine
+            .delete_session("test-session".to_string())
+            .await
+            .unwrap();
+        assert_eq!(deleted.id, "test-session");
+    }
+
+    #[tokio::test]
+    async fn test_task_lifecycle() {
+        let (engine, _temp_dir) = create_test_engine().await;
+
+        // Setup: register app and create session
+        let app_attr = ApplicationAttributes {
+            image: None,
+            description: None,
+            labels: vec![],
+            command: Some("/bin/test".to_string()),
+            arguments: vec![],
+            environments: std::collections::HashMap::new(),
+            working_directory: None,
+            max_instances: 10,
+            delay_release: Duration::seconds(0),
+            schema: None,
+            url: None,
+        };
+        engine
+            .register_application("test-app".to_string(), app_attr)
+            .await
+            .unwrap();
+
+        let ssn_attr = SessionAttributes {
+            id: "test-session".to_string(),
+            application: "test-app".to_string(),
+            slots: 1,
+            common_data: None,
+            min_instances: 0,
+            max_instances: None,
+        };
+        engine.create_session(ssn_attr).await.unwrap();
+
+        // Create task with input
+        let input = Bytes::from("test input data");
+        let task = engine
+            .create_task("test-session".to_string(), Some(input.clone()))
+            .await
+            .unwrap();
+        assert_eq!(task.id, 1);
+        assert_eq!(task.state, TaskState::Pending);
+        assert_eq!(task.input, Some(input));
+
+        // Get task
+        let gid = TaskGID {
+            ssn_id: "test-session".to_string(),
+            task_id: 1,
+        };
+        let task2 = engine.get_task(gid.clone()).await.unwrap();
+        assert_eq!(task2.id, 1);
+
+        // Update task state
+        let task3 = engine
+            .update_task_state(gid.clone(), TaskState::Running, None)
+            .await
+            .unwrap();
+        assert_eq!(task3.state, TaskState::Running);
+
+        // Update task result
+        let output = Bytes::from("test output data");
+        let result = TaskResult {
+            state: TaskState::Succeed,
+            output: Some(output.clone()),
+            message: None,
+        };
+        let task4 = engine
+            .update_task_result(gid.clone(), result)
+            .await
+            .unwrap();
+        assert_eq!(task4.state, TaskState::Succeed);
+        assert_eq!(task4.output, Some(output));
+
+        // Find tasks
+        let tasks = engine.find_tasks("test-session".to_string()).await.unwrap();
+        assert_eq!(tasks.len(), 1);
+
+        // Create another task
+        let task5 = engine
+            .create_task("test-session".to_string(), None)
+            .await
+            .unwrap();
+        assert_eq!(task5.id, 2);
+
+        // Complete second task
+        let gid2 = TaskGID {
+            ssn_id: "test-session".to_string(),
+            task_id: 2,
+        };
+        engine
+            .update_task_state(gid2, TaskState::Succeed, None)
+            .await
+            .unwrap();
+
+        // Now we can close the session
+        let closed = engine
+            .close_session("test-session".to_string())
+            .await
+            .unwrap();
+        assert_eq!(closed.status.state, SessionState::Closed);
+    }
+}

--- a/session_manager/src/storage/engine/mod.rs
+++ b/session_manager/src/storage/engine/mod.rs
@@ -21,6 +21,7 @@ use common::apis::{
     SessionAttributes, SessionID, Task, TaskGID, TaskInput, TaskOutput, TaskResult, TaskState,
 };
 
+mod filesystem;
 mod sqlite;
 mod types;
 
@@ -81,6 +82,34 @@ pub trait Engine: Send + Sync + 'static {
     async fn find_tasks(&self, ssn_id: SessionID) -> Result<Vec<Task>, FlameError>;
 }
 
+/// Connect to a storage engine based on the URL scheme.
+///
+/// Supported URL schemes:
+/// - `sqlite://` or `sqlite:` - SQLite database (default)
+/// - `filesystem://`, `file://`, `fs://` - Filesystem-based storage
+///
+/// Path resolution:
+/// - Triple slash (e.g., `fs:///data`) - Absolute path (`/data`)
+/// - Double slash (e.g., `fs://data`) - Relative to FLAME_HOME (`${FLAME_HOME}/data`)
+///
+/// # Examples
+///
+/// ```ignore
+/// // SQLite storage
+/// let engine = connect("sqlite:///var/lib/flame/sessions.db").await?;
+///
+/// // Filesystem storage (absolute path)
+/// let engine = connect("fs:///var/lib/flame").await?;
+///
+/// // Filesystem storage (relative to FLAME_HOME)
+/// let engine = connect("fs://data").await?;  // -> ${FLAME_HOME}/data
+/// ```
 pub async fn connect(url: &str) -> Result<EnginePtr, FlameError> {
-    sqlite::SqliteEngine::new_ptr(url).await
+    if url.starts_with("filesystem://") || url.starts_with("file://") || url.starts_with("fs://") {
+        tracing::info!("Using filesystem storage engine: {}", url);
+        filesystem::FilesystemEngine::new_ptr(url).await
+    } else {
+        tracing::info!("Using SQLite storage engine: {}", url);
+        sqlite::SqliteEngine::new_ptr(url).await
+    }
 }


### PR DESCRIPTION
Add a high-performance filesystem storage engine for Flame sessions, applications, and tasks using append-only binary files with CRC32 checksums.

Features:
- URL schemes: filesystem://, file://, fs:// with FLAME_HOME-relative paths
- Fixed-size task records using bincode for O(1) random access
- Append-only inputs.bin/outputs.bin for task data
- JSON metadata files for sessions and applications
- Session-level mutex locks for concurrent task operations
- Atomic writes with temp file + rename pattern

Also updates CI configs to use fs://data/ storage and adds design docs.

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-opencode)