### PR TITLE
feat(cache): add pluggable storage backend for object cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1657,6 +1657,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "stdng",
+ "tempfile",
  "tokio",
  "tonic",
  "tracing",

--- a/docs/designs/RFE414-cache-none-storage/FS.md
+++ b/docs/designs/RFE414-cache-none-storage/FS.md
@@ -1,0 +1,983 @@
+---
+Issue: "#414"
+Author: Flame Team
+Date: 2026-04-24
+---
+
+# Design Document: None Storage for Object Cache
+
+## 1. Motivation
+
+**Background:**
+
+Currently, Flame's Object Cache (`object_cache` crate) always persists data to disk using Arrow IPC format. While this provides durability and crash recovery, it introduces disk I/O overhead that can impact performance for compute-oriented workloads.
+
+The Object Cache currently:
+- Writes every object to disk immediately on `put`/`update`
+- Stores delta files on disk for `patch` operations
+- Loads objects from disk on cache miss or restart
+
+For some workloads, this persistence is unnecessary:
+1. **Real-time Processing**: Task results are consumed immediately; historical objects are not needed
+2. **Ephemeral Compute**: Objects are temporary intermediate results that don't need durability
+3. **High-Throughput Scenarios**: Disk I/O becomes the performance bottleneck
+4. **Development and Testing**: Fast iteration without persistence overhead
+
+**Reference Implementation:**
+
+The Session Manager already implements a similar pattern with `storage.engine`:
+- `session_manager/src/storage/engine/mod.rs` - `Engine` trait + `connect()` factory
+- `session_manager/src/storage/engine/none.rs` - `NoneEngine` implementation
+- `session_manager/src/storage/engine/sqlite.rs` - `SqliteEngine` implementation
+- `session_manager/src/storage/engine/filesystem.rs` - `FilesystemEngine` implementation
+
+**Target:**
+
+This design aims to:
+
+1. **Introduce a Storage Engine Trait** - Abstract storage operations behind a trait
+2. **Implement "None" Storage Engine** - A memory-only backend with no disk persistence
+3. **Maintain API Compatibility** - No changes to gRPC/Flight APIs or client SDKs
+4. **Improve Performance** - Eliminate disk I/O for compute-oriented workloads
+
+## 2. Function Specification
+
+**Configuration:**
+
+Enhance `cache.storage` field to support URL-style configuration (consistent with `cluster.storage` for session manager):
+
+```yaml
+cache:
+  endpoint: "grpc://127.0.0.1:9090"
+  network_interface: "eth0"
+  storage: "fs:///var/lib/flame/cache"  # Filesystem storage at absolute path
+  eviction:
+    policy: "lru"
+    max_memory: "1G"
+    max_objects: 10000
+```
+
+For memory-only mode:
+
+```yaml
+cache:
+  endpoint: "grpc://127.0.0.1:9090"
+  network_interface: "eth0"
+  storage: "none"                       # No disk persistence
+  eviction:
+    policy: "lru"
+    max_memory: "1G"
+```
+
+**Supported URL Schemes:**
+
+| Scheme | Example | Description |
+|--------|---------|-------------|
+| `none` | `none` | Memory-only, no persistence |
+| `fs://` | `fs:///var/lib/flame/cache` | Filesystem storage (absolute path) |
+| `file://` | `file:///var/lib/flame/cache` | Alias for `fs://` |
+| (plain path) | `/var/lib/flame/cache` | Legacy format, treated as filesystem storage |
+
+**Path Resolution (for `fs://` and `file://`):**
+- Triple slash (e.g., `fs:///data`) - Absolute path (`/data`)
+- Double slash (e.g., `fs://data`) - Relative to `FLAME_HOME` (`${FLAME_HOME}/data`)
+
+**Configuration Options:**
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `storage` | `String` | None | Storage URL: `none`, `fs:///path`, or legacy path |
+
+**Behavior Matrix:**
+
+| `storage` Value | Behavior |
+|-----------------|----------|
+| `"none"` | Memory-only, no persistence |
+| `"fs:///path"` or `"file:///path"` | Filesystem storage at specified path |
+| `"/path"` (plain path, legacy) | Filesystem storage at specified path |
+| Not set or empty | Warning logged, falls back to `none` |
+
+**Environment Variables:**
+
+- `FLAME_CACHE_STORAGE`: Override storage URL (e.g., `none`, `fs:///tmp/cache`)
+
+**API:**
+
+No changes to external Flight APIs. The storage engine is an internal implementation detail:
+
+- `do_put`: Upload an object → stored in memory (+ disk if disk backend)
+- `do_get`: Retrieve an object → from memory or disk
+- `do_action(PUT/UPDATE/DELETE/PATCH)`: Same behavior, different persistence
+
+**CLI:**
+
+No changes to CLI. Storage type is selected via `flame-cluster.yaml` configuration.
+
+**Scope:**
+
+*In Scope:*
+- `StorageEngine` trait abstracting storage operations
+- `DiskStorage` implementation (extract existing disk I/O from `cache.rs`)
+- `NoneStorage` implementation (memory-only, no persistence)
+- URL-style configuration via `cache.storage` field
+- Thread-safe concurrent access
+
+*Out of Scope:*
+- Distributed cache storage (single-node only)
+- Object replication or backup
+- Tiered storage (memory + disk fallback)
+- TTL-based cleanup (existing eviction handles this)
+
+*Limitations:*
+- With `none` storage, all cached objects are lost on restart
+- With `none` storage, evicted objects cannot be recovered
+- `patch` operation is not supported with `none` storage (returns error)
+
+**Feature Interaction:**
+
+*Related Features:*
+- **RFE394 None Storage for Session Manager**: Similar pattern, different component
+- **RFE366 LRU Eviction Policy**: Eviction policy remains unchanged
+- **RFE318 Object Cache**: Base implementation being extended
+
+*Updates Required:*
+1. `object_cache/src/storage/mod.rs`: New module with `StorageEngine` trait and `connect()` factory
+2. `object_cache/src/storage/disk.rs`: Extract disk I/O from `cache.rs`
+3. `object_cache/src/storage/none.rs`: New `NoneStorage` implementation
+4. `object_cache/src/cache.rs`: Refactor to use `StorageEngine`
+5. No changes needed to `common/src/ctx.rs` (reuse existing `storage` field)
+
+*Integration Points:*
+- Storage backend integrates via `StorageEngine` trait
+- ObjectCache delegates all I/O to storage engine
+- Eviction policy unchanged (operates on in-memory index)
+
+*Compatibility:*
+- Fully backward compatible: existing plain path configs (e.g., `/var/lib/flame/cache`) continue to work
+- New URL-style configs (`fs:///path`, `none`) provide explicit control
+
+*Breaking Changes:*
+- None. `storage: "none"` is opt-in; existing path-based configs work unchanged.
+- `patch` operation returns error with none storage (design decision)
+
+## 3. Implementation Detail
+
+**Architecture:**
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                         ObjectCache                                  │
+├─────────────────────────────────────────────────────────────────────┤
+│  endpoint: CacheEndpoint                                            │
+│  storage: StorageEnginePtr  ──────┐                                │
+│  objects: HashMap<String, Object>  │                                │
+│  metadata: HashMap<String, Meta>   │                                │
+│  eviction_policy: EvictionPolicy   │                                │
+└────────────────────────────────────┼────────────────────────────────┘
+                                     │
+                    ┌────────────────┴────────────────┐
+                    │      StorageEngine Trait       │
+                    ├─────────────────────────────────┤
+                    │  write_object()                 │
+                    │  read_object()                  │
+                    │  patch_object()                 │
+                    │  delete_object()                │
+                    │  delete_objects()               │
+                    │  load_objects()                 │
+                    └────────────────┬────────────────┘
+                                     │
+              ┌──────────────────────┼──────────────────────┐
+              │                      │                      │
+     ┌────────┴────────┐    ┌───────┴───────┐              │
+     │   DiskStorage   │    │  NoneStorage  │              │
+     ├─────────────────┤    ├───────────────┤              │
+     │ storage_path    │    │ (no fields)   │              │
+     │                 │    │               │              │
+     │ Arrow IPC files │    │ All ops no-op │              │
+     │ Delta files     │    │ Returns Ok()  │              │
+     └─────────────────┘    └───────────────┘              │
+                                                           │
+                                    Future: Other backends ┘
+```
+
+**Components:**
+
+### Component 1: StorageEngine Trait (`object_cache/src/storage/mod.rs`)
+
+```rust
+use async_trait::async_trait;
+use common::FlameError;
+use crate::{Object, ObjectMetadata};
+
+/// Storage backend trait for ObjectCache.
+///
+/// Implementations must be thread-safe (Send + Sync).
+/// 
+/// The storage engine is responsible for:
+/// - Persisting objects (base data + deltas)
+/// - Managing delta files internally
+/// - Loading objects with their deltas on read
+#[async_trait]
+pub trait StorageEngine: Send + Sync + 'static {
+    /// Write an object to persistent storage.
+    /// Clears any existing deltas for this key.
+    async fn write_object(&self, key: &str, object: &Object) -> Result<(), FlameError>;
+    
+    /// Read an object from persistent storage.
+    /// Returns the object with all deltas populated in `object.deltas`.
+    /// Returns None if object doesn't exist in storage.
+    async fn read_object(&self, key: &str) -> Result<Option<Object>, FlameError>;
+    
+    /// Append a delta to an existing object (PATCH operation).
+    /// Returns updated metadata including new delta count.
+    /// 
+    /// # Errors
+    /// - Returns NotFound if the base object doesn't exist
+    /// - Returns InvalidConfig if patch is not supported (e.g., none storage)
+    async fn patch_object(&self, key: &str, delta: &Object) -> Result<ObjectMetadata, FlameError>;
+    
+    /// Delete an object and all its deltas from persistent storage.
+    async fn delete_object(&self, key: &str) -> Result<(), FlameError>;
+    
+    /// Delete all objects for a session.
+    async fn delete_objects(&self, session_id: &str) -> Result<(), FlameError>;
+    
+    /// Load all objects from storage (for startup recovery).
+    /// Returns Vec of (key, object, delta_count).
+    /// Objects are returned with deltas populated.
+    async fn load_objects(&self) -> Result<Vec<(String, Object, u64)>, FlameError>;
+}
+
+pub type StorageEnginePtr = Box<dyn StorageEngine>;
+```
+
+### Component 2: DiskStorage (`object_cache/src/storage/disk.rs`)
+
+Extract existing disk I/O logic from `cache.rs`:
+
+```rust
+use std::fs;
+use std::path::{Path, PathBuf};
+use async_trait::async_trait;
+use rayon::prelude::*;
+
+use common::FlameError;
+use crate::{Object, ObjectMetadata};
+use super::StorageEngine;
+
+/// Maximum number of deltas allowed per object before requiring compaction.
+const MAX_DELTAS_PER_OBJECT: u64 = 1000;
+
+/// Disk-based storage engine using Arrow IPC format.
+pub struct DiskStorage {
+    storage_path: PathBuf,
+}
+
+impl DiskStorage {
+    pub fn new(storage_path: PathBuf) -> Result<Self, FlameError> {
+        if !storage_path.exists() {
+            tracing::info!("Creating storage directory: {:?}", storage_path);
+            fs::create_dir_all(&storage_path)?;
+        }
+        Ok(Self { storage_path })
+    }
+    
+    fn object_path(&self, key: &str) -> PathBuf {
+        self.storage_path.join(format!("{}.arrow", key))
+    }
+    
+    fn delta_dir(&self, key: &str) -> PathBuf {
+        self.storage_path.join(format!("{}.deltas", key))
+    }
+    
+    fn session_dir(&self, session_id: &str) -> PathBuf {
+        self.storage_path.join(session_id)
+    }
+    
+    /// Count the number of delta files for an object.
+    fn count_deltas(&self, key: &str) -> u64 {
+        let delta_dir = self.delta_dir(key);
+        if !delta_dir.exists() {
+            return 0;
+        }
+        
+        fs::read_dir(&delta_dir)
+            .map(|entries| {
+                entries
+                    .filter_map(|e| e.ok())
+                    .filter(|e| e.path().extension().and_then(|ext| ext.to_str()) == Some("arrow"))
+                    .count() as u64
+            })
+            .unwrap_or(0)
+    }
+    
+    /// Clear all deltas for an object.
+    fn clear_deltas(&self, key: &str) -> Result<(), FlameError> {
+        let delta_dir = self.delta_dir(key);
+        if delta_dir.exists() {
+            fs::remove_dir_all(&delta_dir)?;
+            tracing::debug!("Cleared deltas for object: {}", key);
+        }
+        Ok(())
+    }
+    
+    /// Read all deltas for an object, sorted by index.
+    fn read_deltas(&self, key: &str) -> Result<Vec<Object>, FlameError> {
+        let delta_dir = self.delta_dir(key);
+        if !delta_dir.exists() {
+            return Ok(Vec::new());
+        }
+        
+        let mut delta_files: Vec<_> = fs::read_dir(&delta_dir)?
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().extension().and_then(|ext| ext.to_str()) == Some("arrow"))
+            .collect();
+        
+        delta_files.sort_by_key(|e| {
+            e.path()
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .and_then(|s| s.parse::<u64>().ok())
+                .unwrap_or(u64::MAX)
+        });
+        
+        delta_files
+            .into_par_iter()
+            .map(|entry| load_object_from_file(&entry.path()))
+            .collect()
+    }
+}
+
+#[async_trait]
+impl StorageEngine for DiskStorage {
+    async fn write_object(&self, key: &str, object: &Object) -> Result<(), FlameError> {
+        let parts: Vec<&str> = key.split('/').collect();
+        if parts.len() != 2 {
+            return Err(FlameError::InvalidConfig(format!("Invalid key format: {}", key)));
+        }
+        let session_id = parts[0];
+        
+        // Create session directory
+        let session_dir = self.session_dir(session_id);
+        fs::create_dir_all(&session_dir)?;
+        
+        // Write object to Arrow IPC file
+        let object_path = self.object_path(key);
+        let batch = object_to_batch(object)?;
+        write_batch_to_file(&object_path, &batch)?;
+        
+        // Clear any existing deltas (clean slate)
+        self.clear_deltas(key)?;
+        
+        tracing::debug!("Wrote object to disk: {:?}", object_path);
+        Ok(())
+    }
+    
+    async fn read_object(&self, key: &str) -> Result<Option<Object>, FlameError> {
+        let object_path = self.object_path(key);
+        if !object_path.exists() {
+            return Ok(None);
+        }
+        
+        // Load base object
+        let base = load_object_from_file(&object_path)?;
+        
+        // Load deltas and return object with deltas populated
+        let deltas = self.read_deltas(key)?;
+        Ok(Some(Object::with_deltas(base.version, base.data, deltas)))
+    }
+    
+    async fn patch_object(&self, key: &str, delta: &Object) -> Result<ObjectMetadata, FlameError> {
+        let object_path = self.object_path(key);
+        if !object_path.exists() {
+            return Err(FlameError::NotFound(format!(
+                "object <{}> not found, must put first",
+                key
+            )));
+        }
+        
+        let current_delta_count = self.count_deltas(key);
+        if current_delta_count >= MAX_DELTAS_PER_OBJECT {
+            return Err(FlameError::InvalidState(format!(
+                "object <{}> has reached maximum delta count ({}). Use update_object to compact deltas.",
+                key, MAX_DELTAS_PER_OBJECT
+            )));
+        }
+        
+        // Write delta file
+        let delta_dir = self.delta_dir(key);
+        fs::create_dir_all(&delta_dir)?;
+        
+        let delta_path = delta_dir.join(format!("{}.arrow", current_delta_count));
+        let batch = object_to_batch(delta)?;
+        write_batch_to_file(&delta_path, &batch)?;
+        
+        tracing::debug!("Wrote delta {} to disk: {:?}", current_delta_count, delta_path);
+        
+        // Return updated metadata
+        let size = fs::metadata(&object_path)?.len();
+        Ok(ObjectMetadata {
+            endpoint: String::new(),  // Caller fills this in
+            key: key.to_string(),
+            version: 0,
+            size,
+            delta_count: current_delta_count + 1,
+        })
+    }
+    
+    async fn delete_object(&self, key: &str) -> Result<(), FlameError> {
+        let object_path = self.object_path(key);
+        if object_path.exists() {
+            fs::remove_file(&object_path)?;
+        }
+        self.clear_deltas(key)?;
+        Ok(())
+    }
+    
+    async fn delete_objects(&self, session_id: &str) -> Result<(), FlameError> {
+        let session_dir = self.session_dir(session_id);
+        if session_dir.exists() {
+            fs::remove_dir_all(&session_dir)?;
+            tracing::debug!("Deleted session directory: {:?}", session_dir);
+        }
+        Ok(())
+    }
+    
+    async fn load_objects(&self) -> Result<Vec<(String, Object, u64)>, FlameError> {
+        let mut results = Vec::new();
+        
+        if !self.storage_path.exists() {
+            return Ok(results);
+        }
+        
+        for session_entry in fs::read_dir(&self.storage_path)? {
+            let session_entry = session_entry?;
+            let session_path = session_entry.path();
+            
+            if !session_path.is_dir() {
+                continue;
+            }
+            
+            let session_id = session_path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .ok_or_else(|| FlameError::Internal("Invalid session directory name".to_string()))?;
+            
+            for object_entry in fs::read_dir(&session_path)? {
+                let object_entry = object_entry?;
+                let object_path = object_entry.path();
+                
+                // Skip delta directories
+                if object_path.is_dir() {
+                    continue;
+                }
+                
+                if object_path.extension().and_then(|e| e.to_str()) != Some("arrow") {
+                    continue;
+                }
+                
+                let object_id = object_path
+                    .file_stem()
+                    .and_then(|n| n.to_str())
+                    .ok_or_else(|| FlameError::Internal("Invalid object file name".to_string()))?;
+                
+                let key = format!("{}/{}", session_id, object_id);
+                let delta_count = self.count_deltas(&key);
+                
+                // Load base object
+                let base = load_object_from_file(&object_path)?;
+                
+                // Load deltas
+                let deltas = self.read_deltas(&key)?;
+                let object = Object::with_deltas(base.version, base.data, deltas);
+                
+                results.push((key, object, delta_count));
+            }
+        }
+        
+        tracing::info!("Loaded {} objects from disk", results.len());
+        Ok(results)
+    }
+}
+```
+
+### Component 3: NoneStorage (`object_cache/src/storage/none.rs`)
+
+```rust
+use async_trait::async_trait;
+use common::FlameError;
+use crate::{Object, ObjectMetadata};
+use super::StorageEngine;
+
+/// Memory-only storage engine - no persistence.
+///
+/// All storage operations are no-ops. The in-memory HashMap in ObjectCache
+/// is the sole source of truth.
+///
+/// Use cases:
+/// - Real-time processing where objects are consumed immediately
+/// - High-throughput scenarios where disk I/O is a bottleneck
+/// - Development and testing
+///
+/// Limitations:
+/// - All cached objects are lost on restart
+/// - Evicted objects cannot be recovered from disk
+/// - Patch operations are not supported (returns error)
+pub struct NoneStorage;
+
+impl NoneStorage {
+    pub fn new() -> Self {
+        tracing::info!("Using none storage engine (no persistence)");
+        Self
+    }
+}
+
+impl Default for NoneStorage {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl StorageEngine for NoneStorage {
+    async fn write_object(&self, _key: &str, _object: &Object) -> Result<(), FlameError> {
+        // No-op: object is stored in ObjectCache's in-memory HashMap
+        Ok(())
+    }
+    
+    async fn read_object(&self, _key: &str) -> Result<Option<Object>, FlameError> {
+        // Nothing persisted - object must be in memory or it's gone
+        Ok(None)
+    }
+    
+    async fn patch_object(&self, key: &str, _delta: &Object) -> Result<ObjectMetadata, FlameError> {
+        // Patch not supported with none storage
+        Err(FlameError::InvalidConfig(format!(
+            "patch operation not supported with none storage for object <{}>. Use update_object instead.",
+            key
+        )))
+    }
+    
+    async fn delete_object(&self, _key: &str) -> Result<(), FlameError> {
+        // No-op: nothing to delete from disk
+        Ok(())
+    }
+    
+    async fn delete_objects(&self, _session_id: &str) -> Result<(), FlameError> {
+        // No-op: nothing to delete from disk
+        Ok(())
+    }
+    
+    async fn load_objects(&self) -> Result<Vec<(String, Object, u64)>, FlameError> {
+        // Nothing to load
+        Ok(Vec::new())
+    }
+}
+```
+
+### Component 4: Storage Factory (`object_cache/src/storage/mod.rs`)
+
+```rust
+mod disk;
+mod none;
+
+pub use disk::DiskStorage;
+pub use none::NoneStorage;
+
+use std::path::PathBuf;
+use common::FlameError;
+
+// ... trait definition above ...
+
+/// Connect to a storage engine based on the URL scheme.
+///
+/// Supported URL schemes:
+/// - `none` - Memory-only, no persistence
+/// - `fs://` or `file://` - Filesystem storage
+/// - Plain path (legacy) - Treated as filesystem storage
+///
+/// Path resolution for `fs://`:
+/// - Triple slash (e.g., `fs:///data`) - Absolute path (`/data`)
+/// - Double slash (e.g., `fs://data`) - Relative to FLAME_HOME (`${FLAME_HOME}/data`)
+///
+/// # Examples
+///
+/// ```ignore
+/// // Memory-only storage
+/// let storage = connect("none").await?;
+///
+/// // Filesystem storage (absolute path)
+/// let storage = connect("fs:///var/lib/flame/cache").await?;
+///
+/// // Filesystem storage (relative to FLAME_HOME)
+/// let storage = connect("fs://cache").await?;  // -> ${FLAME_HOME}/cache
+///
+/// // Legacy plain path (still supported)
+/// let storage = connect("/var/lib/flame/cache").await?;
+/// ```
+pub async fn connect(url: &str) -> Result<StorageEnginePtr, FlameError> {
+    // Check environment variable override
+    let url = std::env::var("FLAME_CACHE_STORAGE")
+        .ok()
+        .unwrap_or_else(|| url.to_string());
+    
+    if url.is_empty() {
+        tracing::warn!("No cache storage configured - using none storage (no persistence)");
+        return Ok(Box::new(NoneStorage::new()));
+    }
+    
+    if url == "none" {
+        tracing::info!("Cache storage: none (memory-only, no persistence)");
+        return Ok(Box::new(NoneStorage::new()));
+    }
+    
+    // Parse filesystem URL or plain path
+    let storage_path = if url.starts_with("fs://") || url.starts_with("file://") {
+        parse_storage_url(&url)?
+    } else {
+        // Legacy plain path support
+        PathBuf::from(&url)
+    };
+    
+    tracing::info!("Cache storage: filesystem at {:?}", storage_path);
+    Ok(Box::new(DiskStorage::new(storage_path)?))
+}
+
+/// Parse storage URL and resolve path.
+fn parse_storage_url(url: &str) -> Result<PathBuf, FlameError> {
+    let path_part = url
+        .strip_prefix("fs://")
+        .or_else(|| url.strip_prefix("file://"))
+        .ok_or_else(|| FlameError::InvalidConfig(format!("Invalid storage URL: {}", url)))?;
+    
+    if path_part.starts_with('/') {
+        // Absolute path (triple slash: fs:///path -> /path)
+        Ok(PathBuf::from(path_part))
+    } else {
+        // Relative to FLAME_HOME (double slash: fs://path -> ${FLAME_HOME}/path)
+        let flame_home = std::env::var("FLAME_HOME")
+            .unwrap_or_else(|_| "/var/lib/flame".to_string());
+        Ok(PathBuf::from(flame_home).join(path_part))
+    }
+}
+```
+
+### Component 5: ObjectCache Refactoring
+
+Update `ObjectCache` struct in `cache.rs`:
+
+```rust
+pub struct ObjectCache {
+    endpoint: CacheEndpoint,
+    storage: StorageEnginePtr,  // Changed from: storage_path: Option<PathBuf>
+    objects: MutexPtr<HashMap<String, Object>>,
+    metadata: MutexPtr<HashMap<String, ObjectMetadata>>,
+    eviction_policy: EvictionPolicyPtr,
+}
+```
+
+Key method changes:
+
+```rust
+impl ObjectCache {
+    fn new(
+        endpoint: CacheEndpoint,
+        storage: StorageEnginePtr,
+        eviction_config: Option<&EvictionConfig>,
+    ) -> Result<Self, FlameError> {
+        // ... initialization
+    }
+    
+    async fn put_with_id(...) -> Result<ObjectMetadata, FlameError> {
+        // ...
+        // Write to storage (no-op for NoneStorage)
+        // This also clears any existing deltas
+        self.storage.write_object(&key, &object).await?;
+        // ...
+    }
+    
+    async fn get(&self, key: String) -> Result<Object, FlameError> {
+        // Check memory first
+        // ...
+        
+        // Try to load from storage (returns None for NoneStorage)
+        // Storage returns object with deltas already populated
+        if let Some(object) = self.storage.read_object(&key).await? {
+            // Add to memory, return
+        }
+        
+        Err(FlameError::NotFound(...))
+    }
+    
+    async fn patch(&self, key: String, delta: Object) -> Result<ObjectMetadata, FlameError> {
+        // Delegate to storage engine (returns error for NoneStorage)
+        let mut meta = self.storage.patch_object(&key, &delta).await?;
+        meta.endpoint = self.endpoint.to_uri();
+        
+        // Update metadata in memory
+        {
+            let mut metadata = lock_ptr!(self.metadata)?;
+            metadata.insert(key.clone(), meta.clone());
+        }
+        
+        Ok(meta)
+    }
+    
+    async fn load_from_storage(&self) -> Result<(), FlameError> {
+        let items = self.storage.load_objects().await?;
+        // Objects come with deltas already populated
+        // ... populate objects and metadata from items
+    }
+}
+```
+
+### Component 6: Cache Server Startup
+
+Update `run()` function in `cache.rs`:
+
+```rust
+pub async fn run(cache_config: &FlameCache) -> Result<(), FlameError> {
+    let endpoint = CacheEndpoint::try_from(cache_config)?;
+    
+    // Connect to storage engine based on URL
+    let storage_url = cache_config.storage.as_deref().unwrap_or("none");
+    let storage = storage::connect(storage_url).await?;
+    
+    // Create eviction config
+    let eviction_config = EvictionConfig { ... };
+    
+    // Create cache with storage engine
+    let cache = Arc::new(ObjectCache::new(endpoint, storage, Some(&eviction_config))?);
+    
+    // Load existing objects from storage (no-op for NoneStorage)
+    cache.load_from_storage().await?;
+    
+    // Start server...
+}
+```
+
+No changes needed to `common/src/ctx.rs` - the existing `storage: Option<String>` field is reused with URL-style values.
+
+**Data Structures:**
+
+No new public data structures. Internal storage engine implementations are encapsulated behind the trait.
+
+**Algorithms:**
+
+*Object Put with Storage Engine:*
+```
+1. Validate session_id and object_id
+2. Call storage.write_object(key, object)
+   - DiskStorage: Write Arrow IPC file, clear existing deltas
+   - NoneStorage: No-op
+3. Update in-memory objects and metadata HashMaps
+4. Track in eviction policy
+5. Run eviction if needed
+```
+
+*Object Get with Storage Engine:*
+```
+1. Check in-memory objects HashMap
+2. If found, return (deltas already in object.deltas)
+3. If not found, call storage.read_object(key)
+   - DiskStorage: Load from Arrow IPC file with deltas populated
+   - NoneStorage: Returns None
+4. If loaded from storage, add to memory and return
+5. If not found anywhere, return NotFound error
+```
+
+*Patch Operation:*
+```
+1. Call storage.patch_object(key, delta)
+   - DiskStorage: Write delta file, return updated metadata
+   - NoneStorage: Return InvalidConfig error
+2. Update metadata in memory
+```
+
+**Sequence Diagram - Object Put:**
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant OC as ObjectCache
+    participant STG as StorageEngine
+    participant MEM as In-Memory HashMap
+
+    C->>OC: do_put(session_id, data)
+    OC->>OC: Generate key
+    OC->>STG: write_object(key, object)
+    
+    alt DiskStorage
+        STG->>STG: Write Arrow IPC file
+        STG->>STG: Clear existing deltas
+    else NoneStorage
+        STG->>STG: No-op
+    end
+    
+    STG-->>OC: Ok(())
+    OC->>MEM: Insert object
+    OC->>OC: Track in eviction policy
+    OC-->>C: ObjectMetadata
+```
+
+**System Considerations:**
+
+*Performance:*
+- NoneStorage: ~0ms disk latency, pure memory operations
+- DiskStorage: Unchanged from current implementation
+- Expected improvement: 2-5x for write-heavy workloads with NoneStorage
+
+*Scalability:*
+- Memory-only storage scales with available RAM
+- Eviction policy controls memory usage
+- No disk I/O bottleneck with NoneStorage
+
+*Reliability:*
+- NoneStorage: Data is ephemeral by design - no recovery after restart
+- DiskStorage: Unchanged durability guarantees
+- Eviction with NoneStorage permanently loses objects
+
+*Thread Safety:*
+- `StorageEngine` implementations must be `Send + Sync`
+- Existing locking patterns in ObjectCache preserved
+- DiskStorage uses synchronous fs operations (safe with Tokio spawn_blocking if needed)
+
+*Resource Usage:*
+- Memory: Bounded by eviction policy (unchanged)
+- CPU: Reduced for NoneStorage (no serialization for disk)
+- Disk: None for NoneStorage
+
+*Security:*
+- No change to security model
+- NoneStorage: No disk artifacts left behind
+
+*Observability:*
+- Log storage engine type on startup
+- Existing metrics unchanged
+
+**Dependencies:**
+
+*Internal Dependencies:*
+- `common`: FlameError, FlameCache config
+- `stdng`: MutexPtr, lock_ptr macro (existing)
+
+*External Dependencies:*
+- `arrow`, `arrow-flight`: Unchanged (DiskStorage only)
+- `async-trait`: For async trait methods
+
+## 4. Use Cases
+
+**Example 1: High-Throughput Compute Workload**
+
+- Description: ML inference pipeline where intermediate tensors are cached briefly
+- Configuration:
+  ```yaml
+  cache:
+    endpoint: "grpc://127.0.0.1:9090"
+    network_interface: "eth0"
+    storage: "none"
+    eviction:
+      policy: "lru"
+      max_memory: "4G"
+  ```
+- Workflow:
+  1. Start Flame with none storage
+  2. Inference tasks put/get intermediate tensors at high throughput
+  3. No disk I/O overhead - pure memory operations
+  4. Evicted objects are gone (acceptable for ephemeral intermediates)
+  5. Restart clears cache (workers repopulate as needed)
+- Expected outcome: Maximum throughput, bounded memory, ephemeral cache
+
+**Example 2: Development and Testing**
+
+- Description: Fast iteration during development
+- Configuration:
+  ```yaml
+  cache:
+    endpoint: "grpc://127.0.0.1:9090"
+    network_interface: "lo"
+    storage: "none"
+    eviction:
+      policy: "none"
+      max_memory: "512M"
+  ```
+- Workflow:
+  1. Developer runs local Flame cluster
+  2. No disk writes during testing
+  3. Each test run starts with clean cache
+- Expected outcome: Fast startup, no disk cleanup needed
+
+**Example 3: Backward Compatibility (Legacy Path)**
+
+- Description: Existing deployment with plain path continues unchanged
+- Configuration:
+  ```yaml
+  cache:
+    endpoint: "grpc://127.0.0.1:9090"
+    network_interface: "eth0"
+    storage: "/var/lib/flame/cache"    # Legacy plain path still works
+    eviction:
+      policy: "lru"
+      max_memory: "1G"
+  ```
+- Workflow:
+  1. Upgrade to new version
+  2. No config changes needed
+  3. Disk persistence continues as before
+- Expected outcome: Zero behavior change
+
+**Example 4: Explicit Filesystem Storage (URL Style)**
+
+- Description: New deployment using URL-style configuration
+- Configuration:
+  ```yaml
+  cache:
+    endpoint: "grpc://127.0.0.1:9090"
+    network_interface: "eth0"
+    storage: "fs:///var/lib/flame/cache"   # Explicit filesystem URL
+    eviction:
+      policy: "lru"
+      max_memory: "2G"
+  ```
+- Workflow:
+  1. Objects persist to disk at specified path
+  2. Survives restarts
+  3. Evicted objects can be reloaded from disk
+- Expected outcome: Durable cache with recovery
+
+**Example 5: FLAME_HOME Relative Path**
+
+- Description: Storage path relative to FLAME_HOME
+- Configuration:
+  ```yaml
+  cache:
+    endpoint: "grpc://127.0.0.1:9090"
+    network_interface: "eth0"
+    storage: "fs://cache"              # Relative to FLAME_HOME
+    eviction:
+      policy: "lru"
+      max_memory: "1G"
+  ```
+- Environment: `FLAME_HOME=/opt/flame`
+- Workflow:
+  1. Storage path resolves to `/opt/flame/cache`
+  2. Portable configuration across environments
+- Expected outcome: Environment-aware storage location
+
+## 5. References
+
+**Related Documents:**
+- RFE394 None Storage for Session Manager: `docs/designs/RFE394-none-storage/FS.md`
+- RFE318 Object Cache: `docs/designs/RFE318-cache/FS.md`
+- RFE366 LRU Eviction Policy: `docs/designs/RFE366-lru-policy/FS.md`
+- Design Template: `docs/designs/templates.md`
+
+**External References:**
+- GitHub Issue: https://github.com/xflops/flame/issues/414
+- Apache Arrow IPC Format: https://arrow.apache.org/docs/format/Columnar.html#ipc-file-format
+
+**Implementation References:**
+- ObjectCache: `object_cache/src/cache.rs`
+- Eviction Policy: `object_cache/src/eviction.rs`
+- Session Manager Storage Engine: `session_manager/src/storage/engine/`
+- Configuration: `common/src/ctx.rs`

--- a/object_cache/Cargo.toml
+++ b/object_cache/Cargo.toml
@@ -37,3 +37,7 @@ bson = "2"
 clap = { workspace = true }
 
 rayon = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3"
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/object_cache/src/cache.rs
+++ b/object_cache/src/cache.rs
@@ -12,8 +12,6 @@ limitations under the License.
 */
 
 use std::collections::HashMap;
-use std::fs;
-use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::sync::Arc;
 
@@ -23,7 +21,7 @@ use arrow::datatypes::{DataType, Field, Schema};
 use arrow::ipc::writer::{
     CompressionContext, DictionaryTracker, IpcDataGenerator, IpcWriteOptions,
 };
-use arrow::ipc::{reader::FileReader, writer::FileWriter, CompressionType};
+use arrow::ipc::CompressionType;
 use arrow_flight::{
     flight_service_server::{FlightService, FlightServiceServer},
     Action, ActionType, Criteria, Empty, FlightData, FlightDescriptor, FlightEndpoint, FlightInfo,
@@ -46,12 +44,6 @@ use common::ctx::FlameCache;
 use common::FlameError;
 
 use crate::eviction::{new_policy, EvictionConfig, EvictionPolicyPtr};
-
-/// Maximum number of deltas allowed per object before requiring compaction.
-/// This prevents unbounded growth of delta files.
-/// When this limit is reached, patch operations will return an error suggesting
-/// the client should use update_object to compact the deltas.
-const MAX_DELTAS_PER_OBJECT: u64 = 1000;
 
 /// Default batch size for eviction operations
 const EVICTION_BATCH_SIZE: usize = 10;
@@ -219,37 +211,50 @@ impl TryFrom<&String> for CacheEndpoint {
 
 pub struct ObjectCache {
     endpoint: CacheEndpoint,
-    storage_path: Option<PathBuf>,
-    /// In-memory object storage (key present = in memory)
+    storage: crate::storage::StorageEnginePtr,
     objects: MutexPtr<HashMap<String, Object>>,
-    /// Object metadata index (always in memory, tracks all objects)
     metadata: MutexPtr<HashMap<String, ObjectMetadata>>,
-    /// Eviction policy
     eviction_policy: EvictionPolicyPtr,
 }
 
 impl ObjectCache {
     fn new(
         endpoint: CacheEndpoint,
-        storage_path: Option<PathBuf>,
+        storage: crate::storage::StorageEnginePtr,
         eviction_config: Option<&EvictionConfig>,
     ) -> Result<Self, FlameError> {
         let eviction_policy = new_policy(eviction_config);
 
-        let cache = Self {
+        Ok(Self {
             endpoint,
-            storage_path: storage_path.clone(),
+            storage,
             objects: new_ptr(HashMap::new()),
             metadata: new_ptr(HashMap::new()),
             eviction_policy,
-        };
+        })
+    }
 
-        // Load existing objects from disk
-        if let Some(storage_path) = &storage_path {
-            cache.load_from_disk(storage_path)?;
+    async fn load_from_storage(&self) -> Result<(), FlameError> {
+        let items = self.storage.load_objects().await?;
+
+        let mut objects = lock_ptr!(self.objects)?;
+        let mut metadata = lock_ptr!(self.metadata)?;
+
+        for (key, object, delta_count) in items {
+            let size = object.data.len() as u64;
+            let meta = self.create_metadata(key.clone(), size, delta_count);
+
+            objects.insert(key.clone(), object);
+            metadata.insert(key.clone(), meta);
+
+            self.eviction_policy.on_add(&key, size);
         }
 
-        Ok(cache)
+        drop(objects);
+        drop(metadata);
+        self.run_eviction()?;
+
+        Ok(())
     }
 
     fn create_metadata(&self, key: String, size: u64, delta_count: u64) -> ObjectMetadata {
@@ -262,129 +267,6 @@ impl ObjectCache {
         }
     }
 
-    /// Get the delta directory path for an object
-    fn get_delta_dir(&self, key: &str) -> Option<PathBuf> {
-        self.storage_path
-            .as_ref()
-            .map(|p| p.join(format!("{}.deltas", key)))
-    }
-
-    /// Count the number of delta files for an object.
-    /// Returns 0 if the delta directory doesn't exist or is empty.
-    fn count_deltas(&self, key: &str) -> u64 {
-        let delta_dir = match self.get_delta_dir(key) {
-            Some(dir) => dir,
-            None => return 0,
-        };
-
-        if !delta_dir.exists() {
-            return 0;
-        }
-
-        match fs::read_dir(&delta_dir) {
-            Ok(entries) => entries
-                .filter_map(|e| e.ok())
-                .filter(|e| e.path().extension().and_then(|ext| ext.to_str()) == Some("arrow"))
-                .count() as u64,
-            Err(e) => {
-                tracing::warn!("Failed to read delta directory {:?}: {}", delta_dir, e);
-                0
-            }
-        }
-    }
-
-    /// Delete all deltas for an object
-    fn clear_deltas(&self, key: &str) -> Result<(), FlameError> {
-        if let Some(delta_dir) = self.get_delta_dir(key) {
-            if delta_dir.exists() {
-                fs::remove_dir_all(&delta_dir)?;
-                tracing::debug!("Cleared deltas for object: {}", key);
-            }
-        }
-        Ok(())
-    }
-
-    fn load_session_objects(
-        &self,
-        session_path: &Path,
-        objects: &mut HashMap<String, Object>,
-        metadata_map: &mut HashMap<String, ObjectMetadata>,
-    ) -> Result<(), FlameError> {
-        let session_id = session_path
-            .file_name()
-            .and_then(|n| n.to_str())
-            .ok_or_else(|| FlameError::Internal("Invalid session directory name".to_string()))?;
-
-        for object_entry in fs::read_dir(session_path)? {
-            let object_entry = object_entry?;
-            let object_path = object_entry.path();
-
-            // Skip delta directories
-            if object_path.is_dir() {
-                continue;
-            }
-
-            if object_path.extension().and_then(|e| e.to_str()) != Some("arrow") {
-                continue;
-            }
-
-            let object_id = object_path
-                .file_stem()
-                .and_then(|n| n.to_str())
-                .ok_or_else(|| FlameError::Internal("Invalid object file name".to_string()))?;
-
-            let key = format!("{}/{}", session_id, object_id);
-            let size = fs::metadata(&object_path)?.len();
-            let delta_count = self.count_deltas(&key);
-
-            // Load object into memory
-            let object = self.load_object_from_disk_internal(&object_path)?;
-            let meta = self.create_metadata(key.clone(), size, delta_count);
-
-            tracing::debug!("Loaded object: {} (deltas: {})", key, delta_count);
-            objects.insert(key.clone(), object);
-            metadata_map.insert(key.clone(), meta);
-
-            // Track in eviction policy
-            self.eviction_policy.on_add(&key, size);
-        }
-
-        Ok(())
-    }
-
-    fn load_from_disk(&self, storage_path: &Path) -> Result<(), FlameError> {
-        if !storage_path.exists() {
-            tracing::info!("Creating storage directory: {:?}", storage_path);
-            fs::create_dir_all(storage_path)?;
-            return Ok(());
-        }
-
-        tracing::info!("Loading objects from disk: {:?}", storage_path);
-        let mut objects = lock_ptr!(self.objects)?;
-        let mut metadata = lock_ptr!(self.metadata)?;
-
-        for session_entry in fs::read_dir(storage_path)? {
-            let session_entry = session_entry?;
-            let session_path = session_entry.path();
-
-            if !session_path.is_dir() {
-                continue;
-            }
-
-            self.load_session_objects(&session_path, &mut objects, &mut metadata)?;
-        }
-
-        tracing::info!("Loaded {} objects from disk", objects.len());
-
-        // Run eviction if needed after loading
-        drop(objects);
-        drop(metadata);
-        self.run_eviction()?;
-
-        Ok(())
-    }
-
-    /// Run eviction if needed, removing least recently used objects from memory.
     fn run_eviction(&self) -> Result<(), FlameError> {
         loop {
             let keys_to_evict = self.eviction_policy.victims(EVICTION_BATCH_SIZE);
@@ -395,7 +277,6 @@ impl ObjectCache {
             let mut objects = lock_ptr!(self.objects)?;
             for key in keys_to_evict {
                 if objects.contains_key(&key) {
-                    // Remove from in-memory storage (metadata is kept)
                     objects.remove(&key);
                     self.eviction_policy.on_evict(&key);
                     tracing::debug!("Evicted object from memory: {}", key);
@@ -403,28 +284,6 @@ impl ObjectCache {
             }
         }
         Ok(())
-    }
-
-    fn load_object_from_disk_internal(&self, object_path: &Path) -> Result<Object, FlameError> {
-        let file = fs::File::open(object_path)
-            .map_err(|e| FlameError::NotFound(format!("Object file not found: {}", e)))?;
-        let reader = FileReader::try_new(file, None)
-            .map_err(|e| FlameError::Internal(format!("Failed to create reader: {}", e)))?;
-
-        // SAFETY: Skip validation for trusted cache data (3-9x faster reads).
-        // This is safe because all data in the cache was written by this service.
-        let reader = unsafe { reader.with_skip_validation(true) };
-
-        let batch = reader
-            .into_iter()
-            .next()
-            .ok_or_else(|| FlameError::Internal("No batches in file".to_string()))?
-            .map_err(|e| FlameError::Internal(format!("Failed to read batch: {}", e)))?;
-
-        let object = batch_to_object(&batch)
-            .map_err(|e| FlameError::Internal(format!("Failed to parse batch: {}", e)))?;
-
-        Ok(object)
     }
 
     async fn put(
@@ -448,27 +307,10 @@ impl ObjectCache {
         let key = format!("{}/{}", session_id, object_id);
         let size = object.data.len() as u64;
 
-        // Write to disk if storage is configured
-        if let Some(storage_path) = &self.storage_path {
-            // Create session directory
-            let session_dir = storage_path.join(&session_id);
-            fs::create_dir_all(&session_dir)?;
-
-            // Write object to Arrow IPC file
-            let object_path = session_dir.join(format!("{}.arrow", object_id));
-            let batch = object_to_batch(&object)
-                .map_err(|e| FlameError::Internal(format!("Failed to create batch: {}", e)))?;
-
-            write_batch_to_file(&object_path, &batch)?;
-            tracing::debug!("Wrote object to disk: {:?}", object_path);
-
-            // Clear any existing deltas (clean slate per HLD)
-            self.clear_deltas(&key)?;
-        }
+        self.storage.write_object(&key, &object).await?;
 
         let meta = self.create_metadata(key.clone(), size, 0);
 
-        // Update in-memory storage
         {
             let mut objects = lock_ptr!(self.objects)?;
             let mut metadata = lock_ptr!(self.metadata)?;
@@ -477,7 +319,6 @@ impl ObjectCache {
             metadata.insert(key.clone(), meta.clone());
         }
 
-        // Track in eviction policy and run eviction if needed
         self.eviction_policy.on_add(&key, size);
         self.run_eviction()?;
 
@@ -486,175 +327,38 @@ impl ObjectCache {
         Ok(meta)
     }
 
-    fn load_object_from_disk(&self, key: &str) -> Result<Object, FlameError> {
-        validate_key(key)?;
-
-        let storage_path = self
-            .storage_path
-            .as_ref()
-            .ok_or_else(|| FlameError::InvalidConfig("Storage path not configured".to_string()))?;
-
-        let object_path = storage_path.join(format!("{}.arrow", key));
-        self.load_object_from_disk_internal(&object_path)
-    }
-
-    fn load_deltas_from_disk(&self, key: &str) -> Result<Vec<Object>, FlameError> {
-        use rayon::prelude::*;
-
-        let delta_dir = match self.get_delta_dir(key) {
-            Some(dir) if dir.exists() => dir,
-            _ => return Ok(Vec::new()),
-        };
-
-        let entries = match fs::read_dir(&delta_dir) {
-            Ok(entries) => entries,
-            Err(e) => {
-                tracing::warn!("Failed to read delta directory {:?}: {}", delta_dir, e);
-                return Ok(Vec::new());
-            }
-        };
-
-        let mut delta_files: Vec<_> = entries
-            .filter_map(|e| e.ok())
-            .filter(|e| e.path().extension().and_then(|ext| ext.to_str()) == Some("arrow"))
-            .collect();
-
-        delta_files.sort_by_key(|e| {
-            e.path()
-                .file_stem()
-                .and_then(|s| s.to_str())
-                .and_then(|s| s.parse::<u64>().ok())
-                .unwrap_or(u64::MAX)
-        });
-
-        let deltas: Result<Vec<Object>, FlameError> = delta_files
-            .into_par_iter()
-            .map(|entry| {
-                let path = entry.path();
-                let file = fs::File::open(&path).map_err(|e| {
-                    FlameError::Internal(format!("Failed to open delta file {:?}: {}", path, e))
-                })?;
-                let reader = FileReader::try_new(file, None).map_err(|e| {
-                    FlameError::Internal(format!("Failed to create reader for {:?}: {}", path, e))
-                })?;
-                // SAFETY: Skip validation for trusted cache data written by this service.
-                let reader = unsafe { reader.with_skip_validation(true) };
-
-                let batch = reader
-                    .into_iter()
-                    .next()
-                    .ok_or_else(|| {
-                        FlameError::Internal(format!("No batches in delta file {:?}", path))
-                    })?
-                    .map_err(|e| {
-                        FlameError::Internal(format!(
-                            "Failed to read delta batch from {:?}: {}",
-                            path, e
-                        ))
-                    })?;
-
-                batch_to_object(&batch).map_err(|e| {
-                    FlameError::Internal(format!("Failed to parse delta from {:?}: {}", path, e))
-                })
-            })
-            .collect();
-
-        deltas
-    }
-
-    fn try_load_and_index(&self, key: &str) -> Result<Option<Object>, FlameError> {
-        validate_key(key)?;
-
-        let storage_path = match &self.storage_path {
-            Some(path) => path,
-            None => return Ok(None),
-        };
-
-        let object_path = storage_path.join(format!("{}.arrow", key));
-        if !object_path.exists() {
-            return Ok(None);
-        }
-
-        let object = self.load_object_from_disk_internal(&object_path)?;
-        let size = object.data.len() as u64;
-        let delta_count = self.count_deltas(key);
-
-        // Add to in-memory storage
-        {
-            let mut objects = lock_ptr!(self.objects)?;
-            let mut metadata = lock_ptr!(self.metadata)?;
-
-            objects.insert(key.to_string(), object.clone());
-
-            let meta = self.create_metadata(key.to_string(), size, delta_count);
-            metadata.insert(key.to_string(), meta);
-        }
-
-        // Track in eviction policy
-        self.eviction_policy.on_add(key, size);
-        self.run_eviction()?;
-
-        tracing::debug!("Loaded object from disk: {} (deltas: {})", key, delta_count);
-        Ok(Some(object))
-    }
-
-    /// Get an object with all its deltas populated in the deltas field.
-    /// Creates a new Object with deltas rather than mutating an existing one.
     async fn get(&self, key: String) -> Result<Object, FlameError> {
         validate_key(&key)?;
 
         self.eviction_policy.on_access(&key);
 
-        // Check if object is in memory
         {
             let objects = lock_ptr!(self.objects)?;
             if let Some(object) = objects.get(&key) {
                 tracing::debug!("Object get from memory: {}", key);
-                // Load deltas and return object with deltas
-                let deltas = self.load_deltas_from_disk(&key)?;
-                return Ok(Object::with_deltas(
-                    object.version,
-                    object.data.clone(),
-                    deltas,
-                ));
+                return Ok(object.clone());
             }
         }
 
-        // Check if object exists in metadata (on disk but not in memory)
-        let exists_in_metadata = {
-            let metadata = lock_ptr!(self.metadata)?;
-            metadata.contains_key(&key)
-        };
-
-        if exists_in_metadata {
-            // Object is on disk, reload into memory
-            let object = self.load_object_from_disk(&key)?;
+        if let Some(object) = self.storage.read_object(&key).await? {
             let size = object.data.len() as u64;
+            let delta_count = object.deltas.len() as u64;
 
-            // Add back to memory
             {
                 let mut objects = lock_ptr!(self.objects)?;
+                let mut metadata = lock_ptr!(self.metadata)?;
+
                 objects.insert(key.clone(), object.clone());
+
+                let meta = self.create_metadata(key.clone(), size, delta_count);
+                metadata.insert(key.clone(), meta);
             }
 
-            // Track in eviction policy and run eviction
             self.eviction_policy.on_add(&key, size);
             self.run_eviction()?;
 
-            // Load deltas and return
-            let deltas = self.load_deltas_from_disk(&key)?;
-            tracing::debug!(
-                "Object reloaded from disk: {} (deltas: {})",
-                key,
-                deltas.len()
-            );
-            return Ok(Object::with_deltas(object.version, object.data, deltas));
-        }
-
-        // Try to load from disk (not in index)
-        if let Some(base) = self.try_load_and_index(&key)? {
-            let deltas = self.load_deltas_from_disk(&key)?;
-            return Ok(Object::with_deltas(base.version, base.data, deltas));
+            tracing::debug!("Object loaded from storage: {}", key);
+            return Ok(object);
         }
 
         Err(FlameError::NotFound(format!("object <{}> not found", key)))
@@ -663,32 +367,12 @@ impl ObjectCache {
     async fn update(&self, key: String, new_object: Object) -> Result<ObjectMetadata, FlameError> {
         validate_key(&key)?;
 
-        let parts: Vec<&str> = key.split('/').collect();
-        if parts.len() != 2 {
-            return Err(FlameError::InvalidConfig(format!(
-                "Invalid key format: {}",
-                key
-            )));
-        }
-
         let size = new_object.data.len() as u64;
 
-        // Write to disk if storage is configured
-        if let Some(storage_path) = &self.storage_path {
-            let object_path = storage_path.join(format!("{}.arrow", key));
-            let batch = object_to_batch(&new_object)
-                .map_err(|e| FlameError::Internal(format!("Failed to create batch: {}", e)))?;
-
-            write_batch_to_file(&object_path, &batch)?;
-            tracing::debug!("Updated object on disk: {:?}", object_path);
-
-            // Clear all deltas per HLD
-            self.clear_deltas(&key)?;
-        }
+        self.storage.write_object(&key, &new_object).await?;
 
         let meta = self.create_metadata(key.clone(), size, 0);
 
-        // Update in-memory storage
         {
             let mut objects = lock_ptr!(self.objects)?;
             let mut metadata = lock_ptr!(self.metadata)?;
@@ -697,7 +381,6 @@ impl ObjectCache {
             metadata.insert(key.clone(), meta.clone());
         }
 
-        // Track in eviction policy
         self.eviction_policy.on_add(&key, size);
         self.run_eviction()?;
 
@@ -706,85 +389,29 @@ impl ObjectCache {
         Ok(meta)
     }
 
-    /// Append a delta to an existing object (PATCH operation).
-    ///
-    /// # Errors
-    /// - Returns NotFound if the base object doesn't exist
-    /// - Returns InvalidConfig if storage path is not configured
-    /// - Returns InvalidState if delta count exceeds MAX_DELTAS_PER_OBJECT
     async fn patch(&self, key: String, delta: Object) -> Result<ObjectMetadata, FlameError> {
         validate_key(&key)?;
 
         self.eviction_policy.on_access(&key);
 
-        let storage_path = self
-            .storage_path
-            .as_ref()
-            .ok_or_else(|| FlameError::InvalidConfig("Storage path not configured".to_string()))?;
+        let mut meta = self.storage.patch_object(&key, &delta).await?;
+        meta.endpoint = self.endpoint.to_uri();
 
-        // Reserve the next delta index atomically under the lock
-        let next_index = {
+        {
             let mut metadata = lock_ptr!(self.metadata)?;
-            let current_delta_count = match metadata.get(&key) {
-                Some(meta) => meta.delta_count,
-                None => {
-                    drop(metadata);
-                    if self.try_load_and_index(&key)?.is_none() {
-                        return Err(FlameError::NotFound(format!(
-                            "object <{}> not found, must put first",
-                            key
-                        )));
-                    }
-                    metadata = lock_ptr!(self.metadata)?;
-                    metadata.get(&key).map(|m| m.delta_count).unwrap_or(0)
-                }
-            };
-
-            if current_delta_count >= MAX_DELTAS_PER_OBJECT {
-                return Err(FlameError::InvalidState(format!(
-                    "object <{}> has reached maximum delta count ({}). Use update_object to compact deltas.",
-                    key, MAX_DELTAS_PER_OBJECT
-                )));
-            }
-
-            // Reserve the index by incrementing delta_count now
-            if let Some(meta) = metadata.get_mut(&key) {
-                meta.delta_count = current_delta_count + 1;
-            }
-            current_delta_count
-        };
-
-        // Write delta file outside the lock (I/O can be slow)
-        let delta_dir = storage_path.join(format!("{}.deltas", key));
-        fs::create_dir_all(&delta_dir)?;
-
-        let delta_path = delta_dir.join(format!("{}.arrow", next_index));
-        let batch = object_to_batch(&delta)
-            .map_err(|e| FlameError::Internal(format!("Failed to create delta batch: {}", e)))?;
-
-        if let Err(e) = write_batch_to_file(&delta_path, &batch) {
-            // Rollback: decrement delta_count on write failure
-            let mut metadata = lock_ptr!(self.metadata)?;
-            if let Some(meta) = metadata.get_mut(&key) {
-                meta.delta_count = meta.delta_count.saturating_sub(1);
-            }
-            return Err(e);
+            metadata.insert(key.clone(), meta.clone());
         }
 
-        tracing::debug!("Wrote delta {} to disk: {:?}", next_index, delta_path);
+        // Invalidate in-memory cache to force reload with new delta on next access
+        {
+            let mut objects = lock_ptr!(self.objects)?;
+            if objects.remove(&key).is_some() {
+                self.eviction_policy.on_remove(&key);
+            }
+        }
 
-        let metadata = lock_ptr!(self.metadata)?;
-        let updated = metadata
-            .get(&key)
-            .cloned()
-            .ok_or_else(|| FlameError::Internal("Failed to get metadata".to_string()))?;
-
-        tracing::debug!(
-            "Object patch: {} (delta_count: {})",
-            key,
-            updated.delta_count
-        );
-        Ok(updated)
+        tracing::debug!("Object patch: {} (delta_count: {})", key, meta.delta_count);
+        Ok(meta)
     }
 
     async fn delete(&self, session_id: SessionID) -> Result<(), FlameError> {
@@ -801,18 +428,9 @@ impl ObjectCache {
 
         for key in &keys_to_remove {
             self.eviction_policy.on_remove(key);
-            // Also clear deltas for each object
-            self.clear_deltas(key)?;
         }
 
-        // Delete session directory and all objects (including deltas)
-        if let Some(storage_path) = &self.storage_path {
-            let session_dir = storage_path.join(&session_id);
-            if session_dir.exists() {
-                fs::remove_dir_all(&session_dir)?;
-                tracing::debug!("Deleted session directory: {:?}", session_dir);
-            }
-        }
+        self.storage.delete_objects(&session_id).await?;
 
         {
             let mut objects = lock_ptr!(self.objects)?;
@@ -1043,22 +661,6 @@ fn get_object_schema() -> Schema {
         Field::new("version", DataType::UInt64, false),
         Field::new("data", DataType::Binary, false),
     ])
-}
-
-fn write_batch_to_file(path: &Path, batch: &RecordBatch) -> Result<(), FlameError> {
-    let file = fs::File::create(path)?;
-    let options = IpcWriteOptions::default()
-        .try_with_compression(Some(CompressionType::ZSTD))
-        .map_err(|e| FlameError::Internal(format!("Failed to set compression: {}", e)))?;
-    let mut writer = FileWriter::try_new_with_options(file, &batch.schema(), options)
-        .map_err(|e| FlameError::Internal(format!("Failed to create writer: {}", e)))?;
-    writer
-        .write(batch)
-        .map_err(|e| FlameError::Internal(format!("Failed to write batch: {}", e)))?;
-    writer
-        .finish()
-        .map_err(|e| FlameError::Internal(format!("Failed to finish writer: {}", e)))?;
-    Ok(())
 }
 
 // Helper function to create a RecordBatch from object data
@@ -1419,23 +1021,9 @@ pub async fn run(cache_config: &FlameCache) -> Result<(), FlameError> {
     let endpoint = CacheEndpoint::try_from(cache_config)?;
     let address_str = format!("{}:{}", endpoint.host, endpoint.port);
 
-    // Get storage path from config or environment variable
-    let storage_path = if let Some(ref path) = cache_config.storage {
-        Some(PathBuf::from(path))
-    } else if let Ok(path) = std::env::var("FLAME_CACHE_STORAGE") {
-        Some(PathBuf::from(path))
-    } else {
-        None
-    };
+    let storage_url = cache_config.storage.as_deref().unwrap_or("none");
+    let storage = crate::storage::connect(storage_url).await?;
 
-    if let Some(ref path) = storage_path {
-        tracing::info!("Using storage path: {:?}", path);
-    } else {
-        tracing::warn!("No storage path configured - cache will not persist");
-    }
-
-    // Create eviction config from FlameCache.eviction
-    // Environment variables can still override config values (handled in new_policy)
     let eviction_config = EvictionConfig {
         policy: Some(cache_config.eviction.policy.clone()),
         max_memory: Some(ByteSize::b(cache_config.eviction.max_memory).to_string()),
@@ -1451,9 +1039,12 @@ pub async fn run(cache_config: &FlameCache) -> Result<(), FlameError> {
 
     let cache = Arc::new(ObjectCache::new(
         endpoint.clone(),
-        storage_path,
+        storage,
         Some(&eviction_config),
     )?);
+
+    cache.load_from_storage().await?;
+
     let server = FlightCacheServer::new(Arc::clone(&cache));
 
     tracing::info!("Starting Arrow Flight cache server at {}", address_str);
@@ -1464,7 +1055,6 @@ pub async fn run(cache_config: &FlameCache) -> Result<(), FlameError> {
 
     let mut builder = tonic::transport::Server::builder();
 
-    // Apply TLS if cache endpoint requires it (grpcs:// scheme) and TLS is configured
     if cache_config.requires_tls() {
         let tls_config = cache_config.tls.as_ref().ok_or_else(|| {
             FlameError::InvalidConfig(
@@ -1487,4 +1077,375 @@ pub async fn run(cache_config: &FlameCache) -> Result<(), FlameError> {
         .map_err(|e| FlameError::Internal(format!("Server error: {}", e)))?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    mod validation {
+        use super::*;
+
+        #[test]
+        fn validate_key_accepts_valid_keys() {
+            assert!(validate_key("session1/object1").is_ok());
+            assert!(validate_key("abc/def").is_ok());
+            assert!(validate_key("test-session/test-object").is_ok());
+            assert!(validate_key("123/456").is_ok());
+        }
+
+        #[test]
+        fn validate_key_rejects_path_traversal() {
+            assert!(validate_key("../etc/passwd").is_err());
+            assert!(validate_key("session/../other").is_err());
+            assert!(validate_key("session/..").is_err());
+        }
+
+        #[test]
+        fn validate_key_rejects_leading_slash() {
+            assert!(validate_key("/absolute/path").is_err());
+        }
+
+        #[test]
+        fn validate_key_rejects_double_slash() {
+            assert!(validate_key("session//object").is_err());
+        }
+
+        #[test]
+        fn validate_session_id_accepts_valid_ids() {
+            assert!(validate_session_id("session1").is_ok());
+            assert!(validate_session_id("my-session").is_ok());
+            assert!(validate_session_id("test_session_123").is_ok());
+        }
+
+        #[test]
+        fn validate_session_id_rejects_path_traversal() {
+            assert!(validate_session_id("..").is_err());
+            assert!(validate_session_id("../etc").is_err());
+            assert!(validate_session_id("test/path").is_err());
+            assert!(validate_session_id("test\\path").is_err());
+        }
+
+        #[test]
+        fn validate_object_id_accepts_valid_ids() {
+            assert!(validate_object_id("object1").is_ok());
+            assert!(validate_object_id("my-object").is_ok());
+            assert!(validate_object_id("550e8400-e29b-41d4-a716-446655440000").is_ok());
+        }
+
+        #[test]
+        fn validate_object_id_rejects_path_traversal() {
+            assert!(validate_object_id("..").is_err());
+            assert!(validate_object_id("../etc").is_err());
+            assert!(validate_object_id("test/path").is_err());
+            assert!(validate_object_id("test\\path").is_err());
+        }
+    }
+
+    mod object_struct {
+        use super::*;
+
+        #[test]
+        fn new_creates_object_without_deltas() {
+            let obj = Object::new(1, vec![1, 2, 3]);
+            assert_eq!(obj.version, 1);
+            assert_eq!(obj.data, vec![1, 2, 3]);
+            assert!(obj.deltas.is_empty());
+        }
+
+        #[test]
+        fn with_deltas_creates_object_with_deltas() {
+            let delta1 = Object::new(1, vec![4, 5]);
+            let delta2 = Object::new(2, vec![6, 7]);
+            let obj = Object::with_deltas(0, vec![1, 2, 3], vec![delta1.clone(), delta2.clone()]);
+
+            assert_eq!(obj.version, 0);
+            assert_eq!(obj.data, vec![1, 2, 3]);
+            assert_eq!(obj.deltas.len(), 2);
+            assert_eq!(obj.deltas[0].data, vec![4, 5]);
+            assert_eq!(obj.deltas[1].data, vec![6, 7]);
+        }
+
+        #[test]
+        fn object_clone_works() {
+            let obj = Object::new(42, vec![10, 20, 30]);
+            let cloned = obj.clone();
+            assert_eq!(cloned.version, obj.version);
+            assert_eq!(cloned.data, obj.data);
+        }
+    }
+
+    mod cache_endpoint {
+        use super::*;
+
+        #[test]
+        fn to_uri_formats_grpc_scheme() {
+            let endpoint = CacheEndpoint {
+                scheme: "grpc".to_string(),
+                host: "localhost".to_string(),
+                port: 9090,
+            };
+            assert_eq!(endpoint.to_uri(), "grpc://localhost:9090");
+        }
+
+        #[test]
+        fn to_uri_converts_grpcs_to_grpc_tls() {
+            let endpoint = CacheEndpoint {
+                scheme: "grpcs".to_string(),
+                host: "example.com".to_string(),
+                port: 443,
+            };
+            assert_eq!(endpoint.to_uri(), "grpc+tls://example.com:443");
+        }
+
+        #[test]
+        fn try_from_string_parses_valid_endpoint() {
+            let endpoint_str = "grpc://localhost:9090".to_string();
+            let endpoint = CacheEndpoint::try_from(&endpoint_str).unwrap();
+            assert_eq!(endpoint.scheme, "grpc");
+            assert_eq!(endpoint.host, "localhost");
+            assert_eq!(endpoint.port, 9090);
+        }
+
+        #[test]
+        fn try_from_string_uses_default_port() {
+            let endpoint_str = "grpc://localhost".to_string();
+            let endpoint = CacheEndpoint::try_from(&endpoint_str).unwrap();
+            assert_eq!(endpoint.port, 9090);
+        }
+
+        #[test]
+        fn try_from_string_rejects_invalid_url() {
+            let endpoint_str = "not a valid url".to_string();
+            assert!(CacheEndpoint::try_from(&endpoint_str).is_err());
+        }
+
+        #[test]
+        fn try_from_string_rejects_missing_host() {
+            let endpoint_str = "grpc:///path".to_string();
+            assert!(CacheEndpoint::try_from(&endpoint_str).is_err());
+        }
+    }
+
+    mod object_batch_conversion {
+        use super::*;
+
+        #[test]
+        fn object_to_batch_and_back() {
+            let original = Object::new(42, vec![1, 2, 3, 4, 5]);
+            let batch = object_to_batch(&original).unwrap();
+
+            assert_eq!(batch.num_rows(), 1);
+            assert_eq!(batch.num_columns(), 2);
+
+            let recovered = batch_to_object(&batch).unwrap();
+            assert_eq!(recovered.version, original.version);
+            assert_eq!(recovered.data, original.data);
+            assert!(recovered.deltas.is_empty());
+        }
+
+        #[test]
+        fn object_to_batch_handles_empty_data() {
+            let obj = Object::new(0, vec![]);
+            let batch = object_to_batch(&obj).unwrap();
+            let recovered = batch_to_object(&batch).unwrap();
+            assert_eq!(recovered.version, 0);
+            assert!(recovered.data.is_empty());
+        }
+
+        #[test]
+        fn object_to_batch_handles_large_data() {
+            let large_data: Vec<u8> = (0..10000).map(|i| (i % 256) as u8).collect();
+            let obj = Object::new(999, large_data.clone());
+            let batch = object_to_batch(&obj).unwrap();
+            let recovered = batch_to_object(&batch).unwrap();
+            assert_eq!(recovered.version, 999);
+            assert_eq!(recovered.data, large_data);
+        }
+
+        #[test]
+        fn get_object_schema_returns_correct_schema() {
+            let schema = get_object_schema();
+            assert_eq!(schema.fields().len(), 2);
+            assert_eq!(schema.field(0).name(), "version");
+            assert_eq!(schema.field(1).name(), "data");
+        }
+    }
+
+    mod object_cache_operations {
+        use super::*;
+
+        async fn create_test_cache() -> ObjectCache {
+            let endpoint = CacheEndpoint {
+                scheme: "grpc".to_string(),
+                host: "localhost".to_string(),
+                port: 9090,
+            };
+            let storage = crate::storage::connect("none").await.unwrap();
+            ObjectCache::new(endpoint, storage, None).unwrap()
+        }
+
+        #[tokio::test]
+        async fn put_and_get_object() {
+            let cache = create_test_cache().await;
+            let obj = Object::new(1, vec![1, 2, 3]);
+
+            let meta = cache
+                .put("test-session".to_string(), obj.clone())
+                .await
+                .unwrap();
+            assert!(meta.key.starts_with("test-session/"));
+            assert_eq!(meta.size, 3);
+
+            let retrieved = cache.get(meta.key.clone()).await.unwrap();
+            assert_eq!(retrieved.version, 1);
+            assert_eq!(retrieved.data, vec![1, 2, 3]);
+        }
+
+        #[tokio::test]
+        async fn put_with_custom_id() {
+            let cache = create_test_cache().await;
+            let obj = Object::new(0, vec![42]);
+
+            let meta = cache
+                .put_with_id("session".to_string(), Some("custom-id".to_string()), obj)
+                .await
+                .unwrap();
+
+            assert_eq!(meta.key, "session/custom-id");
+        }
+
+        #[tokio::test]
+        async fn get_returns_not_found_for_missing_key() {
+            let cache = create_test_cache().await;
+            let result = cache.get("nonexistent/key".to_string()).await;
+            assert!(result.is_err());
+        }
+
+        #[tokio::test]
+        async fn get_rejects_invalid_key() {
+            let cache = create_test_cache().await;
+            let result = cache.get("../invalid".to_string()).await;
+            assert!(result.is_err());
+        }
+
+        #[tokio::test]
+        async fn update_replaces_object() {
+            let cache = create_test_cache().await;
+            let obj1 = Object::new(1, vec![1, 2, 3]);
+
+            let meta = cache.put("session".to_string(), obj1).await.unwrap();
+
+            let obj2 = Object::new(2, vec![4, 5, 6, 7]);
+            let updated_meta = cache.update(meta.key.clone(), obj2).await.unwrap();
+
+            assert_eq!(updated_meta.size, 4);
+
+            let retrieved = cache.get(meta.key).await.unwrap();
+            assert_eq!(retrieved.version, 2);
+            assert_eq!(retrieved.data, vec![4, 5, 6, 7]);
+        }
+
+        #[tokio::test]
+        async fn delete_removes_session_objects() {
+            let cache = create_test_cache().await;
+
+            cache
+                .put("session-to-delete".to_string(), Object::new(0, vec![1]))
+                .await
+                .unwrap();
+            cache
+                .put("session-to-delete".to_string(), Object::new(0, vec![2]))
+                .await
+                .unwrap();
+            cache
+                .put("other-session".to_string(), Object::new(0, vec![3]))
+                .await
+                .unwrap();
+
+            cache.delete("session-to-delete".to_string()).await.unwrap();
+
+            let all = cache.list_all().await.unwrap();
+            assert_eq!(all.len(), 1);
+            assert!(all[0].key.starts_with("other-session/"));
+        }
+
+        #[tokio::test]
+        async fn list_all_returns_all_metadata() {
+            let cache = create_test_cache().await;
+
+            cache
+                .put("s1".to_string(), Object::new(0, vec![1]))
+                .await
+                .unwrap();
+            cache
+                .put("s2".to_string(), Object::new(0, vec![2]))
+                .await
+                .unwrap();
+
+            let all = cache.list_all().await.unwrap();
+            assert_eq!(all.len(), 2);
+        }
+
+        #[tokio::test]
+        async fn put_rejects_invalid_session_id() {
+            let cache = create_test_cache().await;
+            let result = cache
+                .put("../bad".to_string(), Object::new(0, vec![]))
+                .await;
+            assert!(result.is_err());
+        }
+
+        #[tokio::test]
+        async fn put_with_id_rejects_invalid_object_id() {
+            let cache = create_test_cache().await;
+            let result = cache
+                .put_with_id(
+                    "session".to_string(),
+                    Some("../bad".to_string()),
+                    Object::new(0, vec![]),
+                )
+                .await;
+            assert!(result.is_err());
+        }
+
+        #[tokio::test]
+        async fn create_metadata_includes_endpoint() {
+            let cache = create_test_cache().await;
+            let meta = cache.create_metadata("test/key".to_string(), 100, 5);
+
+            assert_eq!(meta.key, "test/key");
+            assert_eq!(meta.size, 100);
+            assert_eq!(meta.delta_count, 5);
+            assert!(meta.endpoint.contains("localhost:9090"));
+        }
+    }
+
+    mod flight_data_conversion {
+        use super::*;
+
+        #[test]
+        fn object_to_flight_data_vec_creates_valid_flight_data() {
+            let obj = Object::new(1, vec![1, 2, 3]);
+            let flight_data = object_to_flight_data_vec(&obj).unwrap();
+
+            assert!(!flight_data.is_empty());
+        }
+
+        #[test]
+        fn object_to_flight_data_vec_includes_deltas() {
+            let delta = Object::new(1, vec![4, 5]);
+            let obj = Object::with_deltas(0, vec![1, 2, 3], vec![delta]);
+            let flight_data = object_to_flight_data_vec(&obj).unwrap();
+
+            assert!(flight_data.len() >= 2);
+        }
+
+        #[test]
+        fn encode_schema_returns_valid_bytes() {
+            let schema = get_object_schema();
+            let encoded = encode_schema(&schema).unwrap();
+            assert!(!encoded.is_empty());
+        }
+    }
 }

--- a/object_cache/src/lib.rs
+++ b/object_cache/src/lib.rs
@@ -13,8 +13,10 @@ limitations under the License.
 
 pub mod cache;
 pub mod eviction;
+pub mod storage;
 
 pub use cache::{run, CacheEndpoint, FlightCacheServer, Object, ObjectCache, ObjectMetadata};
 pub use eviction::{
     new_policy, EvictionConfig, EvictionPolicy, EvictionPolicyPtr, LRUPolicy, NoEvictionPolicy,
 };
+pub use storage::{connect as connect_storage, StorageEngine, StorageEnginePtr};

--- a/object_cache/src/storage/disk.rs
+++ b/object_cache/src/storage/disk.rs
@@ -1,0 +1,509 @@
+/*
+Copyright 2025 The Flame Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use arrow::array::{BinaryArray, RecordBatch, UInt64Array};
+use arrow::datatypes::{DataType, Field, Schema};
+use arrow::ipc::writer::IpcWriteOptions;
+use arrow::ipc::{reader::FileReader, writer::FileWriter, CompressionType};
+use async_trait::async_trait;
+use rayon::prelude::*;
+
+use common::FlameError;
+
+use crate::{Object, ObjectMetadata};
+
+use super::StorageEngine;
+
+const MAX_DELTAS_PER_OBJECT: u64 = 1000;
+
+/// Disk-based storage engine using Arrow IPC format.
+pub struct DiskStorage {
+    storage_path: PathBuf,
+}
+
+impl DiskStorage {
+    pub fn new(storage_path: PathBuf) -> Result<Self, FlameError> {
+        if !storage_path.exists() {
+            tracing::info!("Creating storage directory: {:?}", storage_path);
+            fs::create_dir_all(&storage_path)?;
+        }
+        Ok(Self { storage_path })
+    }
+
+    fn object_path(&self, key: &str) -> PathBuf {
+        self.storage_path.join(format!("{}.arrow", key))
+    }
+
+    fn delta_dir(&self, key: &str) -> PathBuf {
+        self.storage_path.join(format!("{}.deltas", key))
+    }
+
+    fn session_dir(&self, session_id: &str) -> PathBuf {
+        self.storage_path.join(session_id)
+    }
+}
+
+#[async_trait]
+impl StorageEngine for DiskStorage {
+    async fn write_object(&self, key: &str, object: &Object) -> Result<(), FlameError> {
+        let parts: Vec<&str> = key.split('/').collect();
+        if parts.len() != 2 {
+            return Err(FlameError::InvalidConfig(format!(
+                "Invalid key format: {}",
+                key
+            )));
+        }
+        let session_id = parts[0].to_string();
+
+        let session_dir = self.session_dir(&session_id);
+        let object_path = self.object_path(key);
+        let delta_dir = self.delta_dir(key);
+        let object_clone = object.clone();
+
+        tokio::task::spawn_blocking(move || {
+            fs::create_dir_all(&session_dir)?;
+            let batch = object_to_batch(&object_clone)?;
+            write_batch_to_file(&object_path, &batch)?;
+            if delta_dir.exists() {
+                fs::remove_dir_all(&delta_dir)?;
+            }
+            tracing::debug!("Wrote object to disk: {:?}", object_path);
+            Ok(())
+        })
+        .await
+        .map_err(|e| FlameError::Internal(format!("Task join error: {}", e)))?
+    }
+
+    async fn read_object(&self, key: &str) -> Result<Option<Object>, FlameError> {
+        let object_path = self.object_path(key);
+        let delta_dir = self.delta_dir(key);
+
+        tokio::task::spawn_blocking(move || {
+            if !object_path.exists() {
+                return Ok(None);
+            }
+            let base = load_object_from_file(&object_path)?;
+            let deltas = read_deltas_sync(&delta_dir)?;
+            Ok(Some(Object::with_deltas(base.version, base.data, deltas)))
+        })
+        .await
+        .map_err(|e| FlameError::Internal(format!("Task join error: {}", e)))?
+    }
+
+    async fn patch_object(&self, key: &str, delta: &Object) -> Result<ObjectMetadata, FlameError> {
+        let object_path = self.object_path(key);
+        let delta_dir = self.delta_dir(key);
+        let key_owned = key.to_string();
+        let delta_clone = delta.clone();
+
+        tokio::task::spawn_blocking(move || {
+            if !object_path.exists() {
+                return Err(FlameError::NotFound(format!(
+                    "object <{}> not found, must put first",
+                    key_owned
+                )));
+            }
+
+            fs::create_dir_all(&delta_dir)?;
+
+            let batch = object_to_batch(&delta_clone)?;
+            let mut index = count_deltas_sync(&delta_dir);
+
+            loop {
+                if index >= MAX_DELTAS_PER_OBJECT {
+                    return Err(FlameError::InvalidState(format!(
+                        "object <{}> has reached maximum delta count ({}). Use update_object to compact deltas.",
+                        key_owned, MAX_DELTAS_PER_OBJECT
+                    )));
+                }
+
+                let delta_path = delta_dir.join(format!("{}.arrow", index));
+
+                match fs::OpenOptions::new()
+                    .write(true)
+                    .create_new(true)
+                    .open(&delta_path)
+                {
+                    Ok(file) => {
+                        write_batch_to_writer(file, &batch)?;
+                        tracing::debug!("Wrote delta {} to disk: {:?}", index, delta_path);
+                        break;
+                    }
+                    Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                        index += 1;
+                        continue;
+                    }
+                    Err(e) => {
+                        return Err(FlameError::Internal(format!(
+                            "Failed to create delta file: {}",
+                            e
+                        )))
+                    }
+                }
+            }
+
+            let size = fs::metadata(&object_path)?.len();
+            Ok(ObjectMetadata {
+                endpoint: String::new(),
+                key: key_owned,
+                version: 0,
+                size,
+                delta_count: index + 1,
+            })
+        })
+        .await
+        .map_err(|e| FlameError::Internal(format!("Task join error: {}", e)))?
+    }
+
+    async fn delete_object(&self, key: &str) -> Result<(), FlameError> {
+        let object_path = self.object_path(key);
+        let delta_dir = self.delta_dir(key);
+
+        tokio::task::spawn_blocking(move || {
+            if object_path.exists() {
+                fs::remove_file(&object_path)?;
+            }
+            if delta_dir.exists() {
+                fs::remove_dir_all(&delta_dir)?;
+            }
+            Ok(())
+        })
+        .await
+        .map_err(|e| FlameError::Internal(format!("Task join error: {}", e)))?
+    }
+
+    async fn delete_objects(&self, session_id: &str) -> Result<(), FlameError> {
+        let session_dir = self.session_dir(session_id);
+
+        tokio::task::spawn_blocking(move || {
+            if session_dir.exists() {
+                fs::remove_dir_all(&session_dir)?;
+                tracing::debug!("Deleted session directory: {:?}", session_dir);
+            }
+            Ok(())
+        })
+        .await
+        .map_err(|e| FlameError::Internal(format!("Task join error: {}", e)))?
+    }
+
+    async fn load_objects(&self) -> Result<Vec<(String, Object, u64)>, FlameError> {
+        let storage_path = self.storage_path.clone();
+
+        tokio::task::spawn_blocking(move || {
+            let mut results = Vec::new();
+
+            if !storage_path.exists() {
+                return Ok(results);
+            }
+
+            for session_entry in fs::read_dir(&storage_path)? {
+                let session_entry = session_entry?;
+                let session_path = session_entry.path();
+
+                if !session_path.is_dir() {
+                    continue;
+                }
+
+                let session_id = session_path
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .ok_or_else(|| {
+                        FlameError::Internal("Invalid session directory name".to_string())
+                    })?;
+
+                for object_entry in fs::read_dir(&session_path)? {
+                    let object_entry = object_entry?;
+                    let object_path = object_entry.path();
+
+                    if object_path.is_dir() {
+                        continue;
+                    }
+
+                    if object_path.extension().and_then(|e| e.to_str()) != Some("arrow") {
+                        continue;
+                    }
+
+                    let object_id = object_path
+                        .file_stem()
+                        .and_then(|n| n.to_str())
+                        .ok_or_else(|| {
+                            FlameError::Internal("Invalid object file name".to_string())
+                        })?;
+
+                    let key = format!("{}/{}", session_id, object_id);
+                    let delta_dir = session_path.join(format!("{}.deltas", object_id));
+                    let delta_count = count_deltas_sync(&delta_dir);
+
+                    let base = load_object_from_file(&object_path)?;
+                    let deltas = read_deltas_sync(&delta_dir)?;
+                    let object = Object::with_deltas(base.version, base.data, deltas);
+
+                    results.push((key, object, delta_count));
+                }
+            }
+
+            tracing::info!("Loaded {} objects from disk", results.len());
+            Ok(results)
+        })
+        .await
+        .map_err(|e| FlameError::Internal(format!("Task join error: {}", e)))?
+    }
+}
+
+fn get_object_schema() -> Schema {
+    Schema::new(vec![
+        Field::new("version", DataType::UInt64, false),
+        Field::new("data", DataType::Binary, false),
+    ])
+}
+
+fn count_deltas_sync(delta_dir: &Path) -> u64 {
+    if !delta_dir.exists() {
+        return 0;
+    }
+
+    fs::read_dir(delta_dir)
+        .map(|entries| {
+            entries
+                .filter_map(|e| e.ok())
+                .filter(|e| e.path().extension().and_then(|ext| ext.to_str()) == Some("arrow"))
+                .count() as u64
+        })
+        .unwrap_or(0)
+}
+
+fn read_deltas_sync(delta_dir: &Path) -> Result<Vec<Object>, FlameError> {
+    if !delta_dir.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut delta_files: Vec<_> = fs::read_dir(delta_dir)?
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().and_then(|ext| ext.to_str()) == Some("arrow"))
+        .collect();
+
+    delta_files.sort_by_key(|e| {
+        e.path()
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .and_then(|s| s.parse::<u64>().ok())
+            .unwrap_or(u64::MAX)
+    });
+
+    delta_files
+        .into_par_iter()
+        .map(|entry| load_object_from_file(&entry.path()))
+        .collect()
+}
+
+fn write_batch_to_file(path: &Path, batch: &RecordBatch) -> Result<(), FlameError> {
+    let file = fs::File::create(path)?;
+    write_batch_to_writer(file, batch)
+}
+
+fn write_batch_to_writer(file: fs::File, batch: &RecordBatch) -> Result<(), FlameError> {
+    let options = IpcWriteOptions::default()
+        .try_with_compression(Some(CompressionType::ZSTD))
+        .map_err(|e| FlameError::Internal(format!("Failed to set compression: {}", e)))?;
+    let mut writer = FileWriter::try_new_with_options(file, &batch.schema(), options)
+        .map_err(|e| FlameError::Internal(format!("Failed to create writer: {}", e)))?;
+    writer
+        .write(batch)
+        .map_err(|e| FlameError::Internal(format!("Failed to write batch: {}", e)))?;
+    writer
+        .finish()
+        .map_err(|e| FlameError::Internal(format!("Failed to finish writer: {}", e)))?;
+    Ok(())
+}
+
+fn object_to_batch(object: &Object) -> Result<RecordBatch, FlameError> {
+    let schema = get_object_schema();
+
+    let version_array = UInt64Array::from(vec![object.version]);
+    let data_array = BinaryArray::from(vec![object.data.as_slice()]);
+
+    RecordBatch::try_new(
+        Arc::new(schema),
+        vec![Arc::new(version_array), Arc::new(data_array)],
+    )
+    .map_err(|e| FlameError::Internal(format!("Failed to create RecordBatch: {}", e)))
+}
+
+fn load_object_from_file(path: &Path) -> Result<Object, FlameError> {
+    let file = fs::File::open(path).map_err(|e| {
+        if e.kind() == std::io::ErrorKind::NotFound {
+            FlameError::NotFound(format!("Object file not found: {}", path.display()))
+        } else {
+            FlameError::Internal(format!("Failed to open object file: {}", e))
+        }
+    })?;
+    let reader = FileReader::try_new(file, None)
+        .map_err(|e| FlameError::Internal(format!("Failed to create reader: {}", e)))?;
+
+    // SAFETY: Skipping Arrow IPC validation is safe here because:
+    // 1. All data in this cache directory was written by this service using write_batch_to_file()
+    // 2. The Arrow IPC format includes checksums that detect corruption during read
+    // 3. This provides 3-9x faster reads for trusted cache data
+    // 4. If files are externally modified/corrupted, Arrow will still detect most issues
+    //    via schema validation and array bounds checking in batch_to_object()
+    let reader = unsafe { reader.with_skip_validation(true) };
+
+    let batch = reader
+        .into_iter()
+        .next()
+        .ok_or_else(|| FlameError::Internal("No batches in file".to_string()))?
+        .map_err(|e| FlameError::Internal(format!("Failed to read batch: {}", e)))?;
+
+    batch_to_object(&batch)
+}
+
+fn batch_to_object(batch: &RecordBatch) -> Result<Object, FlameError> {
+    if batch.num_rows() != 1 {
+        return Err(FlameError::InvalidState(
+            "Expected exactly one row".to_string(),
+        ));
+    }
+
+    let version_col = batch
+        .column(0)
+        .as_any()
+        .downcast_ref::<UInt64Array>()
+        .ok_or_else(|| FlameError::Internal("Invalid version column".to_string()))?;
+    let data_col = batch
+        .column(1)
+        .as_any()
+        .downcast_ref::<BinaryArray>()
+        .ok_or_else(|| FlameError::Internal("Invalid data column".to_string()))?;
+
+    let version = version_col.value(0);
+    let data = data_col.value(0).to_vec();
+
+    Ok(Object::new(version, data))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[tokio::test]
+    async fn test_disk_storage_write_read() {
+        let temp_dir = tempdir().unwrap();
+        let storage = DiskStorage::new(temp_dir.path().to_path_buf()).unwrap();
+
+        let object = Object::new(1, vec![1, 2, 3, 4, 5]);
+        storage
+            .write_object("test-session/obj1", &object)
+            .await
+            .unwrap();
+
+        let result = storage.read_object("test-session/obj1").await.unwrap();
+        assert!(result.is_some());
+        let loaded = result.unwrap();
+        assert_eq!(loaded.version, 1);
+        assert_eq!(loaded.data, vec![1, 2, 3, 4, 5]);
+        assert!(loaded.deltas.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_disk_storage_patch() {
+        let temp_dir = tempdir().unwrap();
+        let storage = DiskStorage::new(temp_dir.path().to_path_buf()).unwrap();
+
+        let object = Object::new(1, vec![1, 2, 3]);
+        storage
+            .write_object("test-session/obj1", &object)
+            .await
+            .unwrap();
+
+        let delta = Object::new(0, vec![4, 5, 6]);
+        let meta = storage
+            .patch_object("test-session/obj1", &delta)
+            .await
+            .unwrap();
+        assert_eq!(meta.delta_count, 1);
+
+        let loaded = storage
+            .read_object("test-session/obj1")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(loaded.deltas.len(), 1);
+        assert_eq!(loaded.deltas[0].data, vec![4, 5, 6]);
+    }
+
+    #[tokio::test]
+    async fn test_disk_storage_delete() {
+        let temp_dir = tempdir().unwrap();
+        let storage = DiskStorage::new(temp_dir.path().to_path_buf()).unwrap();
+
+        let object = Object::new(1, vec![1, 2, 3]);
+        storage
+            .write_object("test-session/obj1", &object)
+            .await
+            .unwrap();
+
+        storage.delete_object("test-session/obj1").await.unwrap();
+
+        let result = storage.read_object("test-session/obj1").await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_disk_storage_delete_objects() {
+        let temp_dir = tempdir().unwrap();
+        let storage = DiskStorage::new(temp_dir.path().to_path_buf()).unwrap();
+
+        let object1 = Object::new(1, vec![1, 2, 3]);
+        let object2 = Object::new(2, vec![4, 5, 6]);
+        storage
+            .write_object("test-session/obj1", &object1)
+            .await
+            .unwrap();
+        storage
+            .write_object("test-session/obj2", &object2)
+            .await
+            .unwrap();
+
+        storage.delete_objects("test-session").await.unwrap();
+
+        let result1 = storage.read_object("test-session/obj1").await.unwrap();
+        let result2 = storage.read_object("test-session/obj2").await.unwrap();
+        assert!(result1.is_none());
+        assert!(result2.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_disk_storage_load_objects() {
+        let temp_dir = tempdir().unwrap();
+        let storage = DiskStorage::new(temp_dir.path().to_path_buf()).unwrap();
+
+        let object1 = Object::new(1, vec![1, 2, 3]);
+        let object2 = Object::new(2, vec![4, 5, 6]);
+        storage
+            .write_object("session1/obj1", &object1)
+            .await
+            .unwrap();
+        storage
+            .write_object("session2/obj2", &object2)
+            .await
+            .unwrap();
+
+        let objects = storage.load_objects().await.unwrap();
+        assert_eq!(objects.len(), 2);
+    }
+}

--- a/object_cache/src/storage/mod.rs
+++ b/object_cache/src/storage/mod.rs
@@ -1,0 +1,180 @@
+/*
+Copyright 2025 The Flame Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Storage engine module for ObjectCache.
+//!
+//! This module provides pluggable storage engines for the object cache:
+//! - `DiskStorage` - Persistent storage using Arrow IPC format
+//! - `NoneStorage` - Memory-only storage with no persistence
+//!
+//! Use `connect()` to create a storage engine from a URL string.
+
+mod disk;
+mod none;
+
+pub use disk::DiskStorage;
+pub use none::NoneStorage;
+
+use std::path::PathBuf;
+
+use async_trait::async_trait;
+
+use common::FlameError;
+
+use crate::{Object, ObjectMetadata};
+
+/// Storage engine trait for ObjectCache.
+///
+/// Implementations must be thread-safe (Send + Sync).
+///
+/// The storage engine is responsible for:
+/// - Persisting objects (base data + deltas)
+/// - Managing delta files internally
+/// - Loading objects with their deltas on read
+#[async_trait]
+pub trait StorageEngine: Send + Sync + 'static {
+    /// Write an object to persistent storage.
+    /// Clears any existing deltas for this key.
+    async fn write_object(&self, key: &str, object: &Object) -> Result<(), FlameError>;
+
+    /// Read an object from persistent storage.
+    /// Returns the object with all deltas populated in `object.deltas`.
+    /// Returns None if object doesn't exist in storage.
+    async fn read_object(&self, key: &str) -> Result<Option<Object>, FlameError>;
+
+    /// Append a delta to an existing object (PATCH operation).
+    /// Returns updated metadata including new delta count.
+    ///
+    /// # Errors
+    /// - Returns NotFound if the base object doesn't exist
+    /// - Returns InvalidConfig if patch is not supported (e.g., none storage)
+    async fn patch_object(&self, key: &str, delta: &Object) -> Result<ObjectMetadata, FlameError>;
+
+    /// Delete an object and all its deltas from persistent storage.
+    async fn delete_object(&self, key: &str) -> Result<(), FlameError>;
+
+    /// Delete all objects for a session.
+    async fn delete_objects(&self, session_id: &str) -> Result<(), FlameError>;
+
+    /// Load all objects from storage (for startup recovery).
+    /// Returns Vec of (key, object, delta_count).
+    /// Objects are returned with deltas populated.
+    async fn load_objects(&self) -> Result<Vec<(String, Object, u64)>, FlameError>;
+}
+
+pub type StorageEnginePtr = Box<dyn StorageEngine>;
+
+/// Connect to a storage engine based on the URL scheme.
+///
+/// Supported URL schemes:
+/// - `none` - Memory-only, no persistence
+/// - `fs://` or `file://` - Filesystem storage
+/// - Plain path (legacy) - Treated as filesystem storage
+///
+/// Path resolution for `fs://`:
+/// - Triple slash (e.g., `fs:///data`) - Absolute path (`/data`)
+/// - Double slash (e.g., `fs://data`) - Relative to FLAME_HOME (`${FLAME_HOME}/data`)
+///
+/// # Examples
+///
+/// ```ignore
+/// // Memory-only storage
+/// let storage = connect("none").await?;
+///
+/// // Filesystem storage (absolute path)
+/// let storage = connect("fs:///var/lib/flame/cache").await?;
+///
+/// // Filesystem storage (relative to FLAME_HOME)
+/// let storage = connect("fs://cache").await?;  // -> ${FLAME_HOME}/cache
+///
+/// // Legacy plain path (still supported)
+/// let storage = connect("/var/lib/flame/cache").await?;
+/// ```
+pub async fn connect(url: &str) -> Result<StorageEnginePtr, FlameError> {
+    // Check environment variable override
+    let url = std::env::var("FLAME_CACHE_STORAGE")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| url.to_string());
+
+    if url.is_empty() {
+        tracing::warn!("No cache storage configured - using none storage (no persistence)");
+        return Ok(Box::new(NoneStorage::new()));
+    }
+
+    if url == "none" {
+        tracing::info!("Cache storage: none (memory-only, no persistence)");
+        return Ok(Box::new(NoneStorage::new()));
+    }
+
+    // Parse filesystem URL or plain path
+    let storage_path = if url.starts_with("fs://") || url.starts_with("file://") {
+        parse_storage_url(&url)?
+    } else {
+        // Legacy plain path support
+        PathBuf::from(&url)
+    };
+
+    tracing::info!("Cache storage: filesystem at {:?}", storage_path);
+    Ok(Box::new(DiskStorage::new(storage_path)?))
+}
+
+/// Parse storage URL and resolve path.
+fn parse_storage_url(url: &str) -> Result<PathBuf, FlameError> {
+    let path_part = url
+        .strip_prefix("fs://")
+        .or_else(|| url.strip_prefix("file://"))
+        .ok_or_else(|| FlameError::InvalidConfig(format!("Invalid storage URL: {}", url)))?;
+
+    if path_part.starts_with('/') {
+        // Absolute path (triple slash: fs:///path -> /path)
+        Ok(PathBuf::from(path_part))
+    } else {
+        // Relative to FLAME_HOME (double slash: fs://path -> ${FLAME_HOME}/path)
+        let flame_home =
+            std::env::var("FLAME_HOME").unwrap_or_else(|_| "/var/lib/flame".to_string());
+        Ok(PathBuf::from(flame_home).join(path_part))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_storage_url_absolute() {
+        let path = parse_storage_url("fs:///var/lib/flame/cache").unwrap();
+        assert_eq!(path, PathBuf::from("/var/lib/flame/cache"));
+    }
+
+    #[test]
+    fn test_parse_storage_url_relative() {
+        let path = parse_storage_url("fs://cache").unwrap();
+        assert!(path.ends_with("cache"));
+        assert!(path.is_absolute() || path.starts_with("cache"));
+    }
+
+    #[test]
+    fn test_parse_storage_url_file_scheme() {
+        let path = parse_storage_url("file:///tmp/cache").unwrap();
+        assert_eq!(path, PathBuf::from("/tmp/cache"));
+    }
+
+    #[tokio::test]
+    async fn test_connect_none() {
+        let storage = connect("none").await.unwrap();
+        // Verify it's a NoneStorage by checking load_objects returns empty
+        let objects = storage.load_objects().await.unwrap();
+        assert!(objects.is_empty());
+    }
+}

--- a/object_cache/src/storage/none.rs
+++ b/object_cache/src/storage/none.rs
@@ -1,0 +1,108 @@
+/*
+Copyright 2025 The Flame Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use async_trait::async_trait;
+
+use common::FlameError;
+
+use crate::{Object, ObjectMetadata};
+
+use super::StorageEngine;
+
+/// Memory-only storage engine - no persistence.
+pub struct NoneStorage;
+
+impl NoneStorage {
+    pub fn new() -> Self {
+        tracing::info!("Using none storage engine (no persistence)");
+        Self
+    }
+}
+
+impl Default for NoneStorage {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl StorageEngine for NoneStorage {
+    async fn write_object(&self, _key: &str, _object: &Object) -> Result<(), FlameError> {
+        Ok(())
+    }
+
+    async fn read_object(&self, _key: &str) -> Result<Option<Object>, FlameError> {
+        Ok(None)
+    }
+
+    async fn patch_object(&self, key: &str, _delta: &Object) -> Result<ObjectMetadata, FlameError> {
+        Err(FlameError::InvalidConfig(format!(
+            "patch operation not supported with none storage for object <{}>. Use update_object instead.",
+            key
+        )))
+    }
+
+    async fn delete_object(&self, _key: &str) -> Result<(), FlameError> {
+        Ok(())
+    }
+
+    async fn delete_objects(&self, _session_id: &str) -> Result<(), FlameError> {
+        Ok(())
+    }
+
+    async fn load_objects(&self) -> Result<Vec<(String, Object, u64)>, FlameError> {
+        Ok(Vec::new())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_none_storage_write_read() {
+        let storage = NoneStorage::new();
+        let object = Object::new(0, vec![1, 2, 3]);
+
+        storage.write_object("session/obj1", &object).await.unwrap();
+
+        let result = storage.read_object("session/obj1").await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_none_storage_patch_returns_error() {
+        let storage = NoneStorage::new();
+        let delta = Object::new(0, vec![4, 5, 6]);
+
+        let result = storage.patch_object("session/obj1", &delta).await;
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), FlameError::InvalidConfig(_)));
+    }
+
+    #[tokio::test]
+    async fn test_none_storage_delete() {
+        let storage = NoneStorage::new();
+
+        storage.delete_object("session/obj1").await.unwrap();
+        storage.delete_objects("session").await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_none_storage_load_objects() {
+        let storage = NoneStorage::new();
+
+        let objects = storage.load_objects().await.unwrap();
+        assert!(objects.is_empty());
+    }
+}


### PR DESCRIPTION
## Summary

- Introduces a storage abstraction layer for the object cache supporting multiple backends
- Implements `DiskStorage` for file-based persistence using Arrow IPC format
- Implements `NoneStorage` for in-memory testing without disk I/O overhead
- Refactors `ObjectCache` to use the new `StorageBackend` trait with async operations

## Changes

- New `storage` module with `StorageBackend` trait and implementations
- `ObjectCache` now accepts pluggable storage via `connect(storage_url)`
- Storage URLs: `file:///path` or `/path` for disk, `none` for in-memory
- Design doc added at `docs/designs/RFE414-cache-none-storage/FS.md`

## Fixes

- Added missing imports (`Path`, `fs`, `FileWriter`) that broke the build
- Applied `cargo fmt` fixes for code style consistency