### PR TITLE
[codex] fix flamepy review findings

### DIFF
--- a/object_cache/src/cache.rs
+++ b/object_cache/src/cache.rs
@@ -139,6 +139,8 @@ impl ObjectKey {
     pub fn matches(&self, key_str: &str) -> bool {
         if self.is_all_sessions() {
             key_str.starts_with(&format!("{}/", self.app_name))
+        } else if let Some(full_key) = self.to_key() {
+            key_str == full_key
         } else {
             key_str.starts_with(&format!("{}/", self.to_prefix()))
         }
@@ -1467,6 +1469,19 @@ mod tests {
         }
 
         #[test]
+        fn object_key_matches_exact_full_key() {
+            let full_key = ObjectKey::from_path("app/session/uuid").unwrap();
+            let session_key = ObjectKey::from_path("app/session").unwrap();
+            let app_key = ObjectKey::from_path("app/*").unwrap();
+
+            assert!(full_key.matches("app/session/uuid"));
+            assert!(!full_key.matches("app/session/other"));
+            assert!(session_key.matches("app/session/uuid"));
+            assert!(session_key.matches("app/session/other"));
+            assert!(app_key.matches("app/other/uuid"));
+        }
+
+        #[test]
         fn object_key_with_generated_id() {
             let key = ObjectKey::from_path("app/session").unwrap();
             assert!(key.object_id.is_none());
@@ -1762,6 +1777,28 @@ mod tests {
             let all = cache.list_all().await.unwrap();
             assert_eq!(all.len(), 1);
             assert!(all[0].key.starts_with("app/other-session/"));
+        }
+
+        #[tokio::test]
+        async fn delete_removes_exact_object() {
+            let cache = create_test_cache().await;
+
+            let key = ObjectKey::from_path("app/session").unwrap();
+            let meta1 = cache
+                .put(key.clone(), Object::new(0, vec![1]))
+                .await
+                .unwrap();
+            let meta2 = cache
+                .put(key.clone(), Object::new(0, vec![2]))
+                .await
+                .unwrap();
+
+            let delete_key = ObjectKey::from_path(&meta1.key).unwrap();
+            cache.delete(&delete_key).await.unwrap();
+
+            let all = cache.list_all().await.unwrap();
+            assert_eq!(all.len(), 1);
+            assert_eq!(all[0].key, meta2.key);
         }
 
         #[tokio::test]

--- a/object_cache/src/storage/disk.rs
+++ b/object_cache/src/storage/disk.rs
@@ -176,16 +176,34 @@ impl StorageEngine for DiskStorage {
     }
 
     async fn delete_objects(&self, key: &ObjectKey) -> Result<(), FlameError> {
-        let dir_to_delete = if key.is_all_sessions() {
-            self.app_dir(key)
+        let object_path = key.object_id.as_ref().map(|_| self.object_path(key));
+        let delta_dir = key.object_id.as_ref().map(|_| self.delta_dir(key));
+        let dir_to_delete = if object_path.is_none() && key.is_all_sessions() {
+            Some(self.app_dir(key))
+        } else if object_path.is_none() {
+            Some(self.session_dir(key))
         } else {
-            self.session_dir(key)
+            None
         };
 
         tokio::task::spawn_blocking(move || {
-            if dir_to_delete.exists() {
-                fs::remove_dir_all(&dir_to_delete)?;
-                tracing::debug!("Deleted directory: {:?}", dir_to_delete);
+            if let Some(path) = object_path {
+                if path.exists() {
+                    fs::remove_file(&path)?;
+                    tracing::debug!("Deleted object file: {:?}", path);
+                }
+            }
+            if let Some(path) = delta_dir {
+                if path.exists() {
+                    fs::remove_dir_all(&path)?;
+                    tracing::debug!("Deleted delta directory: {:?}", path);
+                }
+            }
+            if let Some(path) = dir_to_delete {
+                if path.exists() {
+                    fs::remove_dir_all(&path)?;
+                    tracing::debug!("Deleted directory: {:?}", path);
+                }
             }
             Ok(())
         })
@@ -540,6 +558,28 @@ mod tests {
 
         assert!(storage.read_object(&key1).await.unwrap().is_none());
         assert!(storage.read_object(&key2).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_disk_storage_delete_exact_object() {
+        let temp_dir = tempdir().unwrap();
+        let storage = DiskStorage::new(temp_dir.path().to_path_buf()).unwrap();
+
+        let key1 = test_key("test-app", "test-session", "obj1");
+        let key2 = test_key("test-app", "test-session", "obj2");
+        storage
+            .write_object(&key1, &Object::new(1, vec![1, 2, 3]))
+            .await
+            .unwrap();
+        storage
+            .write_object(&key2, &Object::new(2, vec![4, 5, 6]))
+            .await
+            .unwrap();
+
+        storage.delete_objects(&key1).await.unwrap();
+
+        assert!(storage.read_object(&key1).await.unwrap().is_none());
+        assert!(storage.read_object(&key2).await.unwrap().is_some());
     }
 
     #[tokio::test]

--- a/object_cache/src/storage/disk.rs
+++ b/object_cache/src/storage/disk.rs
@@ -575,10 +575,17 @@ mod tests {
             .write_object(&key2, &Object::new(2, vec![4, 5, 6]))
             .await
             .unwrap();
+        storage
+            .patch_object(&key1, &Object::new(0, vec![7]))
+            .await
+            .unwrap();
+        let key1_delta_dir = storage.delta_dir(&key1);
+        assert!(key1_delta_dir.exists());
 
         storage.delete_objects(&key1).await.unwrap();
 
         assert!(storage.read_object(&key1).await.unwrap().is_none());
+        assert!(!key1_delta_dir.exists());
         assert!(storage.read_object(&key2).await.unwrap().is_some());
     }
 

--- a/sdk/python/src/flamepy/agent/instance.py
+++ b/sdk/python/src/flamepy/agent/instance.py
@@ -78,11 +78,16 @@ class FlameInstance(FlameService):
         logger.debug(f"entrypoint: {func.__name__}")
 
         sig = inspect.signature(func)
-        self._entrypoint = func
         assert len(sig.parameters) == 1 or len(sig.parameters) == 0, "Entrypoint must have exactly zero or one parameter"
+
+        parameter = None
         for param in sig.parameters.values():
             assert param.kind == inspect.Parameter.POSITIONAL_OR_KEYWORD, "Parameter must be positional or keyword"
-            self._parameter = param
+            parameter = param
+
+        self._entrypoint = func
+        self._parameter = parameter
+        return func
 
     def on_session_enter(self, context: SessionContext):
         logger = logging.getLogger(__name__)
@@ -116,11 +121,9 @@ class FlameInstance(FlameService):
         logger.debug(f"on_task_invoke: {res}")
 
         # For agent module: serialize output with cloudpickle, return bytes
-        output_bytes = None
-        if res is not None:
-            output_bytes = cloudpickle.dumps(res, protocol=cloudpickle.DEFAULT_PROTOCOL)
-
-        return TaskOutput(output_bytes)
+        if res is None:
+            return None
+        return TaskOutput(cloudpickle.dumps(res, protocol=cloudpickle.DEFAULT_PROTOCOL))
 
     def on_session_leave(self):
         logger = logging.getLogger(__name__)

--- a/sdk/python/src/flamepy/core/cache.py
+++ b/sdk/python/src/flamepy/core/cache.py
@@ -166,10 +166,10 @@ def _cache_remove(key: tuple) -> None:
         _object_cache.pop(key, None)
 
 
-def _cache_remove_prefix(prefix: str) -> None:
-    """Remove all entries matching prefix."""
+def _cache_remove_matching(object_key: "ObjectKey") -> None:
+    """Remove all entries matched by an ObjectKey."""
     with _cache_lock:
-        keys_to_remove = [k for k in _object_cache if k[1].startswith(prefix)]
+        keys_to_remove = [k for k in _object_cache if object_key.matches_key(k[1])]
         for key in keys_to_remove:
             _object_cache.pop(key, None)
 
@@ -238,6 +238,8 @@ class ObjectKey:
     def __post_init__(self):
         if not self.app_name:
             raise ValueError("app_name cannot be empty")
+        if self.app_name == WILDCARD_SESSION:
+            raise ValueError("Wildcard '*' not allowed for app_name")
         if ".." in self.app_name or "\\" in self.app_name or "/" in self.app_name:
             raise ValueError(f"app_name contains invalid characters: '{self.app_name}'")
 
@@ -255,24 +257,39 @@ class ObjectKey:
                 raise ValueError("Wildcard session '*' cannot have object_id")
             if not self.object_id:
                 raise ValueError("object_id cannot be empty string")
-            if ".." in self.object_id or "\\" in self.object_id:
+            if self.object_id == WILDCARD_SESSION:
+                raise ValueError("Wildcard '*' not allowed for object_id")
+            if ".." in self.object_id or "\\" in self.object_id or "/" in self.object_id:
                 raise ValueError(f"object_id contains invalid characters: '{self.object_id}'")
+
+    @classmethod
+    def from_path(cls, path: str) -> "ObjectKey":
+        """Parse from key prefix or full key.
+
+        Accepts '<app>/<ssn>' prefixes and '<app>/<ssn>/<uuid>' full keys.
+        """
+        parts = path.split("/")
+        if len(parts) == 2:
+            return cls(app_name=parts[0], session_id=parts[1], object_id=None)
+        if len(parts) == 3:
+            return cls(app_name=parts[0], session_id=parts[1], object_id=parts[2])
+        raise ValueError(f"Invalid object key path '{path}': expected '<app>/<ssn>' or '<app>/<ssn>/<uuid>' format")
 
     @classmethod
     def from_prefix(cls, prefix: str) -> "ObjectKey":
         """Parse from key prefix '<app>/<ssn>'."""
-        parts = prefix.split("/")
-        if len(parts) != 2:
+        key = cls.from_path(prefix)
+        if key.object_id is not None:
             raise ValueError(f"Invalid key prefix '{prefix}': expected '<app>/<ssn>' format")
-        return cls(app_name=parts[0], session_id=parts[1], object_id=None)
+        return key
 
     @classmethod
     def from_key(cls, key: str) -> "ObjectKey":
         """Parse from full key '<app>/<ssn>/<uuid>'."""
-        parts = key.split("/")
-        if len(parts) != 3:
+        object_key = cls.from_path(key)
+        if object_key.object_id is None:
             raise ValueError(f"Invalid object key '{key}': expected '<app>/<ssn>/<uuid>' format")
-        return cls(app_name=parts[0], session_id=parts[1], object_id=parts[2])
+        return object_key
 
     @classmethod
     def for_shared(cls, app_name: str) -> "ObjectKey":
@@ -305,6 +322,19 @@ class ObjectKey:
         if self.object_id is None:
             return None
         return f"{self.app_name}/{self.session_id}/{self.object_id}"
+
+    def matches_key(self, key: str) -> bool:
+        """Return True if this prefix/full ObjectKey matches a full object key."""
+        try:
+            object_key = ObjectKey.from_key(key)
+        except ValueError:
+            return False
+
+        if self.is_all_sessions():
+            return object_key.app_name == self.app_name
+        if self.object_id is None:
+            return object_key.app_name == self.app_name and object_key.session_id == self.session_id
+        return object_key == self
 
     def __str__(self) -> str:
         return self.to_key() or self.to_prefix()
@@ -898,17 +928,20 @@ def patch_object(ref: ObjectRef, delta: Any) -> "ObjectRef":
 
 
 def delete_objects(key_prefix: str) -> None:
-    """Delete all objects under a key prefix from the cache.
+    """Delete objects matching a key or key prefix from the cache.
 
-    This deletes all objects matching the prefix pattern from the server.
+    This deletes all objects matching the key or prefix pattern from the server.
     Also clears any matching entries from the client-side cache.
 
     Args:
-        key_prefix: Key prefix in format "<app>/*" (all sessions) or "<app>/<session>"
+        key_prefix: Key in format "<app>/<session>/<object>" or key prefix in
+            format "<app>/*" (all sessions) or "<app>/<session>"
 
     Raises:
         ValueError: If key_prefix format is invalid or cache not configured
     """
+    object_key = ObjectKey.from_path(key_prefix)
+
     context = _get_cached_context()
     cache_config = context.cache
 
@@ -930,18 +963,13 @@ def delete_objects(key_prefix: str) -> None:
 
     client = _get_flight_client(cache_endpoint, cache_tls)
 
-    action = flight.Action("DELETE", key_prefix.encode("utf-8"))
+    action = flight.Action("DELETE", str(object_key).encode("utf-8"))
     results = list(client.do_action(action))
 
     if not results:
         raise ValueError("No result received from DELETE action")
 
-    if key_prefix.endswith("/*"):
-        app_prefix = key_prefix[:-1]
-    else:
-        app_prefix = f"{key_prefix}/"
-
-    _cache_remove_prefix(app_prefix)
+    _cache_remove_matching(object_key)
 
 
 _UPLOAD_CHUNK_SIZE = 1024 * 1024  # 1MB
@@ -968,12 +996,8 @@ def upload_object(key_or_prefix: str, file_path: str) -> ObjectRef:
     if not os.path.exists(file_path):
         raise FileNotFoundError(f"File not found: {file_path}")
 
-    parts = key_or_prefix.split("/")
-    if len(parts) == 2:
-        ObjectKey.from_prefix(key_or_prefix)
-    elif len(parts) == 3:
-        ObjectKey.from_key(key_or_prefix)
-    else:
+    object_key = ObjectKey.from_path(key_or_prefix)
+    if object_key.is_all_sessions():
         raise ValueError(f"Invalid key format: {key_or_prefix}")
 
     context = _get_cached_context()
@@ -1003,7 +1027,7 @@ def upload_object(key_or_prefix: str, file_path: str) -> ObjectRef:
     )
 
     client = _get_flight_client(cache_endpoint, cache_tls)
-    descriptor = flight.FlightDescriptor.for_path(key_or_prefix)
+    descriptor = flight.FlightDescriptor.for_path(str(object_key))
     options = flight.FlightCallOptions(timeout=300)
 
     file_size = os.path.getsize(file_path)

--- a/sdk/python/src/flamepy/core/cache.py
+++ b/sdk/python/src/flamepy/core/cache.py
@@ -325,16 +325,20 @@ class ObjectKey:
 
     def matches_key(self, key: str) -> bool:
         """Return True if this prefix/full ObjectKey matches a full object key."""
-        try:
-            object_key = ObjectKey.from_key(key)
-        except ValueError:
-            return False
-
         if self.is_all_sessions():
-            return object_key.app_name == self.app_name
+            prefix = f"{self.app_name}/"
+            if not key.startswith(prefix):
+                return False
+            suffix = key[len(prefix) :]
+            session_id, separator, object_id = suffix.partition("/")
+            return bool(session_id and separator and object_id) and "/" not in object_id
         if self.object_id is None:
-            return object_key.app_name == self.app_name and object_key.session_id == self.session_id
-        return object_key == self
+            prefix = f"{self.app_name}/{self.session_id}/"
+            if not key.startswith(prefix):
+                return False
+            object_id = key[len(prefix) :]
+            return bool(object_id) and "/" not in object_id
+        return key == self.to_key()
 
     def __str__(self) -> str:
         return self.to_key() or self.to_prefix()

--- a/sdk/python/src/flamepy/core/client.py
+++ b/sdk/python/src/flamepy/core/client.py
@@ -65,6 +65,44 @@ from flamepy.proto.types_pb2 import ResourceRequirement as ResourceRequirementPr
 logger = logging.getLogger(__name__)
 
 
+def _optional_field(message: Any, field: str) -> Any:
+    return getattr(message, field) if message.HasField(field) else None
+
+
+def _schema_from_application_spec(spec: ApplicationSpec) -> Optional[ApplicationSchema]:
+    if not spec.HasField("schema"):
+        return None
+    return ApplicationSchema(
+        input=_optional_field(spec.schema, "input"),
+        output=_optional_field(spec.schema, "output"),
+        common_data=_optional_field(spec.schema, "common_data"),
+    )
+
+
+def _application_from_proto(app) -> Application:
+    spec = app.spec
+    environments = {env.name: env.value for env in spec.environments}
+    return Application(
+        id=app.metadata.id,
+        name=app.metadata.name,
+        state=ApplicationState(app.status.state),
+        creation_time=datetime.fromtimestamp(app.status.creation_time / 1000, tz=timezone.utc),
+        shim=Shim(spec.shim),
+        image=_optional_field(spec, "image"),
+        description=_optional_field(spec, "description"),
+        labels=list(spec.labels),
+        command=_optional_field(spec, "command"),
+        arguments=list(spec.arguments),
+        environments=environments,
+        working_directory=_optional_field(spec, "working_directory"),
+        max_instances=_optional_field(spec, "max_instances"),
+        delay_release=_optional_field(spec, "delay_release"),
+        schema=_schema_from_application_spec(spec),
+        url=_optional_field(spec, "url"),
+        installer=_optional_field(spec, "installer"),
+    )
+
+
 def connect(addr: str, tls_config: Optional[FlameClientTls] = None) -> "Connection":
     """Connect to the Flame service.
 
@@ -342,39 +380,7 @@ class Connection:
         try:
             response = self._frontend.ListApplication(request)
 
-            applications = []
-            for app in response.applications:
-                schema = None
-                if app.spec.schema is not None:
-                    schema = ApplicationSchema(
-                        input=app.spec.schema.input,
-                        output=app.spec.schema.output,
-                        common_data=app.spec.schema.common_data,
-                    )
-                environments = {}
-                if app.spec.environments is not None:
-                    for env in app.spec.environments:
-                        environments[env.name] = env.value
-
-                applications.append(
-                    Application(
-                        id=app.metadata.id,
-                        name=app.metadata.name,
-                        state=ApplicationState(app.status.state),
-                        creation_time=datetime.fromtimestamp(app.status.creation_time / 1000, tz=timezone.utc),
-                        shim=Shim(app.spec.shim),
-                        image=app.spec.image,
-                        command=app.spec.command,
-                        arguments=list(app.spec.arguments),
-                        environments=environments,
-                        working_directory=app.spec.working_directory,
-                        max_instances=app.spec.max_instances,
-                        delay_release=app.spec.delay_release,
-                        schema=schema,
-                        url=app.spec.url if app.spec.HasField("url") else None,
-                        installer=app.spec.installer if app.spec.HasField("installer") else None,
-                    )
-                )
+            applications = [_application_from_proto(app) for app in response.applications]
 
             return applications
 
@@ -387,36 +393,7 @@ class Connection:
 
         try:
             response = self._frontend.GetApplication(request)
-            schema = None
-            if response.spec.schema is not None:
-                schema = ApplicationSchema(
-                    input=response.spec.schema.input,
-                    output=response.spec.schema.output,
-                    common_data=response.spec.schema.common_data,
-                )
-
-            environments = {}
-            if response.spec.environments is not None:
-                for env in response.spec.environments:
-                    environments[env.name] = env.value
-
-            return Application(
-                id=response.metadata.id,
-                name=response.metadata.name,
-                state=ApplicationState(response.status.state),
-                creation_time=datetime.fromtimestamp(response.status.creation_time / 1000, tz=timezone.utc),
-                shim=Shim(response.spec.shim),
-                image=response.spec.image,
-                command=response.spec.command,
-                arguments=list(response.spec.arguments),
-                environments=environments,
-                working_directory=response.spec.working_directory,
-                max_instances=response.spec.max_instances,
-                delay_release=response.spec.delay_release,
-                schema=schema,
-                url=response.spec.url if response.spec.HasField("url") else None,
-                installer=response.spec.installer if response.spec.HasField("installer") else None,
-            )
+            return _application_from_proto(response)
 
         except grpc.RpcError as e:
             if e.code() == grpc.StatusCode.NOT_FOUND:
@@ -454,7 +431,7 @@ class Connection:
         try:
             response = self._frontend.CreateSession(request)
             # Common data is bytes in core API
-            common_data_bytes = response.spec.common_data if response.spec.HasField("common_data") and response.spec.common_data else None
+            common_data_bytes = response.spec.common_data if response.spec.HasField("common_data") else None
 
             session = Session(
                 connection=self,
@@ -483,7 +460,7 @@ class Connection:
             sessions = []
             for session in response.sessions:
                 # Common data is bytes in core API
-                common_data_bytes = session.spec.common_data if session.spec.HasField("common_data") and session.spec.common_data else None
+                common_data_bytes = session.spec.common_data if session.spec.HasField("common_data") else None
 
                 sessions.append(
                     Session(
@@ -540,7 +517,7 @@ class Connection:
         try:
             response = self._frontend.OpenSession(request)
             # Common data is bytes in core API
-            common_data_bytes = response.spec.common_data if response.spec.HasField("common_data") and response.spec.common_data else None
+            common_data_bytes = response.spec.common_data if response.spec.HasField("common_data") else None
 
             return Session(
                 connection=self,
@@ -567,7 +544,7 @@ class Connection:
             response = self._frontend.GetSession(request)
 
             # Common data is bytes in core API
-            common_data_bytes = response.spec.common_data if response.spec.HasField("common_data") and response.spec.common_data else None
+            common_data_bytes = response.spec.common_data if response.spec.HasField("common_data") else None
 
             return Session(
                 connection=self,
@@ -594,7 +571,7 @@ class Connection:
             response = self._frontend.CloseSession(request)
 
             # Common data is bytes in core API
-            common_data_bytes = response.spec.common_data if response.spec.HasField("common_data") and response.spec.common_data else None
+            common_data_bytes = response.spec.common_data if response.spec.HasField("common_data") else None
 
             return Session(
                 connection=self,
@@ -709,8 +686,8 @@ class Session:
                 session_id=self.id,
                 state=TaskState(response.status.state),
                 creation_time=datetime.fromtimestamp(response.status.creation_time / 1000, tz=timezone.utc),
-                input=response.spec.input if response.spec.HasField("input") and response.spec.input else None,
-                output=response.spec.output if response.spec.HasField("output") and response.spec.output else None,
+                input=response.spec.input if response.spec.HasField("input") else None,
+                output=response.spec.output if response.spec.HasField("output") else None,
                 completion_time=(datetime.fromtimestamp(response.status.completion_time / 1000, tz=timezone.utc) if response.status.HasField("completion_time") else None),
                 events=[
                     Event(
@@ -835,8 +812,8 @@ def _task_from_proto(response, session_id: str) -> Task:
         session_id=session_id,
         state=TaskState(response.status.state),
         creation_time=datetime.fromtimestamp(response.status.creation_time / 1000, tz=timezone.utc),
-        input=response.spec.input if response.spec.HasField("input") and response.spec.input else None,
-        output=response.spec.output if response.spec.HasField("output") and response.spec.output else None,
+        input=response.spec.input if response.spec.HasField("input") else None,
+        output=response.spec.output if response.spec.HasField("output") else None,
         completion_time=(datetime.fromtimestamp(response.status.completion_time / 1000, tz=timezone.utc) if response.status.HasField("completion_time") else None),
         events=[
             Event(

--- a/sdk/python/src/flamepy/core/service.py
+++ b/sdk/python/src/flamepy/core/service.py
@@ -154,7 +154,7 @@ class FlameInstanceServicer(InstanceServicer):
             logger.debug(f"app_context: {app_context}")
 
             # Common data is bytes in core API
-            common_data_bytes = request.common_data if request.HasField("common_data") and request.common_data else None
+            common_data_bytes = request.common_data if request.HasField("common_data") else None
 
             session_context = SessionContext(
                 _common_data=common_data_bytes,
@@ -185,7 +185,7 @@ class FlameInstanceServicer(InstanceServicer):
         try:
             # Convert protobuf request to TaskContext
             # Task input is bytes in core API
-            input_bytes = request.input if request.HasField("input") and request.input else None
+            input_bytes = request.input if request.HasField("input") else None
 
             task_context = TaskContext(
                 task_id=request.task_id,
@@ -199,7 +199,9 @@ class FlameInstanceServicer(InstanceServicer):
             output_data = self._service.on_task_invoke(task_context)
             logger.debug("on_task_invoke completed successfully")
 
-            # Return task output
+            # Return task output. Leave optional output unset for services that intentionally return None.
+            if output_data is None:
+                return TaskResultProto(return_code=0, message=None)
             return TaskResultProto(return_code=0, output=output_data, message=None)
 
         except Exception as e:

--- a/sdk/python/src/flamepy/runner/runner.py
+++ b/sdk/python/src/flamepy/runner/runner.py
@@ -263,6 +263,13 @@ class RunnerService:
             if not callable(attr):
                 continue
 
+            if hasattr(type(self), attr_name) or attr_name in self.__dict__:
+                logger.warning(
+                    "Skipping wrapper for method '%s' because it conflicts with RunnerService",
+                    attr_name,
+                )
+                continue
+
             # Create a wrapper for this method
             wrapper = self._create_method_wrapper(attr_name)
             setattr(self, attr_name, wrapper)

--- a/sdk/python/src/flamepy/runner/runpy.py
+++ b/sdk/python/src/flamepy/runner/runpy.py
@@ -90,9 +90,6 @@ class FlameRunpyService(FlameService):
         if isinstance(value, ObjectRef):
             logger.debug(f"Resolving ObjectRef: {value}")
             resolved_value = get_object(value)
-            if resolved_value is None:
-                raise ValueError(f"Failed to retrieve ObjectRef from cache: {value}")
-
             logger.debug(f"Resolved ObjectRef to type: {type(resolved_value)}")
             return resolved_value
 
@@ -103,8 +100,6 @@ class FlameRunpyService(FlameService):
                 object_ref = ObjectRef.decode(value)
                 logger.debug(f"Decoded bytes to ObjectRef: {object_ref}")
                 resolved_value = get_object(object_ref)
-                if resolved_value is None:
-                    raise ValueError(f"Failed to retrieve ObjectRef from cache: {object_ref}")
                 logger.debug(f"Resolved ObjectRef (from bytes) to type: {type(resolved_value)}")
                 return resolved_value
             except Exception as e:
@@ -158,8 +153,6 @@ class FlameRunpyService(FlameService):
         if len(refs) == 1:
             location, original, obj_ref = refs[0]
             resolved = get_object(obj_ref)
-            if resolved is None:
-                raise ValueError(f"Failed to retrieve ObjectRef from cache: {obj_ref}")
 
             if location.startswith("arg:"):
                 idx = int(location.split(":")[1])
@@ -182,8 +175,6 @@ class FlameRunpyService(FlameService):
                 location = future_to_location[future]
                 try:
                     result = future.result()
-                    if result is None:
-                        raise ValueError(f"Failed to retrieve ObjectRef from cache at {location}")
                     resolved_values[location] = result
                 except Exception as e:
                     raise ValueError(f"Failed to resolve ObjectRef at {location}: {e}")

--- a/sdk/python/src/flamepy/runner/storage.py
+++ b/sdk/python/src/flamepy/runner/storage.py
@@ -344,13 +344,13 @@ class CacheStorage(StorageBackend):
             raise FlameError(FlameErrorCode.INTERNAL, f"Failed to download package from cache: {str(e)}")
 
     def delete(self, filename: str) -> None:
-        from flamepy.core.cache import delete_objects
+        from flamepy.core.cache import ObjectKey, delete_objects
 
         if not self._app_name:
             return
 
         try:
-            key = f"{self._app_name}/pkg/{filename}"
+            key = str(ObjectKey(app_name=self._app_name, session_id="pkg", object_id=filename))
             delete_objects(key)
             logger.debug(f"Deleted package from cache: {key}")
         except Exception as e:

--- a/sdk/python/tests/test_cache.py
+++ b/sdk/python/tests/test_cache.py
@@ -3,6 +3,7 @@ import threading
 import bson
 import numpy as np
 import pyarrow as pa
+import pytest
 
 from flamepy.core.cache import (
     _MAGIC_PREFIX_LEN,
@@ -665,8 +666,11 @@ class TestDeleteObjects:
             _object_cache[cache_key3] = Object(version=1, data="data3")
             _object_cache[cache_key4] = Object(version=1, data="data4")
 
+        action_bodies = []
+
         class MockFlightClient:
             def do_action(self, action):
+                action_bodies.append(action.body.to_pybytes().decode("utf-8"))
                 return [type("Result", (), {"body": type("Body", (), {"to_pybytes": lambda: b"OK"})()})()]
 
         class MockContext:
@@ -675,13 +679,96 @@ class TestDeleteObjects:
         monkeypatch.setattr(cache_module, "FlameContext", lambda: MockContext())
         monkeypatch.setattr(cache_module, "_get_flight_client", lambda ep, tls=None: MockFlightClient())
 
-        delete_objects("myapp")
+        delete_objects("myapp/*")
 
         with _cache_lock:
             assert cache_key1 not in _object_cache
             assert cache_key2 not in _object_cache
             assert cache_key3 not in _object_cache
             assert cache_key4 in _object_cache
+
+        assert action_bodies == ["myapp/*"]
+
+    def test_delete_objects_clears_session_without_prefix_bleed(self, monkeypatch):
+        from flamepy.core import cache as cache_module
+        from flamepy.core.types import FlameClientCache
+
+        cache_key1 = ("grpc://host:9090", "myapp/session/obj1")
+        cache_key2 = ("grpc://host:9090", "myapp/session2/obj1")
+        cache_key3 = ("grpc://host:9090", "myapp/session-extra/obj1")
+
+        with _cache_lock:
+            _object_cache[cache_key1] = Object(version=1, data="data1")
+            _object_cache[cache_key2] = Object(version=1, data="data2")
+            _object_cache[cache_key3] = Object(version=1, data="data3")
+
+        action_bodies = []
+
+        class MockFlightClient:
+            def do_action(self, action):
+                action_bodies.append(action.body.to_pybytes().decode("utf-8"))
+                return [type("Result", (), {"body": type("Body", (), {"to_pybytes": lambda: b"OK"})()})()]
+
+        class MockContext:
+            cache = FlameClientCache(endpoint="grpc://host:9090")
+
+        monkeypatch.setattr(cache_module, "FlameContext", lambda: MockContext())
+        monkeypatch.setattr(cache_module, "_get_flight_client", lambda ep, tls=None: MockFlightClient())
+
+        delete_objects("myapp/session")
+
+        with _cache_lock:
+            assert cache_key1 not in _object_cache
+            assert cache_key2 in _object_cache
+            assert cache_key3 in _object_cache
+
+        assert action_bodies == ["myapp/session"]
+
+    def test_delete_objects_clears_exact_full_key(self, monkeypatch):
+        from flamepy.core import cache as cache_module
+        from flamepy.core.types import FlameClientCache
+
+        cache_key1 = ("grpc://host:9090", "myapp/pkg/file1.tar.gz")
+        cache_key2 = ("grpc://host:9090", "myapp/pkg/file2.tar.gz")
+
+        with _cache_lock:
+            _object_cache[cache_key1] = Object(version=1, data="data1")
+            _object_cache[cache_key2] = Object(version=1, data="data2")
+
+        action_bodies = []
+
+        class MockFlightClient:
+            def do_action(self, action):
+                action_bodies.append(action.body.to_pybytes().decode("utf-8"))
+                return [type("Result", (), {"body": type("Body", (), {"to_pybytes": lambda: b"OK"})()})()]
+
+        class MockContext:
+            cache = FlameClientCache(endpoint="grpc://host:9090")
+
+        monkeypatch.setattr(cache_module, "FlameContext", lambda: MockContext())
+        monkeypatch.setattr(cache_module, "_get_flight_client", lambda ep, tls=None: MockFlightClient())
+
+        delete_objects("myapp/pkg/file1.tar.gz")
+
+        with _cache_lock:
+            assert cache_key1 not in _object_cache
+            assert cache_key2 in _object_cache
+
+        assert action_bodies == ["myapp/pkg/file1.tar.gz"]
+
+    def test_delete_objects_rejects_invalid_path_before_remote_action(self, monkeypatch):
+        from flamepy.core import cache as cache_module
+
+        def fail_get_flight_client(endpoint, tls=None):
+            raise AssertionError("remote client should not be created for invalid paths")
+
+        monkeypatch.setattr(cache_module, "_get_flight_client", fail_get_flight_client)
+
+        with pytest.raises(ValueError):
+            delete_objects("myapp")
+
+        with pytest.raises(ValueError):
+            delete_objects("a/b/c/d")
 
 
 class TestUploadDownloadObject:
@@ -788,18 +875,39 @@ class TestUploadDownloadObject:
             cache_module.upload_object("myapp/pkg/test.tar.gz", "/nonexistent/file.tar.gz")
 
     def test_upload_object_invalid_key_format(self, tmp_path):
-        import pytest
-
         from flamepy.core import cache as cache_module
 
         test_file = tmp_path / "test.tar.gz"
         test_file.write_bytes(b"test content")
 
-        with pytest.raises(ValueError, match="Invalid key format"):
+        with pytest.raises(ValueError):
             cache_module.upload_object("invalid", str(test_file))
 
-        with pytest.raises(ValueError, match="Invalid key format"):
+        with pytest.raises(ValueError):
             cache_module.upload_object("a/b/c/d", str(test_file))
+
+    @pytest.mark.parametrize(
+        "key_or_prefix",
+        [
+            "/session",
+            "app/",
+            "../session",
+            "app/../obj",
+            "app/session/",
+            "*/session",
+            "app/*",
+            "app/*/obj",
+            "app/session/*",
+        ],
+    )
+    def test_upload_object_validation_comes_from_object_key(self, key_or_prefix, tmp_path):
+        from flamepy.core import cache as cache_module
+
+        test_file = tmp_path / "test.tar.gz"
+        test_file.write_bytes(b"test content")
+
+        with pytest.raises(ValueError):
+            cache_module.upload_object(key_or_prefix, str(test_file))
 
     def test_download_object(self, monkeypatch, tmp_path):
         import pyarrow as pa
@@ -871,9 +979,14 @@ class TestObjectKey:
         assert key.session_id == "pkg"
         assert key.object_id == "file.tar.gz"
 
-    def test_from_prefix_invalid(self):
-        import pytest
+    def test_from_path_accepts_prefix_and_full_key(self):
+        prefix = ObjectKey.from_path("myapp/pkg")
+        full_key = ObjectKey.from_path("myapp/pkg/file.tar.gz")
 
+        assert prefix == ObjectKey(app_name="myapp", session_id="pkg")
+        assert full_key == ObjectKey(app_name="myapp", session_id="pkg", object_id="file.tar.gz")
+
+    def test_from_prefix_invalid(self):
         with pytest.raises(ValueError):
             ObjectKey.from_prefix("invalid")
 
@@ -881,10 +994,38 @@ class TestObjectKey:
             ObjectKey.from_prefix("a/b/c")
 
     def test_from_key_invalid(self):
-        import pytest
-
         with pytest.raises(ValueError):
             ObjectKey.from_key("a/b")
 
         with pytest.raises(ValueError):
             ObjectKey.from_key("a/b/c/d")
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/session",
+            "app/",
+            "../session",
+            "app/../obj",
+            "app/session/",
+            "*/session",
+            "app/*/obj",
+            "app/session/*",
+        ],
+    )
+    def test_from_path_rejects_invalid_components(self, path):
+        with pytest.raises(ValueError):
+            ObjectKey.from_path(path)
+
+    def test_matches_key(self):
+        all_sessions = ObjectKey.for_all_sessions("myapp")
+        session = ObjectKey.from_prefix("myapp/session")
+        exact = ObjectKey.from_key("myapp/session/obj1")
+
+        assert all_sessions.matches_key("myapp/session/obj1")
+        assert all_sessions.matches_key("myapp/other/obj2")
+        assert not all_sessions.matches_key("other/session/obj1")
+        assert session.matches_key("myapp/session/obj1")
+        assert not session.matches_key("myapp/session2/obj1")
+        assert exact.matches_key("myapp/session/obj1")
+        assert not exact.matches_key("myapp/session/obj2")

--- a/sdk/python/tests/test_cache.py
+++ b/sdk/python/tests/test_cache.py
@@ -1029,3 +1029,8 @@ class TestObjectKey:
         assert not session.matches_key("myapp/session2/obj1")
         assert exact.matches_key("myapp/session/obj1")
         assert not exact.matches_key("myapp/session/obj2")
+        assert not all_sessions.matches_key("myapp")
+        assert not all_sessions.matches_key("myapp/session")
+        assert not all_sessions.matches_key("myapp/session/obj1/extra")
+        assert not session.matches_key("myapp/session")
+        assert not session.matches_key("myapp/session/obj1/extra")

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -172,6 +172,38 @@ class TestSessionOperations:
         )
         assert session.common_data() == b"test-data"
 
+    def test_session_get_task_preserves_empty_optional_bytes(self):
+        from flamepy.core.client import Session, SessionState
+        from flamepy.proto.types_pb2 import Metadata, Task, TaskSpec, TaskStatus
+
+        class DummyFrontendWithTask:
+            def GetTask(self, req):  # noqa: N802
+                task = Task(
+                    metadata=Metadata(id="task-1"),
+                    spec=TaskSpec(session_id=req.session_id, input=b"", output=b""),
+                    status=TaskStatus(state=2, creation_time=int(time.time() * 1000)),
+                )
+                return task
+
+        connection = type("Conn", (), {"_frontend": DummyFrontendWithTask(), "_executor": None, "close": lambda self: None})()
+        session = Session(
+            connection=connection,
+            id="sess-test",
+            application="test-app",
+            state=SessionState.OPEN,
+            creation_time=datetime.now(timezone.utc),
+            pending=0,
+            running=0,
+            succeed=0,
+            failed=0,
+            completion_time=None,
+        )
+
+        task = session.get_task("task-1")
+
+        assert task.input == b""
+        assert task.output == b""
+
     def test_session_create_task_rejects_non_bytes(self):
         session = self.create_test_session()
         with pytest.raises(FlameError) as exc_info:
@@ -244,6 +276,63 @@ class TestGrpcErrorMapping:
 
         error = client.Connection._grpc_error_to_flame_error(FakeRpcError(), "test operation")
         assert error.code == FlameErrorCode.INTERNAL
+
+
+class TestApplicationConversion:
+    def test_list_applications_preserves_absent_optional_fields(self):
+        from flamepy.proto.types_pb2 import Application as ApplicationProto
+        from flamepy.proto.types_pb2 import ApplicationList, ApplicationStatus, Metadata
+
+        class Frontend:
+            def ListApplication(self, req):  # noqa: N802
+                app = ApplicationProto(
+                    metadata=Metadata(id="app-1", name="app"),
+                    status=ApplicationStatus(state=0, creation_time=int(time.time() * 1000)),
+                )
+                return ApplicationList(applications=[app])
+
+        conn = client.Connection("http://unused", DummyChannel("unused"), Frontend())
+        try:
+            apps = conn.list_applications()
+        finally:
+            conn.close()
+
+        assert len(apps) == 1
+        app = apps[0]
+        assert app.image is None
+        assert app.command is None
+        assert app.working_directory is None
+        assert app.max_instances is None
+        assert app.delay_release is None
+        assert app.schema is None
+        assert app.url is None
+        assert app.installer is None
+
+    def test_get_application_preserves_present_empty_optional_fields(self):
+        from flamepy.proto.types_pb2 import Application as ApplicationProto
+        from flamepy.proto.types_pb2 import ApplicationSchema, ApplicationStatus, Metadata
+
+        class Frontend:
+            def GetApplication(self, req):  # noqa: N802
+                app = ApplicationProto(
+                    metadata=Metadata(id="app-1", name=req.name),
+                    status=ApplicationStatus(state=0, creation_time=int(time.time() * 1000)),
+                )
+                app.spec.image = ""
+                app.spec.schema.CopyFrom(ApplicationSchema(input=""))
+                return app
+
+        conn = client.Connection("http://unused", DummyChannel("unused"), Frontend())
+        try:
+            app = conn.get_application("app")
+        finally:
+            conn.close()
+
+        assert app.image == ""
+        assert app.command is None
+        assert app.schema is not None
+        assert app.schema.input == ""
+        assert app.schema.output is None
 
 
 class TestTaskWatcher:

--- a/sdk/python/tests/test_runner_service.py
+++ b/sdk/python/tests/test_runner_service.py
@@ -207,6 +207,41 @@ def test_runnerservice_close_closes_session():
     mock_session.close.assert_called_once()
 
 
+def test_runnerservice_does_not_overwrite_close_with_user_method():
+    """Test generated wrappers do not replace RunnerService lifecycle methods."""
+    from flamepy.runner.runner import RunnerService
+
+    class ServiceWithClose:
+        def close(self):
+            return "user-close"
+
+    rs = object.__new__(RunnerService)
+    rs._app = "test-app"
+    rs._execution_object = ServiceWithClose()
+    rs._function_wrapper = None
+    rs._session = MagicMock()
+
+    rs._generate_wrappers()
+    rs.close()
+
+    rs._session.close.assert_called_once()
+
+
+def test_runpy_resolves_object_ref_to_cached_none():
+    """Test cached None is a valid ObjectRef value, not a retrieval miss."""
+    from flamepy.core.cache import ObjectRef
+    from flamepy.runner.runpy import FlameRunpyService
+
+    svc = FlameRunpyService()
+    ref = ObjectRef(endpoint="grpc://host:9090", key="app/session/object", version=1)
+
+    with patch("flamepy.runner.runpy.get_object", return_value=None):
+        assert svc._resolve_object_ref(ref) is None
+        args, kwargs = svc._resolve_object_refs_parallel((ref,), {"value": ref})
+        assert args == (None,)
+        assert kwargs == {"value": None}
+
+
 def test_runner_get_resolves_futures():
     """Test Runner.get() resolves multiple ObjectFutures."""
     from flamepy.runner.runner import ObjectFuture, Runner

--- a/sdk/python/tests/test_service.py
+++ b/sdk/python/tests/test_service.py
@@ -179,7 +179,63 @@ def test_on_task_invoke_exception_path():  # noqa: N802
     req = MockTaskRequest()
     resp = servicer.OnTaskInvoke(req, DummyContext())
     assert resp.return_code == -1
-    assert getattr(resp, "output", None) is None
+    assert not resp.HasField("output")
+
+
+def test_service_preserves_empty_optional_bytes():  # noqa: N802
+    class CaptureService(service.FlameService):
+        def __init__(self):
+            self.session_context = None
+            self.task_context = None
+
+        def on_session_enter(self, context: service.SessionContext):
+            self.session_context = context
+            return True
+
+        def on_task_invoke(self, context: service.TaskContext):
+            self.task_context = context
+            return None
+
+        def on_session_leave(self):
+            return True
+
+    svc = CaptureService()
+    servicer = service.FlameInstanceServicer(svc)
+
+    class MockAppCtx:
+        name = "app"
+        image = None
+        command = None
+        working_directory = None
+        url = None
+
+        def HasField(self, field):  # noqa: N802
+            return False
+
+    class MockSessionEnterRequest:
+        session_id = "sess"
+        application = MockAppCtx()
+        common_data = b""
+
+        def HasField(self, field):  # noqa: N802
+            return field == "common_data"
+
+    class MockTaskRequest:
+        task_id = "task"
+        session_id = "sess"
+        input = b""
+
+        def HasField(self, field):  # noqa: N802
+            return field == "input"
+
+    enter_resp = servicer.OnSessionEnter(MockSessionEnterRequest(), DummyContext())
+    invoke_resp = servicer.OnTaskInvoke(MockTaskRequest(), DummyContext())
+
+    assert enter_resp.return_code == 0
+    assert svc.session_context.common_data() == b""
+    assert invoke_resp.return_code == 0
+    assert not invoke_resp.HasField("output")
+    assert svc.task_context.input == b""
 
 
 def test_flame_instance_server_start_and_stop(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

Fixes the flamepy review findings around agent task handling, protobuf optional field preservation, runner wrapper safety, cache package deletion, and object-cache exact-key deletion.

## Details

- Return the original function from `FlameInstance.entrypoint()` so decorator usage keeps the user function binding.
- Treat agent/service `None` results as successful no-output tasks instead of constructing `TaskOutput(None)`.
- Preserve optional bytes presence for empty `b""` common data, task input, and task output.
- Convert application protobufs through `HasField()` so absent optional fields and schema remain `None`.
- Keep object key/path parsing centralized in `ObjectKey`, and allow `delete_objects()` to delete either prefixes or exact full keys.
- Update cache package cleanup to delete the requested package object instead of the whole package prefix.
- Prevent generated `RunnerService` wrappers from overwriting SDK lifecycle methods such as `close()`.
- Allow cached Python `None` to resolve through ObjectRef argument paths.
- Add object-cache exact-key deletion support for in-memory matching and disk storage cleanup.

## Validation

- `sdk/python/.venv/bin/python -m pytest sdk/python/tests -q` passed: 207 tests.
- `sdk/python/.venv/bin/ruff check sdk/python/src/flamepy sdk/python/tests` passed.
- `sdk/python/.venv/bin/ruff format sdk/python/src/flamepy sdk/python/tests` left files unchanged.
- `uv build` passed in `sdk/python`.
- `cargo fmt -p flame-object-cache` passed.
- `cargo build -p flame-object-cache` passed.
- `cargo clippy -p flame-object-cache --all-targets -- -D warnings` passed.
- `cargo test -p flame-object-cache` passed: 70 tests.
- `git diff --check` passed.