### PR TITLE
feat: add wasm feature flag and flmping perf mode

### DIFF
--- a/executor_manager/Cargo.toml
+++ b/executor_manager/Cargo.toml
@@ -5,6 +5,10 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+default = []
+wasm = ["dep:wasmtime", "dep:wasmtime-wasi"]
+
 [dependencies]
 rpc = { path = "../rpc" }
 common = { path = "../common" }
@@ -36,8 +40,8 @@ tar = "0.4"
 zip = "2"
 reqwest = { version = "0.12", features = ["rustls-tls", "stream"], default-features = false }
 futures-util = "0.3"
-wasmtime = "43"
-wasmtime-wasi = "43"
+wasmtime = { version = "43", optional = true }
+wasmtime-wasi = { version = "43", optional = true }
 anyhow = "1"
 tokio-stream = { workspace = true }
 shellexpand = "3.1"

--- a/executor_manager/src/shims/mod.rs
+++ b/executor_manager/src/shims/mod.rs
@@ -13,6 +13,7 @@ limitations under the License.
 
 mod grpc_shim;
 mod host_shim;
+#[cfg(feature = "wasm")]
 mod wasm_shim;
 
 use std::collections::HashMap;
@@ -25,6 +26,7 @@ use async_trait::async_trait;
 use tokio::sync::Mutex;
 
 use self::host_shim::HostShim;
+#[cfg(feature = "wasm")]
 use self::wasm_shim::WasmShim;
 
 use crate::executor::Executor;
@@ -206,7 +208,12 @@ pub async fn new(
     );
 
     match shim_type {
+        #[cfg(feature = "wasm")]
         ShimType::Wasm => Ok(WasmShim::new_ptr(executor, app, install_env_vars).await?),
+        #[cfg(not(feature = "wasm"))]
+        ShimType::Wasm => Err(FlameError::InvalidConfig(
+            "WASM shim is not enabled. Rebuild with --features wasm".to_string(),
+        )),
         ShimType::Host => Ok(HostShim::new_ptr(executor, app, install_env_vars).await?),
     }
 }

--- a/flmping/src/client.rs
+++ b/flmping/src/client.rs
@@ -14,7 +14,6 @@ limitations under the License.
 mod apis;
 
 use std::error::Error;
-use std::sync::atomic::{AtomicU32, Ordering};
 use std::time::Instant;
 
 use byte_unit::Byte;
@@ -25,7 +24,7 @@ use flame_rs::apis::FlameError;
 use flame_rs::client::{Session, SessionAttributes, Task, TaskInformer};
 use futures::future::try_join_all;
 use indicatif::HumanCount;
-use stdng::{lock_ptr, new_ptr};
+use stdng::{lock_ptr, new_ptr, MutexPtr};
 
 use crate::apis::{PingRequest, PingResponse};
 
@@ -114,6 +113,24 @@ async fn main() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
+async fn run_tasks<T: TaskInformer + 'static>(
+    ssn: &Session,
+    task_num: i32,
+    duration: Option<u64>,
+    memory: Option<u64>,
+    informer: MutexPtr<T>,
+) -> Result<u128, Box<dyn Error>> {
+    let input: flame_rs::apis::TaskInput = PingRequest { duration, memory }.try_into()?;
+    let start = Instant::now();
+
+    let tasks: Vec<_> = (0..task_num)
+        .map(|_| ssn.run_task(Some(input.clone()), informer.clone()))
+        .collect();
+
+    try_join_all(tasks).await?;
+    Ok(start.elapsed().as_millis())
+}
+
 async fn run_perf_mode(
     ssn: &Session,
     task_num: i32,
@@ -121,20 +138,7 @@ async fn run_perf_mode(
     memory: Option<u64>,
 ) -> Result<(), Box<dyn Error>> {
     let info = new_ptr(PerfInformer::new());
-    let start = Instant::now();
-
-    let tasks: Vec<_> = (0..task_num)
-        .map(|_| {
-            let input = PingRequest { duration, memory }.try_into();
-            async {
-                let input = input?;
-                ssn.run_task(Some(input), info.clone()).await
-            }
-        })
-        .collect();
-
-    try_join_all(tasks).await?;
-    let duration_ms = start.elapsed().as_millis();
+    let duration_ms = run_tasks(ssn, task_num, duration, memory, info.clone()).await?;
 
     let info = lock_ptr!(info)?;
     info.print_summary(task_num, duration_ms);
@@ -149,20 +153,7 @@ async fn run_output_mode(
     memory: Option<u64>,
 ) -> Result<(), Box<dyn Error>> {
     let info = new_ptr(OutputInfor::new());
-    let start = Instant::now();
-
-    let tasks: Vec<_> = (0..task_num)
-        .map(|_| {
-            let input = PingRequest { duration, memory }.try_into();
-            async {
-                let input = input?;
-                ssn.run_task(Some(input), info.clone()).await
-            }
-        })
-        .collect();
-
-    try_join_all(tasks).await?;
-    let duration_ms = start.elapsed().as_millis();
+    let duration_ms = run_tasks(ssn, task_num, duration, memory, info.clone()).await?;
 
     {
         let info = lock_ptr!(info)?;
@@ -221,24 +212,22 @@ impl OutputInfor {
 }
 
 struct PerfInformer {
-    succeeded: AtomicU32,
-    failed: AtomicU32,
+    succeeded: u32,
+    failed: u32,
 }
 
 impl PerfInformer {
     fn new() -> Self {
         Self {
-            succeeded: AtomicU32::new(0),
-            failed: AtomicU32::new(0),
+            succeeded: 0,
+            failed: 0,
         }
     }
 
     fn print_summary(&self, task_num: i32, duration_ms: u128) {
-        let succeeded = self.succeeded.load(Ordering::Relaxed);
-        let failed = self.failed.load(Ordering::Relaxed);
         let duration_secs = duration_ms as f64 / 1000.0;
         let throughput = if duration_secs > 0.0 {
-            succeeded as f64 / duration_secs
+            self.succeeded as f64 / duration_secs
         } else {
             0.0
         };
@@ -247,8 +236,8 @@ impl PerfInformer {
         println!("BENCHMARK RESULTS");
         println!("{}", "=".repeat(60));
         println!("Duration:        {:.2}s", duration_secs);
-        println!("Succeeded:       {}/{}", succeeded, task_num);
-        println!("Failed:          {}", failed);
+        println!("Succeeded:       {}/{}", self.succeeded, task_num);
+        println!("Failed:          {}", self.failed);
         println!("Throughput:      {:.2} tasks/sec", throughput);
         println!("{}\n", "=".repeat(60));
     }
@@ -258,14 +247,14 @@ impl TaskInformer for PerfInformer {
     fn on_update(&mut self, task: Task) {
         if task.is_completed() {
             if task.is_succeed() {
-                self.succeeded.fetch_add(1, Ordering::Relaxed);
+                self.succeeded += 1;
             } else {
-                self.failed.fetch_add(1, Ordering::Relaxed);
+                self.failed += 1;
             }
         }
     }
 
     fn on_error(&mut self, _: FlameError) {
-        self.failed.fetch_add(1, Ordering::Relaxed);
+        self.failed += 1;
     }
 }

--- a/flmping/src/client.rs
+++ b/flmping/src/client.rs
@@ -14,6 +14,7 @@ limitations under the License.
 mod apis;
 
 use std::error::Error;
+use std::sync::atomic::{AtomicU32, Ordering};
 use std::time::Instant;
 
 use byte_unit::Byte;
@@ -21,7 +22,7 @@ use clap::Parser;
 use comfy_table::presets::NOTHING;
 use comfy_table::Table;
 use flame_rs::apis::FlameError;
-use flame_rs::client::{SessionAttributes, Task, TaskInformer};
+use flame_rs::client::{Session, SessionAttributes, Task, TaskInformer};
 use futures::future::try_join_all;
 use indicatif::HumanCount;
 use stdng::{lock_ptr, new_ptr};
@@ -55,6 +56,9 @@ struct Cli {
     /// The memory (bytes) to allocate to the tasks
     #[arg(short, long)]
     memory: Option<String>,
+    /// Performance benchmark mode (summary only, no per-task output)
+    #[arg(short, long, default_value = "false")]
+    perf: bool,
 }
 
 const DEFAULT_APP: &str = "flmping";
@@ -99,26 +103,66 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .as_millis();
     println!("Session <{}> was created in <{ssn_creation_time} ms>, start to run <{}> tasks in the session:\n", ssn.id, HumanCount(task_num as u64));
 
-    let mut tasks = vec![];
-    let tasks_creations_start_time = Instant::now();
-
-    let info = new_ptr(OutputInfor::new());
-
-    for _ in 0..task_num {
-        let input = PingRequest {
-            duration: cli.duration,
-            memory,
-        }
-        .try_into()?;
-        tasks.push(ssn.run_task(Some(input), info.clone()));
+    if cli.perf {
+        run_perf_mode(&ssn, task_num, cli.duration, memory).await?;
+    } else {
+        run_output_mode(&ssn, task_num, cli.duration, memory).await?;
     }
 
-    try_join_all(tasks).await?;
-    let tasks_creation_end_time = Instant::now();
+    ssn.close().await?;
 
-    let tasks_creation_time = tasks_creation_end_time
-        .duration_since(tasks_creations_start_time)
-        .as_millis();
+    Ok(())
+}
+
+async fn run_perf_mode(
+    ssn: &Session,
+    task_num: i32,
+    duration: Option<u64>,
+    memory: Option<u64>,
+) -> Result<(), Box<dyn Error>> {
+    let info = new_ptr(PerfInformer::new());
+    let start = Instant::now();
+
+    let tasks: Vec<_> = (0..task_num)
+        .map(|_| {
+            let input = PingRequest { duration, memory }.try_into();
+            async {
+                let input = input?;
+                ssn.run_task(Some(input), info.clone()).await
+            }
+        })
+        .collect();
+
+    try_join_all(tasks).await?;
+    let duration_ms = start.elapsed().as_millis();
+
+    let info = lock_ptr!(info)?;
+    info.print_summary(task_num, duration_ms);
+
+    Ok(())
+}
+
+async fn run_output_mode(
+    ssn: &Session,
+    task_num: i32,
+    duration: Option<u64>,
+    memory: Option<u64>,
+) -> Result<(), Box<dyn Error>> {
+    let info = new_ptr(OutputInfor::new());
+    let start = Instant::now();
+
+    let tasks: Vec<_> = (0..task_num)
+        .map(|_| {
+            let input = PingRequest { duration, memory }.try_into();
+            async {
+                let input = input?;
+                ssn.run_task(Some(input), info.clone()).await
+            }
+        })
+        .collect();
+
+    try_join_all(tasks).await?;
+    let duration_ms = start.elapsed().as_millis();
 
     {
         let info = lock_ptr!(info)?;
@@ -128,10 +172,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
     println!(
         "\n\n<{}> tasks was completed in <{} ms>.\n",
         HumanCount(task_num as u64),
-        HumanCount(tasks_creation_time as u64)
+        HumanCount(duration_ms as u64)
     );
-
-    ssn.close().await?;
 
     Ok(())
 }
@@ -175,5 +217,55 @@ impl TaskInformer for OutputInfor {
 impl OutputInfor {
     fn print(&self) {
         println!("{}", self.table);
+    }
+}
+
+struct PerfInformer {
+    succeeded: AtomicU32,
+    failed: AtomicU32,
+}
+
+impl PerfInformer {
+    fn new() -> Self {
+        Self {
+            succeeded: AtomicU32::new(0),
+            failed: AtomicU32::new(0),
+        }
+    }
+
+    fn print_summary(&self, task_num: i32, duration_ms: u128) {
+        let succeeded = self.succeeded.load(Ordering::Relaxed);
+        let failed = self.failed.load(Ordering::Relaxed);
+        let duration_secs = duration_ms as f64 / 1000.0;
+        let throughput = if duration_secs > 0.0 {
+            succeeded as f64 / duration_secs
+        } else {
+            0.0
+        };
+
+        println!("\n{}", "=".repeat(60));
+        println!("BENCHMARK RESULTS");
+        println!("{}", "=".repeat(60));
+        println!("Duration:        {:.2}s", duration_secs);
+        println!("Succeeded:       {}/{}", succeeded, task_num);
+        println!("Failed:          {}", failed);
+        println!("Throughput:      {:.2} tasks/sec", throughput);
+        println!("{}\n", "=".repeat(60));
+    }
+}
+
+impl TaskInformer for PerfInformer {
+    fn on_update(&mut self, task: Task) {
+        if task.is_completed() {
+            if task.is_succeed() {
+                self.succeeded.fetch_add(1, Ordering::Relaxed);
+            } else {
+                self.failed.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+    }
+
+    fn on_error(&mut self, _: FlameError) {
+        self.failed.fetch_add(1, Ordering::Relaxed);
     }
 }

--- a/perf/ray/compose.yaml
+++ b/perf/ray/compose.yaml
@@ -17,6 +17,7 @@ services:
       --block
     volumes:
       - ray-data:/tmp/ray
+      - ./:/opt/ray
     healthcheck:
       test: ["CMD", "ray", "status"]
       interval: 10s

--- a/perf/ray/main.py
+++ b/perf/ray/main.py
@@ -17,9 +17,7 @@ from dataclasses import dataclass
 
 import ray
 
-NUM_SESSIONS = 3
-TASKS_PER_SESSION = 300
-TOTAL_TASKS = NUM_SESSIONS * TASKS_PER_SESSION
+TOTAL_TASKS = 900
 TIMEOUT_SECS = 600
 
 
@@ -35,59 +33,34 @@ class BenchmarkResult:
 
 
 @ray.remote
-def benchmark_task(session_id: int, task_id: int, input: bytes) -> bytes:
-    return b"ok" 
-
-
-@ray.remote
-def run_session(session_id: int, tasks_per_session: int) -> tuple[int, int]:
-    task_refs = [
-        benchmark_task.remote(session_id, task_id, b"benchmark")
-        for task_id in range(tasks_per_session)
-    ]
-
-    succeeded = 0
-    failed = 0
-
-    results = ray.get(task_refs)
-    for result in results:
-        if result:
-            succeeded += 1
-        else:
-            failed += 1
-
-    return succeeded, failed
+def benchmark_task(task_id: int, input: bytes) -> bytes:
+    return b"ok"
 
 
 def run_benchmark(
-    num_sessions: int = NUM_SESSIONS,
-    tasks_per_session: int = TASKS_PER_SESSION,
+    total_tasks: int = TOTAL_TASKS,
 ) -> BenchmarkResult:
-    total_tasks = num_sessions * tasks_per_session
-
     print("\n" + "=" * 60)
-    print(
-        f"BENCHMARK: {num_sessions} sessions × {tasks_per_session} tasks = {total_tasks} total"
-    )
+    print(f"BENCHMARK: {total_tasks} tasks")
     print("=" * 60 + "\n")
 
     start = time.perf_counter()
 
-    session_refs = [
-        run_session.remote(session_id, tasks_per_session)
-        for session_id in range(num_sessions)
+    task_refs = [
+        benchmark_task.remote(task_id, b"benchmark")
+        for task_id in range(total_tasks)
     ]
 
-    results = ray.get(session_refs)
+    results = ray.get(task_refs)
 
     duration = time.perf_counter() - start
 
-    total_succeeded = sum(r[0] for r in results)
-    total_failed = sum(r[1] for r in results)
+    succeeded = sum(1 for r in results if r)
+    failed = sum(1 for r in results if not r)
 
     return BenchmarkResult(
-        succeeded=total_succeeded,
-        failed=total_failed,
+        succeeded=succeeded,
+        failed=failed,
         duration_secs=duration,
     )
 
@@ -111,16 +84,10 @@ def main():
         help="Ray cluster address (default: auto, use 'ray://<ip>:10001' for Ray Client)",
     )
     parser.add_argument(
-        "--sessions",
-        type=int,
-        default=NUM_SESSIONS,
-        help=f"Number of concurrent sessions (default: {NUM_SESSIONS})",
-    )
-    parser.add_argument(
         "--tasks",
         type=int,
-        default=TASKS_PER_SESSION,
-        help=f"Tasks per session (default: {TASKS_PER_SESSION})",
+        default=TOTAL_TASKS,
+        help=f"Total number of tasks (default: {TOTAL_TASKS})",
     )
     parser.add_argument(
         "--timeout",
@@ -130,24 +97,19 @@ def main():
     )
     args = parser.parse_args()
 
-    total_tasks = args.sessions * args.tasks
-
     if args.address == "auto":
         ray.init()
     else:
         ray.init(args.address)
 
     try:
-        result = run_benchmark(
-            num_sessions=args.sessions,
-            tasks_per_session=args.tasks,
-        )
+        result = run_benchmark(total_tasks=args.tasks)
 
-        print_results(result, total_tasks)
+        print_results(result, args.tasks)
 
         assert result.failed == 0, f"Benchmark had {result.failed} failed tasks"
-        assert result.succeeded == total_tasks, (
-            f"Not all tasks succeeded: {result.succeeded}/{total_tasks}"
+        assert result.succeeded == args.tasks, (
+            f"Not all tasks succeeded: {result.succeeded}/{args.tasks}"
         )
         assert result.duration_secs < args.timeout, (
             f"Benchmark exceeded {args.timeout}s timeout: {result.duration_secs:.2f}s"


### PR DESCRIPTION
## Summary

- Make WASM shim optional via `wasm` feature flag in executor_manager
- Add `--perf/-p` flag to flmping for benchmark mode

## Changes

### WASM Feature Flag
- `wasmtime` and `wasmtime-wasi` dependencies are now optional
- Build without WASM: `cargo build -p flame-executor-manager`
- Build with WASM: `cargo build -p flame-executor-manager --features wasm`
- Returns clear error when WASM shim requested but feature disabled

### flmping Perf Mode
- New `--perf/-p` flag shows throughput summary instead of per-task output
- Useful for performance testing with large task counts
- Example: `flmping -p -t 15000 -s 4`

```
root@15790c6216ec:/# flmping -p -t 15000
Session <flmping-d2HrU2> was created in <0 ms>, start to run <15,000> tasks in the session:


============================================================
BENCHMARK RESULTS
============================================================
Duration:        1.82s
Succeeded:       15000/15000
Failed:          0
Throughput:      8259.91 tasks/sec
============================================================

```