### PR TITLE
[codex] Implement simplified flame-rs API

### DIFF
--- a/.github/workflows/e2e-bm.yaml
+++ b/.github/workflows/e2e-bm.yaml
@@ -110,7 +110,7 @@ jobs:
           curl -s http://127.0.0.1:9090/ || echo "Note: Object cache gRPC endpoint (expected no HTTP response)"
 
       - name: Run test_runner
-        timeout-minutes: 10
+        timeout-minutes: 20
         run: |
           export PYTHONPATH="$(pwd)/e2e/src:$PYTHONPATH"
           export FLAME_LOG=DEBUG

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1828,6 +1828,7 @@ dependencies = [
  "bincode",
  "bytes",
  "chrono",
+ "flame-rs-macros",
  "futures",
  "prost 0.14.3",
  "serde",
@@ -1849,6 +1850,16 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+]
+
+[[package]]
+name = "flame-rs-macros"
+version = "0.5.0"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1959,7 +1970,6 @@ dependencies = [
 name = "flmexec"
 version = "0.5.0"
 dependencies = [
- "chrono",
  "clap",
  "flame-rs",
  "futures",
@@ -1981,7 +1991,6 @@ name = "flmping"
 version = "0.5.0"
 dependencies = [
  "byte-unit",
- "chrono",
  "clap",
  "comfy-table",
  "flame-rs",
@@ -1990,12 +1999,8 @@ dependencies = [
  "indicatif",
  "serde",
  "serde_derive",
- "serde_json",
- "stdng",
  "tokio",
- "tonic",
  "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,12 +10,12 @@ members = [
     "executor_manager",
     "rpc",
     "sdk/rust",
+    "sdk/rust/macros",
     "examples/pi/rust",
     "cri",
     "stdng",
     "object_cache",
 ]
-
 [workspace.dependencies]
 tokio = { version = "1", features = ["full"] }
 tonic = { version = "0.14", features = ["tls-ring"] }
@@ -64,6 +64,10 @@ tempfile = "3"
 comfy-table = "7"
 jsonschema = "0.33"
 gethostname = "1"
+proc-macro2 = "1"
+proc-macro-crate = "3"
+quote = "1"
+syn = { version = "2", features = ["full"] }
 
 # Arrow ecosystem (v58 for tonic 0.14 compatibility)
 arrow = "58"

--- a/docs/designs/RFE455-simplify-flame-rs-api/FS.md
+++ b/docs/designs/RFE455-simplify-flame-rs-api/FS.md
@@ -281,7 +281,7 @@ impl Session {
     ) -> Result<Option<O>, FlameError>
     where
         I: IntoTaskInput,
-        O: FromTaskOutput;
+        O: FromTaskOutput + Send + 'static;
 
     pub async fn run<I, O>(
         &self,
@@ -289,7 +289,7 @@ impl Session {
     ) -> Result<TaskHandle<O>, FlameError>
     where
         I: IntoTaskInput,
-        O: FromTaskOutput;
+        O: FromTaskOutput + Send + 'static;
 
     pub fn common_data<T>(&self) -> Result<Option<T>, FlameError>
     where
@@ -303,21 +303,22 @@ impl Session {
 
 ```rust
 pub struct TaskHandle<O> {
-    session: Session,
     task_id: TaskID,
-    _output: std::marker::PhantomData<O>,
+    future: std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<Option<O>, FlameError>> + Send + 'static>,
+    >,
 }
 
-impl<O> TaskHandle<O>
-where
-    O: FromTaskOutput,
-{
+impl<O> TaskHandle<O> {
     pub fn id(&self) -> &TaskID;
-    pub async fn wait(self) -> Result<Option<O>, FlameError>;
+}
+
+impl<O> std::future::Future for TaskHandle<O> {
+    type Output = Result<Option<O>, FlameError>;
 }
 ```
 
-The MVP should expose `wait().await` rather than implementing `Future` directly. A `Future` implementation can be added later if its cancellation and error semantics are clear.
+`TaskHandle` is directly awaitable. Awaiting the handle waits for terminal task state, returns decoded output when the task succeeds, and returns a `FlameError` containing task state and event details when the task fails or is cancelled. Dropping a handle does not cancel the remote task in the MVP.
 
 Input conversion is explicit and shared by `invoke(...)` and `run(...)`:
 
@@ -419,7 +420,7 @@ let handles = futures::future::try_join_all(
 .await?;
 
 for handle in handles {
-    let response = handle.wait().await?;
+    let response = handle.await?;
     println!("{response:?}");
 }
 ```
@@ -780,13 +781,14 @@ pub struct Session {
 }
 
 pub struct TaskHandle<O> {
-    session: Session,
     task_id: TaskID,
-    _output: std::marker::PhantomData<O>,
+    future: std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<Option<O>, FlameError>> + Send + 'static>,
+    >,
 }
 ```
 
-`TaskHandle` owns a cloned `Session`, which is cheap because the underlying `Connection` is cloneable. Dropping a handle does not cancel the remote task in the MVP. Explicit cancellation can be designed separately if the frontend protocol grows that operation.
+`TaskHandle` stores the created task ID plus an internal future that owns the cloned `Session` needed to watch the remote task to completion. Dropping a handle does not cancel the remote task in the MVP. Explicit cancellation can be designed separately if the frontend protocol grows that operation.
 
 Generated services use a small wrapper:
 
@@ -1095,7 +1097,7 @@ Workflow:
 
 1. Create or open a session once.
 2. Call `ssn.run::<_, ResponseType>(...)` for each request.
-3. Await each `TaskHandle<ResponseType>::wait()` as capacity becomes available.
+3. Await each `TaskHandle<ResponseType>` as capacity becomes available.
 
 Expected outcome:
 
@@ -1171,6 +1173,7 @@ Expected outcome:
   - `IntoTaskInput` implementations encode `FlameMessage` inputs and optional absence
   - `IntoTaskInput for ()` produces absent task input
   - `TaskHandle::id()` returns the created task ID
+  - `TaskHandle` implements `Future<Output = Result<Option<O>, FlameError>>`
 
 - Unit tests for shared `message` helpers:
   - `FlameMessage` derive encodes and decodes a typed payload

--- a/docs/designs/RFE455-simplify-flame-rs-api/FS.md
+++ b/docs/designs/RFE455-simplify-flame-rs-api/FS.md
@@ -1032,7 +1032,7 @@ Typed message client invocation:
 2. Call `invoke(...)` or `run(...)`.
 3. Decode present successful output through `FromTaskOutput`. For `O: FlameMessage`, call `O::decode`.
 4. Return `Ok(None)` if the service produced no output.
-5. Map serialization failures to `FlameError::InvalidConfig` and decode failures to `FlameError::Internal`.
+5. Preserve the `FlameError` returned by `FlameMessage`. The generated JSON implementation maps encode failures to `FlameError::Internal` and decode failures to `FlameError::InvalidConfig`, matching the service-boundary rules below.
 
 Attribute parsing:
 

--- a/docs/designs/RFE455-simplify-flame-rs-api/FS.md
+++ b/docs/designs/RFE455-simplify-flame-rs-api/FS.md
@@ -419,8 +419,7 @@ let handles = futures::future::try_join_all(
 )
 .await?;
 
-for handle in handles {
-    let response = handle.await?;
+for response in futures::future::try_join_all(handles).await? {
     println!("{response:?}");
 }
 ```

--- a/docs/designs/RFE455-simplify-flame-rs-api/FS.md
+++ b/docs/designs/RFE455-simplify-flame-rs-api/FS.md
@@ -155,7 +155,8 @@ The low-level Rust client remains available under `flame_rs::client`. RFE455 add
 
 ```rust
 let ssn = flame_rs::create_session("model-app").await?;
-let output: Option<GenerationResponse> = ssn.invoke(&request).await?;
+let handle = ssn.invoke(&request).await?;
+let output: Option<GenerationResponse> = handle.await?;
 ssn.close().await?;
 ```
 
@@ -278,7 +279,7 @@ impl Session {
     pub async fn invoke<I, O>(
         &self,
         input: I,
-    ) -> Result<Option<O>, FlameError>
+    ) -> Result<TaskHandle<O>, FlameError>
     where
         I: IntoTaskInput,
         O: FromTaskOutput + Send + 'static;
@@ -286,7 +287,7 @@ impl Session {
     pub async fn run<I, O>(
         &self,
         input: I,
-    ) -> Result<TaskHandle<O>, FlameError>
+    ) -> Result<TaskFuture<O>, FlameError>
     where
         I: IntoTaskInput,
         O: FromTaskOutput + Send + 'static;
@@ -297,12 +298,19 @@ impl Session {
 }
 ```
 
-`invoke(...)` is the Rust equivalent of FlamePy's `ssn.invoke(...)`: it creates a task, watches it to completion, and returns the typed output. It hides the current `TaskInformer` boilerplate for one-shot calls.
+`invoke(...)` creates a task and returns a `TaskHandle<O>`. Awaiting the handle waits for terminal task state, returns decoded output when the task succeeds, and returns `FlameError` when the task fails, is cancelled, or the output cannot be decoded.
 
-`run(...)` starts a task and returns a handle for parallel invocation:
+`run(...)` starts a task and returns a richer future for parallel invocation:
 
 ```rust
 pub struct TaskHandle<O> {
+    task_id: TaskID,
+    future: std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<Option<O>, FlameError>> + Send + 'static>,
+    >,
+}
+
+pub struct TaskFuture<O> {
     task_id: TaskID,
     future: std::pin::Pin<
         Box<dyn std::future::Future<Output = Result<TaskResult<O>, FlameError>> + Send + 'static>,
@@ -323,11 +331,19 @@ impl<O> TaskHandle<O> {
 }
 
 impl<O> std::future::Future for TaskHandle<O> {
+    type Output = Result<Option<O>, FlameError>;
+}
+
+impl<O> TaskFuture<O> {
+    pub fn id(&self) -> &TaskID;
+}
+
+impl<O> std::future::Future for TaskFuture<O> {
     type Output = Result<TaskResult<O>, FlameError>;
 }
 ```
 
-`TaskHandle` is directly awaitable. Awaiting the handle waits for terminal task state and returns a `TaskResult<O>` containing the task ID, session ID, terminal state, decoded output on success, and error code/message on failure or cancellation. Transport, watch, and decode failures still return `FlameError`. `invoke(...)` remains the typed one-shot API that unwraps successful output and returns a `FlameError` for failed or cancelled task states. Dropping a handle does not cancel the remote task in the MVP.
+`TaskFuture` is directly awaitable. Awaiting it waits for terminal task state and returns a `TaskResult<O>` containing the task ID, session ID, terminal state, decoded output on success, and error code/message on failure or cancellation. Transport, watch, and decode failures still return `FlameError`. Dropping a handle or future does not cancel the remote task in the MVP.
 
 Input conversion is explicit and shared by `invoke(...)` and `run(...)`:
 
@@ -385,12 +401,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     )
     .await?;
 
-    let response: Option<GenerationResponse> = ssn
+    let handle = ssn
         .invoke(&GenerationRequest {
             prompt: "Hello".to_string(),
             sample_len: 64,
         })
         .await?;
+    let response: Option<GenerationResponse> = handle.await?;
 
     println!("{response:?}");
     ssn.close().await?;
@@ -749,7 +766,7 @@ Existing HostShim / GrpcShim / Executor flow
   - Add default-context helpers: `connect`, `connect_with_context`, `connect_with_config`, `create_session`, `open_session`, and `open_or_create_session`.
   - Add connection-level `create_session_with` and `open_or_create_session_with` for reused connections.
   - Add high-level `Session::invoke`, `Session::run`, and typed common-data accessors.
-  - Add generic `TaskHandle<O>` and `TaskResult<O>`.
+  - Add generic `TaskHandle<O>`, `TaskFuture<O>`, and `TaskResult<O>`.
 
 - `sdk/rust/src/message.rs`
   - Define `FlameMessage`, `IntoTaskInput`, `FromTaskOutput`, and `IntoCommonData`.
@@ -802,6 +819,13 @@ pub struct Session {
 pub struct TaskHandle<O> {
     task_id: TaskID,
     future: std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<Option<O>, FlameError>> + Send + 'static>,
+    >,
+}
+
+pub struct TaskFuture<O> {
+    task_id: TaskID,
+    future: std::pin::Pin<
         Box<dyn std::future::Future<Output = Result<TaskResult<O>, FlameError>> + Send + 'static>,
     >,
 }
@@ -816,7 +840,7 @@ pub struct TaskResult<O> {
 }
 ```
 
-`TaskHandle` stores the created task ID plus an internal future that owns the cloned `Session` needed to watch the remote task to completion. Awaiting it returns `TaskResult<O>` so parallel callers receive typed output and task lifecycle metadata together. Dropping a handle does not cancel the remote task in the MVP. Explicit cancellation can be designed separately if the frontend protocol grows that operation.
+`TaskHandle` stores the created task ID plus an internal future that maps successful terminal state to decoded output and failed terminal state to `FlameError`. `TaskFuture` stores the same task ID plus the richer future that returns `TaskResult<O>` so parallel callers receive typed output and task lifecycle metadata together. Dropping a handle or future does not cancel the remote task in the MVP. Explicit cancellation can be designed separately if the frontend protocol grows that operation.
 
 Generated services use a small wrapper:
 
@@ -989,7 +1013,7 @@ Synchronous client invocation:
 2. Call existing `Session::create_task(input)`.
 3. Watch the task to terminal state through an internal one-shot informer, or factor the current stream loop into a private helper that returns the final `Task`.
 4. For `run(...)`, convert the terminal task into `TaskResult<O>` with decoded output on success and error code/message on failure.
-5. For `invoke(...)`, unwrap successful `TaskResult<O>::output` and map terminal failure states into `FlameError` with task ID and event details.
+5. For `invoke(...)`, wrap the `TaskFuture<O>` in `TaskHandle<O>` and map awaited `TaskResult<O>` to either successful decoded output or `FlameError`.
 
 Typed message client invocation:
 
@@ -1107,7 +1131,8 @@ Workflow:
 1. Build a `SessionOptions` value or pass the application name directly.
 2. Call `flame_rs::create_session(...)`.
 3. Call `ssn.invoke(...)` for typed `FlameMessage` request/response data.
-4. Close the session.
+4. Await the returned `TaskHandle` to get decoded output or `FlameError`.
+5. Close the session.
 
 Expected outcome:
 
@@ -1125,13 +1150,13 @@ Workflow:
 
 1. Create or open a session once.
 2. Call `ssn.run::<_, ResponseType>(...)` for each request.
-3. Await each `TaskHandle<ResponseType>` as capacity becomes available and inspect the returned `TaskResult<ResponseType>`.
+3. Await each `TaskFuture<ResponseType>` as capacity becomes available and inspect the returned `TaskResult<ResponseType>`.
 
 Expected outcome:
 
 - Client code can express FlamePy's `ssn.run(...)` pattern with explicit Rust async handles.
 - Callers receive task ID, session ID, state, decoded output, and failure details in one result value.
-- The handle API leaves room for future cancellation without changing the one-shot `invoke(...)` method.
+- The future API leaves room for future cancellation without changing the one-shot `invoke(...)` method.
 
 **Example 3: Simple Typed Service**
 
@@ -1202,7 +1227,9 @@ Expected outcome:
   - `IntoTaskInput` implementations encode `FlameMessage` inputs and optional absence
   - `IntoTaskInput for ()` produces absent task input
   - `TaskHandle::id()` returns the created task ID
-  - `TaskHandle<O>` implements `Future<Output = Result<TaskResult<O>, FlameError>>`
+  - `TaskFuture::id()` returns the created task ID
+  - `TaskHandle<O>` implements `Future<Output = Result<Option<O>, FlameError>>`
+  - `TaskFuture<O>` implements `Future<Output = Result<TaskResult<O>, FlameError>>`
   - `TaskResult<O>` carries task ID, session ID, terminal state, decoded successful output, and failed task error code/message
 
 - Unit tests for shared `message` helpers:

--- a/docs/designs/RFE455-simplify-flame-rs-api/FS.md
+++ b/docs/designs/RFE455-simplify-flame-rs-api/FS.md
@@ -541,18 +541,29 @@ struct ModelService {
 #[flame_rs::instance]
 impl ModelService {
     async fn enter(&self, _instance: FlameInstance) -> Result<(), FlameError> {
-        *self.assets.lock().unwrap() = Some(load_assets()?);
+        let mut assets = self.assets.lock().map_err(|_| {
+            FlameError::Internal("model assets lock poisoned".to_string())
+        })?;
+        *assets = Some(load_assets()?);
         Ok(())
     }
 
     #[flame_rs::entrypoint]
     async fn generate(&self, req: GenerationRequest) -> Result<GenerationResponse, FlameError> {
-        let assets = self.assets.lock().unwrap();
-        run_generation(assets.as_ref().unwrap(), req)
+        let assets = self.assets.lock().map_err(|_| {
+            FlameError::Internal("model assets lock poisoned".to_string())
+        })?;
+        let assets = assets.as_ref().ok_or_else(|| {
+            FlameError::Internal("model assets are not loaded".to_string())
+        })?;
+        run_generation(assets, req)
     }
 
     async fn leave(&self) -> Result<(), FlameError> {
-        *self.assets.lock().unwrap() = None;
+        let mut assets = self.assets.lock().map_err(|_| {
+            FlameError::Internal("model assets lock poisoned".to_string())
+        })?;
+        *assets = None;
         Ok(())
     }
 }

--- a/docs/designs/RFE455-simplify-flame-rs-api/FS.md
+++ b/docs/designs/RFE455-simplify-flame-rs-api/FS.md
@@ -305,8 +305,17 @@ impl Session {
 pub struct TaskHandle<O> {
     task_id: TaskID,
     future: std::pin::Pin<
-        Box<dyn std::future::Future<Output = Result<Option<O>, FlameError>> + Send + 'static>,
+        Box<dyn std::future::Future<Output = Result<TaskResult<O>, FlameError>> + Send + 'static>,
     >,
+}
+
+pub struct TaskResult<O> {
+    pub task_id: TaskID,
+    pub session_id: SessionID,
+    pub state: TaskState,
+    pub output: Option<O>,
+    pub error_code: Option<i32>,
+    pub error_message: Option<String>,
 }
 
 impl<O> TaskHandle<O> {
@@ -314,11 +323,11 @@ impl<O> TaskHandle<O> {
 }
 
 impl<O> std::future::Future for TaskHandle<O> {
-    type Output = Result<Option<O>, FlameError>;
+    type Output = Result<TaskResult<O>, FlameError>;
 }
 ```
 
-`TaskHandle` is directly awaitable. Awaiting the handle waits for terminal task state, returns decoded output when the task succeeds, and returns a `FlameError` containing task state and event details when the task fails or is cancelled. Dropping a handle does not cancel the remote task in the MVP.
+`TaskHandle` is directly awaitable. Awaiting the handle waits for terminal task state and returns a `TaskResult<O>` containing the task ID, session ID, terminal state, decoded output on success, and error code/message on failure or cancellation. Transport, watch, and decode failures still return `FlameError`. `invoke(...)` remains the typed one-shot API that unwraps successful output and returns a `FlameError` for failed or cancelled task states. Dropping a handle does not cancel the remote task in the MVP.
 
 Input conversion is explicit and shared by `invoke(...)` and `run(...)`:
 
@@ -419,7 +428,18 @@ let handles = futures::future::try_join_all(
 )
 .await?;
 
-for response in futures::future::try_join_all(handles).await? {
+for result in futures::future::try_join_all(handles).await? {
+    if !result.is_succeed() {
+        eprintln!(
+            "task {} finished with {}: {:?}",
+            result.task_id,
+            result.state,
+            result.error_message,
+        );
+        continue;
+    }
+
+    let response = result.output;
     println!("{response:?}");
 }
 ```
@@ -729,7 +749,7 @@ Existing HostShim / GrpcShim / Executor flow
   - Add default-context helpers: `connect`, `connect_with_context`, `connect_with_config`, `create_session`, `open_session`, and `open_or_create_session`.
   - Add connection-level `create_session_with` and `open_or_create_session_with` for reused connections.
   - Add high-level `Session::invoke`, `Session::run`, and typed common-data accessors.
-  - Add generic `TaskHandle<O>`.
+  - Add generic `TaskHandle<O>` and `TaskResult<O>`.
 
 - `sdk/rust/src/message.rs`
   - Define `FlameMessage`, `IntoTaskInput`, `FromTaskOutput`, and `IntoCommonData`.
@@ -782,12 +802,21 @@ pub struct Session {
 pub struct TaskHandle<O> {
     task_id: TaskID,
     future: std::pin::Pin<
-        Box<dyn std::future::Future<Output = Result<Option<O>, FlameError>> + Send + 'static>,
+        Box<dyn std::future::Future<Output = Result<TaskResult<O>, FlameError>> + Send + 'static>,
     >,
+}
+
+pub struct TaskResult<O> {
+    pub task_id: TaskID,
+    pub session_id: SessionID,
+    pub state: TaskState,
+    pub output: Option<O>,
+    pub error_code: Option<i32>,
+    pub error_message: Option<String>,
 }
 ```
 
-`TaskHandle` stores the created task ID plus an internal future that owns the cloned `Session` needed to watch the remote task to completion. Dropping a handle does not cancel the remote task in the MVP. Explicit cancellation can be designed separately if the frontend protocol grows that operation.
+`TaskHandle` stores the created task ID plus an internal future that owns the cloned `Session` needed to watch the remote task to completion. Awaiting it returns `TaskResult<O>` so parallel callers receive typed output and task lifecycle metadata together. Dropping a handle does not cancel the remote task in the MVP. Explicit cancellation can be designed separately if the frontend protocol grows that operation.
 
 Generated services use a small wrapper:
 
@@ -959,14 +988,14 @@ Synchronous client invocation:
 1. Convert `impl IntoTaskInput` into `Option<TaskInput>`.
 2. Call existing `Session::create_task(input)`.
 3. Watch the task to terminal state through an internal one-shot informer, or factor the current stream loop into a private helper that returns the final `Task`.
-4. Return task output on success.
-5. Map terminal failure states into `FlameError` with task ID and event details.
+4. For `run(...)`, convert the terminal task into `TaskResult<O>` with decoded output on success and error code/message on failure.
+5. For `invoke(...)`, unwrap successful `TaskResult<O>::output` and map terminal failure states into `FlameError` with task ID and event details.
 
 Typed message client invocation:
 
 1. Convert input with `IntoTaskInput`. For `T: FlameMessage`, call `T::encode`; for `()`, produce no task input.
 2. Call `invoke(...)` or `run(...)`.
-3. Decode present output through `FromTaskOutput`. For `O: FlameMessage`, call `O::decode`.
+3. Decode present successful output through `FromTaskOutput`. For `O: FlameMessage`, call `O::decode`.
 4. Return `Ok(None)` if the service produced no output.
 5. Map serialization failures to `FlameError::InvalidConfig` and decode failures to `FlameError::Internal`.
 
@@ -1096,11 +1125,12 @@ Workflow:
 
 1. Create or open a session once.
 2. Call `ssn.run::<_, ResponseType>(...)` for each request.
-3. Await each `TaskHandle<ResponseType>` as capacity becomes available.
+3. Await each `TaskHandle<ResponseType>` as capacity becomes available and inspect the returned `TaskResult<ResponseType>`.
 
 Expected outcome:
 
 - Client code can express FlamePy's `ssn.run(...)` pattern with explicit Rust async handles.
+- Callers receive task ID, session ID, state, decoded output, and failure details in one result value.
 - The handle API leaves room for future cancellation without changing the one-shot `invoke(...)` method.
 
 **Example 3: Simple Typed Service**
@@ -1172,7 +1202,8 @@ Expected outcome:
   - `IntoTaskInput` implementations encode `FlameMessage` inputs and optional absence
   - `IntoTaskInput for ()` produces absent task input
   - `TaskHandle::id()` returns the created task ID
-  - `TaskHandle` implements `Future<Output = Result<Option<O>, FlameError>>`
+  - `TaskHandle<O>` implements `Future<Output = Result<TaskResult<O>, FlameError>>`
+  - `TaskResult<O>` carries task ID, session ID, terminal state, decoded successful output, and failed task error code/message
 
 - Unit tests for shared `message` helpers:
   - `FlameMessage` derive encodes and decodes a typed payload

--- a/docs/designs/RFE455-simplify-flame-rs-api/FS.md
+++ b/docs/designs/RFE455-simplify-flame-rs-api/FS.md
@@ -1,0 +1,1210 @@
+# RFE455: Simplify flame-rs API for Users
+
+GitHub issue: https://github.com/xflops/flame/issues/455
+
+## Summary
+
+This report proposes a higher-level Rust SDK API for Flame. The proposal covers two related surfaces:
+
+- Client helpers for creating sessions and invoking typed tasks with minimal boilerplate.
+- Service macros for defining typed service entrypoints while preserving the existing `FlameService` runtime boundary.
+
+The design centers on one typed payload contract, `FlameMessage`, for task input, task output, and common data. Raw byte workflows remain supported by the existing low-level Rust APIs and are intentionally out of scope for this simplified layer.
+
+## 1. Motivation
+
+**Background:**
+
+The current Rust SDK exposes mostly core APIs. Client code usually has to load `FlameContext`, connect manually, construct `SessionAttributes`, create a session through `Connection`, and then wire task creation/watching through `TaskInformer`. Service code similarly implements `flame_rs::service::FlameService` directly.
+
+These APIs are explicit and stable, but simple applications repeat the same adapter code:
+
+- load config and connect before creating a session
+- build `SessionAttributes` for common session defaults
+- create a task, watch it, and collect output for synchronous invocation
+- implement a custom `TaskInformer` for one-shot task output
+- import `tonic::async_trait` on the service side
+- implement `on_session_enter`, `on_task_invoke`, and `on_session_leave`
+- manually handle missing task input and encode/decode task bytes
+
+This pattern appears in the Rust Pi example, `flmping`, and model-serving examples. In those applications, the core business logic is small: create a session, invoke a task, load state on session enter, and run inference on task invoke. The surrounding adapter code should be optional for common typed use cases.
+
+**Target:**
+
+Add a higher-level `flame-rs` API layer similar to FlamePy:
+
+- top-level client helpers such as `flame_rs::create_session(...)`
+- session methods such as `session.invoke(...)` over `FlameMessage` payloads
+- async task handles for parallel invocation
+- one `FlameMessage` derive macro for typed input, output, and common-data serialization
+- service macros that give Rust services the same high-level shape as `flamepy.service.FlameInstance`
+
+Success criteria:
+
+- Existing `FlameService` implementations continue to compile unchanged.
+- A basic Rust client can create a session and synchronously invoke a task without manually creating a connection or `TaskInformer`.
+- Typed request/response/common-data clients can avoid repeated byte serialization boilerplate.
+- A simple typed request/response service can be written as one annotated entrypoint function, without importing `tonic`, manually parsing task bytes, or writing lifecycle no-op methods.
+- Stateful services can still load and clear resources in session hooks.
+- Raw byte workflows remain available through the existing low-level Rust APIs, outside this simplified layer.
+- Macro expansion is easy to reason about and maps directly to the existing service trait.
+
+## 2. Functional Specification
+
+**Configuration:**
+
+Client helpers and the runtime `FlameMessage` trait are part of the default `flame-rs` API because they only wrap existing runtime dependencies.
+
+Add an optional `macros` feature for the `FlameMessage` derive macro and service-side proc macros:
+
+```toml
+flame-rs = { path = "../../sdk/rust", features = ["macros"] }
+```
+
+The feature enables a new proc-macro crate and re-exports:
+
+- `#[derive(flame_rs::FlameMessage)]` for input, output, and common-data payload types.
+- `#[flame_rs::entrypoint(...)]` for free-function services.
+- `#[flame_rs::instance(...)]` for stateful struct-backed services.
+- `flame_rs::run(...)` as the high-level async runner used from the user's `main` function.
+
+Free-function entrypoint:
+
+```rust
+#[derive(serde::Serialize, serde::Deserialize, flame_rs::FlameMessage)]
+struct InferRequest {
+    prompt: String,
+}
+
+#[derive(serde::Serialize, serde::Deserialize, flame_rs::FlameMessage)]
+struct InferResponse {
+    text: String,
+}
+
+#[flame_rs::entrypoint]
+async fn infer(req: InferRequest) -> Result<InferResponse, FlameError> {
+    ...
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    flame_rs::run(infer).await
+}
+```
+
+Stateful instance:
+
+```rust
+use std::sync::Mutex;
+use flame_rs::service::FlameInstance;
+
+#[derive(serde::Serialize, serde::Deserialize, flame_rs::FlameMessage)]
+struct ModelContext {
+    model_id: String,
+}
+
+#[derive(serde::Serialize, serde::Deserialize, flame_rs::FlameMessage)]
+struct InferRequest {
+    prompt: String,
+}
+
+#[derive(serde::Serialize, serde::Deserialize, flame_rs::FlameMessage)]
+struct InferResponse {
+    text: String,
+}
+
+#[derive(Default)]
+struct ModelInstance {
+    model: Mutex<Option<Model>>,
+}
+
+#[flame_rs::instance]
+impl ModelInstance {
+    async fn enter(&self, instance: FlameInstance) -> Result<(), FlameError> {
+        let ctx = instance.common_data::<ModelContext>()?;
+        ...
+    }
+
+    #[flame_rs::entrypoint]
+    async fn infer(&self, req: InferRequest) -> Result<InferResponse, FlameError> {
+        ...
+    }
+
+    async fn leave(&self) -> Result<(), FlameError> {
+        ...
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    flame_rs::run(ModelInstance::default()).await
+}
+```
+
+Fields:
+
+- `entrypoint`: optional method name override for `#[flame_rs::instance]`. The normal path is to mark the method with `#[flame_rs::entrypoint]`.
+- `enter`: optional session-enter method name. Default: `"enter"` when present; otherwise the generated hook returns `Ok(())`.
+- `leave`: optional session-leave method name. Default: `"leave"` when present; otherwise the generated hook returns `Ok(())`.
+- `debug`: reserved for a future local debug mode aligned with FlamePy. Disabled in the MVP.
+- `crate`: optional crate path override for renamed dependencies. Default: `flame_rs`.
+
+### Client Helper API
+
+The low-level Rust client remains available under `flame_rs::client`. RFE455 adds a higher-level crate-root client path for the common FlamePy-style workflow:
+
+```rust
+let ssn = flame_rs::create_session("model-app").await?;
+let output: Option<GenerationResponse> = ssn.invoke(&request).await?;
+ssn.close().await?;
+```
+
+Top-level helpers:
+
+```rust
+pub async fn connect() -> Result<Connection, FlameError>;
+
+pub async fn connect_with_context(
+    context: FlameContext,
+) -> Result<Connection, FlameError>;
+
+pub async fn connect_with_config(
+    path: Option<String>,
+) -> Result<Connection, FlameError>;
+
+pub async fn create_session(
+    options: impl Into<SessionOptions>,
+) -> Result<Session, FlameError>;
+
+pub async fn open_session(
+    id: impl Into<SessionID>,
+) -> Result<Session, FlameError>;
+
+pub async fn open_or_create_session(
+    id: impl Into<SessionID>,
+    options: impl Into<SessionOptions>,
+) -> Result<Session, FlameError>;
+```
+
+`connect()` loads `FlameContext::from_file_with_env(None)`, reads the current context's cluster endpoint and TLS config, and delegates to the existing `client::connect_with_tls(...)`. This mirrors FlamePy's default connection behavior without introducing a global singleton in the MVP. Applications that need connection reuse can call `connect()` once and keep the returned `Connection`.
+
+Connection-level mirrors avoid reconnecting in long-running clients:
+
+```rust
+impl Connection {
+    pub async fn create_session_with(
+        &self,
+        options: impl Into<SessionOptions>,
+    ) -> Result<Session, FlameError>;
+
+    pub async fn open_or_create_session_with(
+        &self,
+        id: impl Into<SessionID>,
+        options: impl Into<SessionOptions>,
+    ) -> Result<Session, FlameError>;
+}
+```
+
+For `open_or_create_session(...)`, `id` is authoritative. If `SessionOptions::id` is present and differs from `id`, return `FlameError::InvalidConfig`.
+
+`SessionOptions` is the ergonomic builder form of the current `SessionAttributes`:
+
+```rust
+#[derive(Clone, Debug)]
+pub struct SessionOptions {
+    pub id: Option<SessionID>,
+    pub application: String,
+    pub common_data: Option<CommonData>,
+    pub min_instances: u32,
+    pub max_instances: Option<u32>,
+    pub batch_size: u32,
+    pub priority: u32,
+    pub resreq: Option<ResourceRequirement>,
+}
+
+impl SessionOptions {
+    pub fn new(application: impl Into<String>) -> Self;
+    pub fn id(self, id: impl Into<SessionID>) -> Self;
+    pub fn common_data(self, data: impl IntoCommonData) -> Result<Self, FlameError>;
+    pub fn min_instances(self, value: u32) -> Self;
+    pub fn max_instances(self, value: u32) -> Self;
+    pub fn batch_size(self, value: u32) -> Self;
+    pub fn priority(self, value: u32) -> Self;
+    pub fn resreq(self, value: impl Into<ResourceRequirement>) -> Self;
+}
+
+impl From<&str> for SessionOptions;
+impl From<String> for SessionOptions;
+impl From<SessionOptions> for SessionAttributes;
+```
+
+Defaults match FlamePy and the current Rust examples: a generated session ID using `<application>-<short_name>`, `min_instances = 0`, `max_instances = None`, `batch_size = 1`, `priority = 0`, and no explicit resource requirement.
+
+Payload serialization uses one message trait for task input, task output, and common data:
+
+```rust
+pub trait FlameMessage: Sized {
+    fn encode(&self) -> Result<bytes::Bytes, FlameError>;
+    fn decode(bytes: &[u8]) -> Result<Self, FlameError>;
+}
+```
+
+Users derive it once on each typed payload:
+
+```rust
+#[derive(serde::Serialize, serde::Deserialize, flame_rs::FlameMessage)]
+struct GenerationRequest {
+    prompt: String,
+    sample_len: u32,
+}
+
+#[derive(serde::Serialize, serde::Deserialize, flame_rs::FlameMessage)]
+struct GenerationResponse {
+    text: String,
+}
+
+#[derive(serde::Serialize, serde::Deserialize, flame_rs::FlameMessage)]
+struct GenerationContext {
+    system_prompt: String,
+}
+```
+
+The derive macro generates serialization code for the `FlameMessage` trait. The MVP should use `serde_json` internally for portability and debuggability. This RFE does not expose a user-facing serialization-format option. Raw byte workflows should continue to use the existing low-level client and `FlameService` APIs.
+
+High-level session methods:
+
+```rust
+impl Session {
+    pub async fn invoke<I, O>(
+        &self,
+        input: I,
+    ) -> Result<Option<O>, FlameError>
+    where
+        I: IntoTaskInput,
+        O: FromTaskOutput;
+
+    pub async fn run<I, O>(
+        &self,
+        input: I,
+    ) -> Result<TaskHandle<O>, FlameError>
+    where
+        I: IntoTaskInput,
+        O: FromTaskOutput;
+
+    pub fn common_data<T>(&self) -> Result<Option<T>, FlameError>
+    where
+        T: FlameMessage;
+}
+```
+
+`invoke(...)` is the Rust equivalent of FlamePy's `ssn.invoke(...)`: it creates a task, watches it to completion, and returns the typed output. It hides the current `TaskInformer` boilerplate for one-shot calls.
+
+`run(...)` starts a task and returns a handle for parallel invocation:
+
+```rust
+pub struct TaskHandle<O> {
+    session: Session,
+    task_id: TaskID,
+    _output: std::marker::PhantomData<O>,
+}
+
+impl<O> TaskHandle<O>
+where
+    O: FromTaskOutput,
+{
+    pub fn id(&self) -> &TaskID;
+    pub async fn wait(self) -> Result<Option<O>, FlameError>;
+}
+```
+
+The MVP should expose `wait().await` rather than implementing `Future` directly. A `Future` implementation can be added later if its cancellation and error semantics are clear.
+
+Input conversion is explicit and shared by `invoke(...)` and `run(...)`:
+
+```rust
+pub trait IntoTaskInput {
+    fn into_task_input(self) -> Result<Option<TaskInput>, FlameError>;
+}
+
+impl<T> IntoTaskInput for &T where T: FlameMessage;
+impl<T> IntoTaskInput for Option<&T> where T: FlameMessage;
+impl IntoTaskInput for ();
+```
+
+Output and common-data conversion use matching traits:
+
+```rust
+pub trait FromTaskOutput: Sized {
+    fn from_task_output(output: Option<TaskOutput>) -> Result<Option<Self>, FlameError>;
+}
+
+impl<T> FromTaskOutput for T where T: FlameMessage;
+impl FromTaskOutput for ();
+
+pub trait IntoCommonData {
+    fn into_common_data(self) -> Result<CommonData, FlameError>;
+}
+
+impl<T> IntoCommonData for &T where T: FlameMessage;
+```
+
+The typed helpers do not mimic FlamePy's `cloudpickle` service session. Rust callers should use an explicit, portable wire format.
+
+Client example:
+
+```rust
+use flame_rs::client::SessionOptions;
+
+#[derive(serde::Serialize, serde::Deserialize, flame_rs::FlameMessage)]
+struct GenerationRequest {
+    prompt: String,
+    sample_len: u32,
+}
+
+#[derive(serde::Serialize, serde::Deserialize, flame_rs::FlameMessage)]
+struct GenerationResponse {
+    text: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let ssn = flame_rs::create_session(
+        SessionOptions::new("model-app")
+            .min_instances(1)
+            .resreq("cpu=4,mem=16g"),
+    )
+    .await?;
+
+    let response: Option<GenerationResponse> = ssn
+        .invoke(&GenerationRequest {
+            prompt: "Hello".to_string(),
+            sample_len: 64,
+        })
+        .await?;
+
+    println!("{response:?}");
+    ssn.close().await?;
+    Ok(())
+}
+```
+
+Typed common-data example:
+
+```rust
+#[derive(serde::Serialize, serde::Deserialize, flame_rs::FlameMessage)]
+struct ChatContext {
+    system_prompt: String,
+}
+
+let ctx = ChatContext {
+    system_prompt: "Answer concisely.".to_string(),
+};
+
+let options = SessionOptions::new("chat-app")
+    .min_instances(1)
+    .common_data(&ctx)?;
+
+let ssn = flame_rs::create_session(options).await?;
+let restored: Option<ChatContext> = ssn.common_data()?;
+```
+
+Parallel invocation example:
+
+```rust
+let handles = futures::future::try_join_all(
+    prompts
+        .iter()
+        .map(|prompt| ssn.run::<_, GenerationResponse>(prompt)),
+)
+.await?;
+
+for handle in handles {
+    let response = handle.wait().await?;
+    println!("{response:?}");
+}
+```
+
+### Service Macro API
+
+The stable runtime boundary remains the existing trait:
+
+```rust
+#[tonic::async_trait]
+pub trait FlameService: Send + Sync + 'static {
+    async fn on_session_enter(&self, _: SessionContext) -> Result<(), FlameError>;
+    async fn on_task_invoke(&self, _: TaskContext) -> Result<Option<TaskOutput>, FlameError>;
+    async fn on_session_leave(&self) -> Result<(), FlameError>;
+}
+```
+
+The macros expand user entrypoints into generated wrappers that implement `FlameService`. Users own the service function or service type and business logic. Generated wrappers own adapter state, such as the current `SessionContext`.
+
+This mirrors FlamePy with Rust-native syntax:
+
+| FlamePy | Rust macro proposal |
+| --- | --- |
+| `instance = FlameInstance()` | annotated entrypoint function or struct-backed instance |
+| `@instance.entrypoint` | `#[flame_rs::entrypoint]` |
+| entrypoint has zero or one parameter | entrypoint supports zero input, required input, optional input, and optional `FlameInstance` handle |
+| `instance.context()` | `FlameInstance::common_data<T>()` for `T: FlameMessage` in MVP; cache-backed context after Rust cache SDK support |
+| `instance.update_context(data)` | staged for the Rust cache SDK, not part of the MVP |
+| `instance.run()` | `flame_rs::run(...).await` inside the user's `main` |
+
+Example typed service:
+
+```rust
+use flame_rs::apis::FlameError;
+
+#[derive(Default, serde::Serialize, serde::Deserialize, flame_rs::FlameMessage)]
+struct PingRequest {
+    duration: Option<u64>,
+}
+
+#[derive(serde::Serialize, serde::Deserialize, flame_rs::FlameMessage)]
+struct PingResponse {
+    message: String,
+}
+
+#[flame_rs::entrypoint]
+async fn ping(req: Option<PingRequest>) -> Result<PingResponse, FlameError> {
+    let req = req.unwrap_or_default();
+    Ok(PingResponse {
+        message: format!("duration={:?}", req.duration),
+    })
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    flame_rs::run(ping).await
+}
+```
+
+Example stateful typed service:
+
+```rust
+use std::sync::Mutex;
+use flame_rs::apis::FlameError;
+use flame_rs::service::FlameInstance;
+
+#[derive(serde::Serialize, serde::Deserialize, flame_rs::FlameMessage)]
+struct GenerationRequest {
+    prompt: String,
+}
+
+#[derive(serde::Serialize, serde::Deserialize, flame_rs::FlameMessage)]
+struct GenerationResponse {
+    text: String,
+}
+
+#[derive(Default)]
+struct ModelService {
+    assets: Mutex<Option<Assets>>,
+}
+
+#[flame_rs::instance]
+impl ModelService {
+    async fn enter(&self, _instance: FlameInstance) -> Result<(), FlameError> {
+        *self.assets.lock().unwrap() = Some(load_assets()?);
+        Ok(())
+    }
+
+    #[flame_rs::entrypoint]
+    async fn generate(&self, req: GenerationRequest) -> Result<GenerationResponse, FlameError> {
+        let assets = self.assets.lock().unwrap();
+        run_generation(assets.as_ref().unwrap(), req)
+    }
+
+    async fn leave(&self) -> Result<(), FlameError> {
+        *self.assets.lock().unwrap() = None;
+        Ok(())
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    flame_rs::run(ModelService::default()).await
+}
+```
+
+Supported entrypoint signatures:
+
+```rust
+async fn invoke(&self) -> Result<O, FlameError>
+async fn invoke(&self, input: I) -> Result<O, FlameError>
+async fn invoke(&self, input: Option<I>) -> Result<O, FlameError>
+async fn invoke(&self, instance: FlameInstance) -> Result<O, FlameError>
+async fn invoke(&self, instance: FlameInstance, input: I) -> Result<O, FlameError>
+async fn invoke(&self, instance: FlameInstance, input: Option<I>) -> Result<O, FlameError>
+```
+
+For free-function entrypoints, the same signatures are supported without `&self`.
+
+`FlameInstance` is a lightweight runtime handle passed by the generated adapter:
+
+```rust
+pub struct FlameInstance {
+    session: SessionContext,
+}
+
+impl FlameInstance {
+    pub fn session_id(&self) -> &str;
+    pub fn application(&self) -> &ApplicationContext;
+    pub fn common_data<T>(&self) -> Result<Option<T>, FlameError>
+    where
+        T: FlameMessage;
+}
+```
+
+This starts narrower than FlamePy's `context()` and `update_context()` methods because the Rust SDK does not yet expose the object-cache APIs that FlamePy uses for cached context. Cache-backed context update methods should be added after Rust `ObjectRef`, `get_object`, and `update_object` are available.
+
+To make this practical, `ApplicationContext`, `SessionContext`, and `TaskContext` should derive `Clone` and `Debug`. They contain owned strings and `Bytes`, so cloning is acceptable for adapter use.
+
+For typed payloads:
+
+- `I` must implement `FlameMessage` for required and optional typed input.
+- `O` must implement `FlameMessage`, unless `O` is `()`.
+- Missing required input returns `FlameError::InvalidConfig`.
+- `Option<I>` receives `None` when the task input is absent.
+
+Raw `TaskInput` and `TaskOutput` are not supported by the high-level macros. Services that need raw payload control should implement `flame_rs::service::FlameService` directly.
+
+Supported hook signatures:
+
+```rust
+async fn enter(&self) -> Result<(), FlameError>
+async fn enter(&self, instance: FlameInstance) -> Result<(), FlameError>
+async fn leave(&self) -> Result<(), FlameError>
+```
+
+Generated implementations do not support mutable `&mut self`; service state should use the same interior-mutability patterns already required by the current `FlameService` trait.
+
+**CLI:**
+
+No user-facing Flame CLI changes.
+
+**Other Interfaces:**
+
+Add reusable message conversion helpers under `flame_rs::message`:
+
+```rust
+pub fn decode<T>(input: TaskInput) -> Result<T, FlameError>
+where
+    T: FlameMessage;
+
+pub fn decode_optional<T>(input: Option<TaskInput>) -> Result<Option<T>, FlameError>
+where
+    T: FlameMessage;
+
+pub fn encode<T>(output: T) -> Result<Option<TaskOutput>, FlameError>
+where
+    T: FlameMessage;
+
+pub fn encode_optional<T>(output: Option<T>) -> Result<Option<TaskOutput>, FlameError>
+where
+    T: FlameMessage;
+
+pub fn encode_unit() -> Result<Option<TaskOutput>, FlameError>;
+```
+
+Client helpers and service macros should call these helpers instead of embedding repeated parsing code. They are public so manual clients and service adapters can share the same behavior. `flame_rs::service::message` may re-export this module for service-oriented imports, but `flame_rs::message` is the canonical path.
+
+**Scope:**
+
+In scope:
+
+- Top-level Rust client helpers for default-context connections, creating sessions, and opening sessions.
+- `SessionOptions` as a builder-compatible replacement for repetitive `SessionAttributes` construction.
+- `Session::invoke(...)`, `Session::run(...)`, typed `FlameMessage` invocation helpers, and task handles.
+- `FlameMessage` derive support for input, output, and common-data payloads.
+- Optional proc-macro support for Rust FlameInstance-style service implementations.
+- Free-function entrypoint services for the simplest FlamePy-like path.
+- Struct-backed instance services for stateful model/service code.
+- A lightweight `FlameInstance` handle for session/task/common-data access.
+- Typed `FlameMessage` task and common-data payloads.
+- Optional lifecycle hook methods.
+- High-level `flame_rs::run(...)` helper used from a user-authored `main` function.
+- Compile-time validation for unsupported signatures.
+- Tests and docs for generated behavior.
+
+Out of scope:
+
+- Multiple task endpoints per service. The current shim invokes one task method per service.
+- A new wire protocol or protobuf change.
+- Automatic application YAML generation.
+- Separate client-side typed task macros beyond `FlameMessage`.
+- A Rust equivalent of Python `cloudpickle` service sessions.
+- A global default connection singleton. This can be added later if repeated context loading becomes a measured problem.
+- Python service API changes.
+- User-facing serialization format selection. `FlameMessage` owns the typed serialization contract.
+- Raw payload support in the simplified client and service macro APIs. Existing `flame_rs::client::Session::{create_task, run_task, watch_task}` and manual `FlameService` implementations remain the raw path.
+- Full FlamePy `context()` and `update_context()` parity until Rust has object-cache APIs.
+- Local FastAPI-style debug serving in the MVP; Rust local debug mode can be a later feature.
+
+Limitations:
+
+- The macro does not remove the need for explicit state synchronization inside a service.
+- `FlameMessage` is the ergonomic typed path. Performance-sensitive binary payloads should continue using the existing low-level APIs until a typed binary message format is designed.
+- Proc-macro errors must be carefully tested so users do not see opaque generated-code failures.
+
+**Feature Interaction:**
+
+Related features:
+
+- Rust SDK client runtime: `sdk/rust/src/client/mod.rs`
+- Rust SDK context loading: `sdk/rust/src/apis/ctx.rs`
+- Rust SDK service runtime: `sdk/rust/src/service/mod.rs`
+- Host shim gRPC bridge: `executor_manager/src/shims/host_shim.rs`
+- Existing Rust services: `flmping`, `flmexec`, `examples/pi/rust`
+- Model-serving examples
+
+Updates required:
+
+- `sdk/rust/src/client/mod.rs`: add `SessionOptions`, top-level helpers, invocation helpers, and task handles.
+- `sdk/rust/src/lib.rs`: re-export high-level client helpers, `FlameMessage`, and message conversion traits at the crate root.
+- `sdk/rust/src/message.rs`: add `FlameMessage`, input/output/common-data conversion traits, and shared message helpers.
+- `sdk/rust/Cargo.toml`: optional `flame-rs-macros` dependency behind `macros`.
+- Root `Cargo.toml`: add `sdk/rust/macros` as a workspace member.
+- `sdk/rust/src/service/mod.rs`: re-export shared message helpers for service imports and expose `FlameInstance`.
+- Rust SDK docs and at least one example should show the macro path.
+
+Compatibility:
+
+- No breaking changes to `Connection`, `Session`, `SessionAttributes`, or `TaskInformer`.
+- No breaking changes to `FlameService`.
+- Existing manual service implementations remain supported.
+- Existing manual client implementations remain supported.
+- Macro-generated wrapper services produce the same gRPC responses as manual implementations.
+- The `macros` feature is opt-in to avoid adding `syn`/`quote` compile cost to minimal SDK consumers.
+
+Breaking changes:
+
+- None.
+
+## 3. Implementation Details
+
+**Architecture:**
+
+The simplification layer has a client half and a service half. Neither changes the Flame runtime protocol.
+
+Client helpers are thin async wrappers over the existing frontend gRPC client:
+
+```text
+flame_rs::create_session(...)
+      |
+      | loads FlameContext and connects
+      v
+Connection::create_session(SessionAttributes)
+      |
+      v
+Existing Frontend gRPC API
+
+Session::invoke(...)
+      |
+      | create task + watch task + collect output
+      v
+Existing Session::create_task / watch_task flow
+```
+
+The service macro layer is a source-level adapter:
+
+```text
+User entrypoint function or instance impl
+      |
+      | #[flame_rs::entrypoint] / #[flame_rs::instance]
+      v
+Generated wrapper impl FlameService
+      |
+      v
+Existing flame_rs::service::run()
+      |
+      v
+Existing HostShim / GrpcShim / Executor flow
+```
+
+**Components:**
+
+- `sdk/rust/src/client/mod.rs`
+  - Add `SessionOptions` and conversion to `SessionAttributes`.
+  - Preserve session common data on `Session` so callers can decode it through `Session::common_data<T>()`.
+  - Add default-context helpers: `connect`, `connect_with_context`, `connect_with_config`, `create_session`, `open_session`, and `open_or_create_session`.
+  - Add connection-level `create_session_with` and `open_or_create_session_with` for reused connections.
+  - Add high-level `Session::invoke`, `Session::run`, and typed common-data accessors.
+  - Add generic `TaskHandle<O>`.
+
+- `sdk/rust/src/message.rs`
+  - Define `FlameMessage`, `IntoTaskInput`, `FromTaskOutput`, and `IntoCommonData`.
+  - Provide shared encode/decode helpers for typed task payloads and common data.
+  - Serve client helpers, macro output, and manual services.
+
+- `sdk/rust/macros`
+  - New `proc-macro = true` crate.
+  - Derive `FlameMessage` for typed payload structs and enums.
+  - Parse free-function `#[flame_rs::entrypoint(...)]`.
+  - Parse impl-block `#[flame_rs::instance(...)]` and its entrypoint marker.
+  - Validate method signatures.
+  - Emit a `FlameService` impl.
+
+- `sdk/rust/src/service/mod.rs`
+  - Re-export shared `message` helpers for service imports.
+  - Expose `FlameInstance`.
+  - Add `Clone`/`Debug` derives to service context structs.
+  - Re-export `tonic::async_trait` for generated code if needed.
+
+- `sdk/rust/src/lib.rs`
+  - Re-export high-level client helpers and message traits.
+  - Re-export `flame_rs_macros::{FlameMessage, entrypoint, instance}` behind `macros`.
+  - Export `run(...)` and the conversion trait that turns generated typed entrypoints into `FlameService` wrappers.
+
+**Data Structures:**
+
+No runtime data model changes.
+
+Client helper data structures are SDK-only wrappers around existing types:
+
+```rust
+pub struct SessionOptions {
+    id: Option<SessionID>,
+    application: String,
+    common_data: Option<CommonData>,
+    min_instances: u32,
+    max_instances: Option<u32>,
+    batch_size: u32,
+    priority: u32,
+    resreq: Option<ResourceRequirement>,
+}
+
+// Added to the existing client Session representation.
+pub struct Session {
+    common_data: Option<CommonData>,
+    // existing fields omitted
+}
+
+pub struct TaskHandle<O> {
+    session: Session,
+    task_id: TaskID,
+    _output: std::marker::PhantomData<O>,
+}
+```
+
+`TaskHandle` owns a cloned `Session`, which is cheap because the underlying `Connection` is cloneable. Dropping a handle does not cancel the remote task in the MVP. Explicit cancellation can be designed separately if the frontend protocol grows that operation.
+
+Generated services use a small wrapper:
+
+```rust
+pub struct GeneratedInstance<T> {
+    inner: T,
+    session: std::sync::Mutex<Option<SessionContext>>,
+}
+```
+
+For free functions, `T` is a zero-sized marker. For struct-backed instances, `T` is the user service type.
+
+The high-level runner accepts generated entrypoint descriptors or generated instance wrappers:
+
+```rust
+pub trait IntoFlameInstance {
+    type Service: FlameService;
+
+    fn into_flame_instance(self) -> Self::Service;
+}
+
+pub async fn run<T>(target: T) -> Result<(), Box<dyn std::error::Error>>
+where
+    T: IntoFlameInstance,
+{
+    crate::apis::init_logger()?;
+    crate::service::run(target.into_flame_instance()).await
+}
+```
+
+The existing `flame_rs::service::run(service)` remains the lower-level runner for manual services, including raw byte services and callers that want to initialize logging or runtime behavior themselves.
+
+Internal macro parser structures:
+
+```rust
+struct ServiceMacroArgs {
+    entrypoint_method: Option<String>,
+    enter_method: Option<String>,
+    leave_method: Option<String>,
+    debug: bool,
+    crate_path: syn::Path,
+}
+
+struct HandlerSignature {
+    has_instance_handle: bool,
+    input: HandlerInput,
+    output: HandlerOutput,
+}
+
+enum HandlerInput {
+    None,
+    Required(syn::Type),
+    Optional(syn::Type),
+}
+```
+
+**Generated Code Sketch:**
+
+For a free-function entrypoint:
+
+```rust
+#[derive(serde::Serialize, serde::Deserialize, flame_rs::FlameMessage)]
+struct PingRequest {
+    duration: Option<u64>,
+}
+
+#[derive(serde::Serialize, serde::Deserialize, flame_rs::FlameMessage)]
+struct PingResponse {
+    message: String,
+}
+
+#[flame_rs::entrypoint]
+async fn ping(req: Option<PingRequest>) -> Result<PingResponse, FlameError> {
+    ...
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    flame_rs::run(ping).await
+}
+```
+
+The macro turns the annotated function into an entrypoint descriptor and emits a hidden wrapper service equivalent to:
+
+```rust
+pub const ping: __FlamePingEntrypoint = __FlamePingEntrypoint;
+
+async fn __flame_ping_impl(req: Option<PingRequest>) -> Result<PingResponse, FlameError> {
+    ...
+}
+
+struct __FlamePingEntrypoint;
+
+struct __FlamePingInstance {
+    session: std::sync::Mutex<Option<flame_rs::service::SessionContext>>,
+}
+
+impl flame_rs::IntoFlameInstance for __FlamePingEntrypoint {
+    type Service = __FlamePingInstance;
+
+    fn into_flame_instance(self) -> Self::Service {
+        __FlamePingInstance::default()
+    }
+}
+
+#[flame_rs::service::async_trait]
+impl flame_rs::service::FlameService for __FlamePingInstance {
+    async fn on_session_enter(
+        &self,
+        ctx: flame_rs::service::SessionContext,
+    ) -> Result<(), flame_rs::apis::FlameError> {
+        *self.session.lock().map_err(|_| {
+            flame_rs::apis::FlameError::Internal("instance session lock poisoned".to_string())
+        })? = Some(ctx);
+        Ok(())
+    }
+
+    async fn on_task_invoke(
+        &self,
+        ctx: flame_rs::service::TaskContext,
+    ) -> Result<Option<flame_rs::apis::TaskOutput>, flame_rs::apis::FlameError> {
+        let req = flame_rs::message::decode_optional::<PingRequest>(ctx.input)?;
+        let output = __flame_ping_impl(req).await?;
+        flame_rs::message::encode(output)
+    }
+
+    async fn on_session_leave(&self) -> Result<(), flame_rs::apis::FlameError> {
+        *self.session.lock().map_err(|_| {
+            flame_rs::apis::FlameError::Internal("instance session lock poisoned".to_string())
+        })? = None;
+        Ok(())
+    }
+}
+```
+
+The user writes the service binary entrypoint explicitly:
+
+```rust
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    flame_rs::run(ping).await
+}
+```
+
+For a struct-backed instance, `#[flame_rs::instance]` keeps the inherent impl and emits a generated wrapper around the user type. This is required because Rust macros cannot add hidden fields to a user's struct.
+
+The proc macro should use `proc_macro_crate` plus a `crate = "..."` override so renamed dependencies work.
+
+**Algorithms:**
+
+Default connection:
+
+1. Load `FlameContext::from_file_with_env(None)`.
+2. Read the current context's cluster endpoint and optional TLS config.
+3. Call existing `client::connect_with_tls(endpoint, tls.as_ref())`.
+4. Return the existing `Connection` type.
+
+High-level session creation:
+
+1. Convert `impl Into<SessionOptions>` into `SessionOptions`.
+2. Validate that `application` is not empty.
+3. Fill a missing session ID with `<application>-<stdng::rand::short_name()>`.
+4. Convert `SessionOptions` into existing `SessionAttributes`.
+5. Create a default `Connection`.
+6. Call `Connection::create_session(&attrs)`.
+
+Synchronous client invocation:
+
+1. Convert `impl IntoTaskInput` into `Option<TaskInput>`.
+2. Call existing `Session::create_task(input)`.
+3. Watch the task to terminal state through an internal one-shot informer, or factor the current stream loop into a private helper that returns the final `Task`.
+4. Return task output on success.
+5. Map terminal failure states into `FlameError` with task ID and event details.
+
+Typed message client invocation:
+
+1. Convert input with `IntoTaskInput`. For `T: FlameMessage`, call `T::encode`; for `()`, produce no task input.
+2. Call `invoke(...)` or `run(...)`.
+3. Decode present output through `FromTaskOutput`. For `O: FlameMessage`, call `O::decode`.
+4. Return `Ok(None)` if the service produced no output.
+5. Map serialization failures to `FlameError::InvalidConfig` and decode failures to `FlameError::Internal`.
+
+Attribute parsing:
+
+1. Parse `entrypoint`, `enter`, `leave`, `debug`, and `crate`.
+2. Determine whether the target item is a free function or an inherent impl block.
+3. For free functions, validate the function as the single task entrypoint.
+4. For impl blocks, find exactly one entrypoint by marker attribute or configured method name.
+5. Detect optional hooks by configured/default names.
+6. Validate receiver is `&self` for instance methods.
+7. Validate async methods and return shape.
+8. Generate trait methods and message conversion calls.
+9. Preserve the original function or impl block unchanged, removing consumed helper attributes from emitted impl items.
+
+Input conversion:
+
+1. If the entrypoint has no input parameter, do not inspect `ctx.input`.
+2. If a parameter is `FlameInstance`, construct it from session/task context and pass it.
+3. If parameter is `I: FlameMessage`, require input bytes and decode.
+4. If parameter is `Option<I>`, decode only when bytes are present.
+5. Map decode failures to `FlameError::InvalidConfig`.
+
+Output conversion:
+
+1. `()` maps to `Ok(None)`.
+2. `O: FlameMessage` maps via `O::encode`.
+3. `Option<O>` maps absent output to `None`.
+4. Map encode failures to `FlameError::Internal`.
+
+Error handling:
+
+- MVP handler methods return `Result<_, FlameError>`.
+- Future extension may support `error = "display"` for `Result<_, E>` where `E: Display`, mapping to `FlameError::Internal(e.to_string())`.
+
+**System Considerations:**
+
+Performance:
+
+- Client `invoke(...)` does the same frontend calls as manual `create_task` plus `watch_task`.
+- Top-level session helpers open a connection per call; callers that issue many operations should reuse `Connection` and call the connection-level helper methods.
+- Macro-generated code is equivalent to hand-written adapter code.
+- `FlameMessage` serialization cost is explicit at the payload type boundary.
+- Raw byte performance remains a property of the existing low-level APIs, not this simplified layer.
+
+Scalability:
+
+- No scheduler, executor, or shim changes.
+- Existing per-instance concurrency constraints remain unchanged.
+
+Reliability:
+
+- Client task handles should report failed or cancelled tasks as `FlameError` instead of silently returning absent output.
+- Generated code must avoid `unwrap`.
+- Missing input and bad message bytes should become structured `FlameError::InvalidConfig`.
+- Hook failures propagate exactly as current manual implementations do.
+
+Resource Usage:
+
+- Runtime memory usage is unchanged except for normal message encode/decode buffers.
+- Compile-time cost of `syn`/`quote` is isolated behind the optional `macros` feature.
+
+Security:
+
+- No new code execution path beyond user service code.
+- Message decoding should not log request bodies by default.
+- Error messages should include type/context, not sensitive payload contents.
+
+Observability:
+
+- Client helper errors should include session ID and task ID when available.
+- Generated trait methods should preserve current `tracing::debug!` behavior from `ShimService`.
+- Optional macro-generated trace spans can be added later, but MVP should avoid surprising log volume.
+
+Operational:
+
+- Service binaries are launched the same way by HostShim.
+- Application YAML does not change.
+- Operators can continue debugging generated services through normal Rust logs and task events.
+
+**Dependencies:**
+
+New optional compile-time dependencies:
+
+- `syn`
+- `quote`
+- `proc-macro2`
+- `proc-macro-crate`
+
+Existing runtime dependencies used:
+
+- `bytes`
+- `futures`
+- `serde`
+- `serde_json`
+- `tokio`
+- `tonic`
+
+## 4. Use Cases
+
+**Example 1: Simple Rust Client**
+
+Description:
+
+Create a Flame session and invoke a typed service once without manually managing `Connection`, `SessionAttributes`, task creation, task watching, or `TaskInformer`.
+
+Workflow:
+
+1. Build a `SessionOptions` value or pass the application name directly.
+2. Call `flame_rs::create_session(...)`.
+3. Call `ssn.invoke(...)` for typed `FlameMessage` request/response data.
+4. Close the session.
+
+Expected outcome:
+
+- The client code is close to FlamePy's `flamepy.create_session(...)` plus `ssn.invoke(...)` shape.
+- Existing low-level Rust APIs remain available for callers that need custom task watching.
+- Typed examples do not repeat byte serialization and deserialization code.
+
+**Example 2: Parallel Rust Client Invocations**
+
+Description:
+
+Submit multiple prompts or work items to the same session and collect results later.
+
+Workflow:
+
+1. Create or open a session once.
+2. Call `ssn.run::<_, ResponseType>(...)` for each request.
+3. Await each `TaskHandle<ResponseType>::wait()` as capacity becomes available.
+
+Expected outcome:
+
+- Client code can express FlamePy's `ssn.run(...)` pattern with explicit Rust async handles.
+- The handle API leaves room for future cancellation without changing the one-shot `invoke(...)` method.
+
+**Example 3: Simple Typed Service**
+
+Description:
+
+Convert `flmping` service logic to a typed request/response entrypoint.
+
+Workflow:
+
+1. Add `features = ["macros"]` to the `flame-rs` dependency.
+2. Derive `FlameMessage` on `PingRequest` and `PingResponse`.
+3. Replace the manual trait impl with a free function marked `#[flame_rs::entrypoint]`.
+4. Write `async fn ping(req: Option<PingRequest>) -> Result<PingResponse, FlameError>`.
+5. Call `flame_rs::run(ping).await` from the service binary `main`.
+
+Expected outcome:
+
+- Same wire format as current `flmping`.
+- Less boilerplate in the service file.
+- No direct `tonic` dependency needed by the service binary for the trait impl.
+
+**Example 4: Stateful Model Service**
+
+Description:
+
+Simplify a model-serving service.
+
+Workflow:
+
+1. Store model assets in `Mutex<Option<Assets>>`.
+2. Use `enter` to load model files and tokenizer once per executor instance.
+3. Mark the typed `generate` method with `#[flame_rs::entrypoint]`.
+4. Use `leave` to release assets.
+5. Call `flame_rs::run(ModelService::default()).await` from the service binary `main`.
+
+Expected outcome:
+
+- Service lifecycle remains explicit.
+- Task handler code deals with `GenerationRequest` and `GenerationResponse`, not task bytes.
+- Existing Flame session semantics are unchanged.
+
+## 5. References
+
+**Related Documents:**
+
+- `docs/designs/templates.md`
+- `docs/api/shim.md`
+- `docs/designs/RFE323-runner-v2/FS.md`
+
+**Implementation References:**
+
+- `sdk/rust/src/client/mod.rs`
+- `sdk/rust/src/apis/ctx.rs`
+- `sdk/rust/src/service/mod.rs`
+- `sdk/rust/Cargo.toml`
+- `sdk/python/src/flamepy/core/client.py`
+- `sdk/python/src/flamepy/service/client.py`
+- `examples/pi/rust/src/service.rs`
+- `flmping/src/service.rs`
+- `flmexec/src/service.rs`
+
+**Test Plan:**
+
+- Unit tests for client helpers:
+  - `SessionOptions::from("app")` matches current FlamePy-style defaults
+  - builder setters map correctly to `SessionAttributes`
+  - `resreq("cpu=4,mem=16g,gpu=1")` uses existing `ResourceRequirement` parsing
+  - `IntoTaskInput` implementations encode `FlameMessage` inputs and optional absence
+  - `IntoTaskInput for ()` produces absent task input
+  - `TaskHandle::id()` returns the created task ID
+
+- Unit tests for shared `message` helpers:
+  - `FlameMessage` derive encodes and decodes a typed payload
+  - missing required message input returns `InvalidConfig`
+  - optional message input accepts absence
+  - invalid message bytes return `InvalidConfig`
+  - typed output serializes to bytes
+  - unit output returns no task output
+  - client-side typed output decode handles absent output as `None`
+  - typed common data round-trips through `SessionOptions::common_data`
+
+- `trybuild` compile-pass tests for macro signatures:
+  - `FlameMessage` derive on request, response, and common-data types
+  - typed handler with required input
+  - typed handler with optional input
+  - free-function entrypoint
+  - struct-backed instance entrypoint
+  - handler with `FlameInstance` plus input
+  - hooks present and hooks omitted
+  - custom method names
+
+- `trybuild` compile-fail tests:
+  - missing entrypoint method
+  - more than one entrypoint method
+  - non-async entrypoint
+  - `&mut self` receiver
+  - typed input without `FlameMessage`
+  - entrypoint input using `TaskInput`
+  - entrypoint output using `TaskOutput`
+
+- Integration smoke tests:
+  - Add or update a Rust client example to use `flame_rs::create_session(...)` and `ssn.invoke(...)`.
+  - Convert or add a minimal Rust example service using the macro.
+  - `cargo check -p flame-rs`.
+  - `cargo check -p flame-rs --features macros`.
+  - `cargo check` for the converted client/service examples.
+  - Existing `cargo check --workspace --exclude cri-rs` still passes.

--- a/flmexec/Cargo.toml
+++ b/flmexec/Cargo.toml
@@ -18,7 +18,6 @@ serde_json = { workspace = true }
 serde_derive = { workspace = true }
 futures = { workspace = true }
 clap = { workspace = true }
-chrono = { workspace = true }
 indicatif = {version = "*", features = ["rayon"]}
 tempfile = { workspace = true }
 rand = { workspace = true }

--- a/flmexec/src/client.rs
+++ b/flmexec/src/client.rs
@@ -14,15 +14,15 @@ limitations under the License.
 use futures::future::try_join_all;
 use std::error::Error;
 use std::sync::{Arc, Mutex};
+use std::time::Instant;
 
-use chrono::Local;
 use clap::Parser;
 use indicatif::HumanCount;
 use serde_derive::{Deserialize, Serialize};
 
 use flame_rs as flame;
-use flame_rs::apis::{FlameContext, FlameError};
-use flame_rs::client::{SessionAttributes, Task, TaskInformer};
+use flame_rs::apis::FlameError;
+use flame_rs::client::{SessionOptions, Task, TaskInformer};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct Script {
@@ -68,37 +68,20 @@ async fn main() -> Result<(), Box<dyn Error>> {
     flame::apis::init_logger()?;
     let cli = Cli::parse();
 
-    let ctx = FlameContext::from_file(cli.config)?;
-
     let task_num = cli.task_num.unwrap_or(DEFAULT_TASK_NUM);
 
-    let current_ctx = ctx.get_current_context()?;
-    let conn = flame::client::connect_with_tls(
-        &current_ctx.cluster.endpoint,
-        current_ctx.cluster.tls.as_ref(),
-    )
-    .await?;
+    let conn = flame::connect_with_config(cli.config).await?;
 
-    let ssn_creation_start_time = Local::now();
-    let ssn_attr = SessionAttributes {
-        id: format!("{DEFAULT_APP}-{}", stdng::rand::short_name()),
-        application: DEFAULT_APP.to_string(),
-        common_data: None,
-        min_instances: 0,
-        max_instances: None,
-        batch_size: 1,
-        priority: 0,
-        resreq: None,
-    };
-    let ssn = conn.create_session(&ssn_attr).await?;
-    let ssn_creation_end_time = Local::now();
+    let ssn_creation_start_time = Instant::now();
+    let ssn = conn
+        .create_session_with(SessionOptions::new(DEFAULT_APP))
+        .await?;
 
-    let ssn_creation_time =
-        ssn_creation_end_time.timestamp_millis() - ssn_creation_start_time.timestamp_millis();
+    let ssn_creation_time = ssn_creation_start_time.elapsed().as_millis();
     println!("Session <{}> was created in <{ssn_creation_time} ms>, start to run <{}> tasks in the session:\n", ssn.id, HumanCount(task_num as u64));
 
     let mut tasks = vec![];
-    let tasks_creations_start_time = Local::now();
+    let tasks_creations_start_time = Instant::now();
 
     let info = Arc::new(Mutex::new(ExecInfo {}));
 
@@ -115,10 +98,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     }
 
     try_join_all(tasks).await?;
-    let tasks_creation_end_time = Local::now();
-
-    let tasks_creation_time =
-        tasks_creation_end_time.timestamp_millis() - tasks_creations_start_time.timestamp_millis();
+    let tasks_creation_time = tasks_creations_start_time.elapsed().as_millis();
 
     println!(
         "\n\n<{}> tasks was completed in <{} ms>.\n",

--- a/flmexec/src/service.rs
+++ b/flmexec/src/service.rs
@@ -65,9 +65,7 @@ impl flame::service::FlameService for FlmexecService {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    flame::apis::init_logger()?;
-
-    flame::service::run(FlmexecService {}).await?;
+    flame::run(FlmexecService {}).await?;
 
     tracing::debug!("FlmexecService was stopped.");
 

--- a/flmping/Cargo.toml
+++ b/flmping/Cargo.toml
@@ -6,16 +6,11 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-flame-rs = { path = "../sdk/rust" }
-stdng = { path = "../stdng" }
+flame-rs = { path = "../sdk/rust", features = ["macros"] }
 
 tokio = { workspace = true }
-tonic = { workspace = true }
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true }
-chrono = { workspace = true }
 serde = { workspace = true }
-serde_json = { workspace = true }
 serde_derive = { workspace = true }
 
 futures = { workspace = true }

--- a/flmping/src/apis.rs
+++ b/flmping/src/apis.rs
@@ -11,55 +11,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use flame_rs::apis::{FlameError, TaskInput, TaskOutput};
-
 use serde_derive::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, flame_rs::FlameMessage)]
 pub struct PingRequest {
     pub duration: Option<u64>,
     pub memory: Option<u64>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, flame_rs::FlameMessage)]
 pub struct PingResponse {
     pub message: String,
-}
-
-impl TryFrom<TaskOutput> for PingResponse {
-    type Error = FlameError;
-    fn try_from(output: TaskOutput) -> Result<Self, Self::Error> {
-        let response: Self =
-            serde_json::from_slice(&output).map_err(|e| FlameError::Internal(e.to_string()))?;
-        Ok(response)
-    }
-}
-
-impl TryFrom<PingResponse> for TaskOutput {
-    type Error = FlameError;
-    fn try_from(response: PingResponse) -> Result<Self, Self::Error> {
-        let bytes = TaskOutput::from(
-            serde_json::to_string(&response).map_err(|e| FlameError::Internal(e.to_string()))?,
-        );
-        Ok(bytes)
-    }
-}
-
-impl TryFrom<PingRequest> for TaskInput {
-    type Error = FlameError;
-    fn try_from(request: PingRequest) -> Result<Self, Self::Error> {
-        let bytes = TaskInput::from(
-            serde_json::to_string(&request).map_err(|e| FlameError::Internal(e.to_string()))?,
-        );
-        Ok(bytes)
-    }
-}
-
-impl TryFrom<TaskInput> for PingRequest {
-    type Error = FlameError;
-    fn try_from(input: TaskInput) -> Result<Self, Self::Error> {
-        let request: Self =
-            serde_json::from_slice(&input).map_err(|e| FlameError::Internal(e.to_string()))?;
-        Ok(request)
-    }
 }

--- a/flmping/src/client.rs
+++ b/flmping/src/client.rs
@@ -122,7 +122,7 @@ async fn run_tasks(
     let handles = try_join_all((0..task_num).map(|_| ssn.run::<_, PingResponse>(&input))).await?;
     let outputs = try_join_all(handles.into_iter().map(|handle| async move {
         let task_id = handle.id().clone();
-        let output = handle.wait().await?;
+        let output = handle.await?;
         Ok::<_, flame::apis::FlameError>((task_id, output))
     }))
     .await?;

--- a/flmping/src/client.rs
+++ b/flmping/src/client.rs
@@ -20,15 +20,13 @@ use byte_unit::Byte;
 use clap::Parser;
 use comfy_table::presets::NOTHING;
 use comfy_table::Table;
-use flame_rs::apis::FlameError;
-use flame_rs::client::{ResourceRequirement, Session, SessionAttributes, Task, TaskInformer};
 use futures::future::try_join_all;
 use indicatif::HumanCount;
-use stdng::{lock_ptr, new_ptr, MutexPtr};
+use serde_derive::{Deserialize, Serialize};
 
 use crate::apis::{PingRequest, PingResponse};
 
-use flame::apis::FlameContext;
+use flame::client::{Session, SessionOptions};
 use flame_rs::{self as flame};
 
 #[derive(Parser)]
@@ -67,45 +65,33 @@ struct Cli {
 
 const DEFAULT_APP: &str = "flmping";
 
+#[derive(Debug, Clone, Serialize, Deserialize, flame::FlameMessage)]
+struct PingCommonData {
+    value: String,
+}
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     flame::apis::init_logger()?;
     let cli = Cli::parse();
 
-    let ctx = FlameContext::from_file(cli.config)?;
-
-    // `resreq` is optional. When `None`, the server fills it from
-    // `cluster.resreq` (or a hardcoded fallback).
-    let resreq = cli
-        .resreq
-        .as_ref()
-        .map(|s| ResourceRequirement::from(s.as_str()));
     let task_num = cli.task_num;
     let memory = match cli.memory {
         Some(s) => Some(Byte::parse_str(&s, true)?.as_u64()),
         None => None,
     };
 
-    let current_ctx = ctx.get_current_context()?;
-
-    let conn = flame::client::connect_with_tls(
-        &current_ctx.cluster.endpoint,
-        current_ctx.cluster.tls.as_ref(),
-    )
-    .await?;
+    let conn = flame::connect_with_config(cli.config).await?;
 
     let ssn_creation_start_time = Instant::now();
-    let ssn_attr = SessionAttributes {
-        id: format!("{DEFAULT_APP}-{}", stdng::rand::short_name()),
-        application: DEFAULT_APP.to_string(),
-        common_data: cli.common_data.map(|s| s.into()),
-        min_instances: 0,
-        max_instances: None,
-        batch_size: 1,
-        priority: cli.priority,
-        resreq,
-    };
-    let ssn = conn.create_session(&ssn_attr).await?;
+    let mut options = SessionOptions::new(DEFAULT_APP).priority(cli.priority);
+    if let Some(resreq) = cli.resreq.as_deref() {
+        options = options.resreq(resreq);
+    }
+    if let Some(common_data) = cli.common_data {
+        options = options.common_data(&PingCommonData { value: common_data })?;
+    }
+    let ssn = conn.create_session_with(options).await?;
     let ssn_creation_end_time = Instant::now();
 
     let ssn_creation_time = ssn_creation_end_time
@@ -124,22 +110,24 @@ async fn main() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-async fn run_tasks<T: TaskInformer + 'static>(
+async fn run_tasks(
     ssn: &Session,
     task_num: i32,
     duration: Option<u64>,
     memory: Option<u64>,
-    informer: MutexPtr<T>,
-) -> Result<u128, Box<dyn Error>> {
-    let input: flame_rs::apis::TaskInput = PingRequest { duration, memory }.try_into()?;
+) -> Result<(u128, Vec<(String, Option<PingResponse>)>), Box<dyn Error>> {
+    let input = PingRequest { duration, memory };
     let start = Instant::now();
 
-    let tasks: Vec<_> = (0..task_num)
-        .map(|_| ssn.run_task(Some(input.clone()), informer.clone()))
-        .collect();
+    let handles = try_join_all((0..task_num).map(|_| ssn.run::<_, PingResponse>(&input))).await?;
+    let outputs = try_join_all(handles.into_iter().map(|handle| async move {
+        let task_id = handle.id().clone();
+        let output = handle.wait().await?;
+        Ok::<_, flame::apis::FlameError>((task_id, output))
+    }))
+    .await?;
 
-    try_join_all(tasks).await?;
-    Ok(start.elapsed().as_millis())
+    Ok((start.elapsed().as_millis(), outputs))
 }
 
 async fn run_perf_mode(
@@ -148,11 +136,8 @@ async fn run_perf_mode(
     duration: Option<u64>,
     memory: Option<u64>,
 ) -> Result<(), Box<dyn Error>> {
-    let info = new_ptr(PerfInformer::new());
-    let duration_ms = run_tasks(ssn, task_num, duration, memory, info.clone()).await?;
-
-    let info = lock_ptr!(info)?;
-    info.print_summary(task_num, duration_ms);
+    let (duration_ms, outputs) = run_tasks(ssn, task_num, duration, memory).await?;
+    print_perf_summary(outputs.len() as u32, task_num, duration_ms);
 
     Ok(())
 }
@@ -163,13 +148,8 @@ async fn run_output_mode(
     duration: Option<u64>,
     memory: Option<u64>,
 ) -> Result<(), Box<dyn Error>> {
-    let info = new_ptr(OutputInfor::new());
-    let duration_ms = run_tasks(ssn, task_num, duration, memory, info.clone()).await?;
-
-    {
-        let info = lock_ptr!(info)?;
-        info.print();
-    }
+    let (duration_ms, outputs) = run_tasks(ssn, task_num, duration, memory).await?;
+    print_outputs(ssn, outputs);
 
     println!(
         "\n\n<{}> tasks was completed in <{} ms>.\n",
@@ -180,92 +160,39 @@ async fn run_output_mode(
     Ok(())
 }
 
-struct OutputInfor {
-    table: Table,
+fn print_outputs(ssn: &Session, outputs: Vec<(String, Option<PingResponse>)>) {
+    let mut table = Table::new();
+
+    table
+        .load_preset(NOTHING)
+        .set_header(vec!["Session", "Task", "State", "Output"]);
+
+    for (task_id, output) in outputs {
+        table.add_row(vec![
+            ssn.id.to_string(),
+            task_id,
+            "Succeed".to_string(),
+            output.map(|output| output.message).unwrap_or_default(),
+        ]);
+    }
+
+    println!("{table}");
 }
 
-impl OutputInfor {
-    fn new() -> Self {
-        let mut table = Table::new();
+fn print_perf_summary(succeeded: u32, task_num: i32, duration_ms: u128) {
+    let duration_secs = duration_ms as f64 / 1000.0;
+    let throughput = if duration_secs > 0.0 {
+        succeeded as f64 / duration_secs
+    } else {
+        0.0
+    };
 
-        table
-            .load_preset(NOTHING)
-            .set_header(vec!["Session", "Task", "State", "Output"]);
-
-        Self { table }
-    }
-}
-
-impl TaskInformer for OutputInfor {
-    fn on_update(&mut self, task: Task) {
-        if task.is_completed() {
-            let output = task.output.unwrap_or_default();
-            if let Ok(output) = <PingResponse>::try_from(output) {
-                self.table.add_row(vec![
-                    task.ssn_id.to_string(),
-                    task.id.to_string(),
-                    task.state.to_string(),
-                    output.message.to_string(),
-                ]);
-            }
-        }
-    }
-
-    fn on_error(&mut self, _: FlameError) {
-        print!("Got an error")
-    }
-}
-
-impl OutputInfor {
-    fn print(&self) {
-        println!("{}", self.table);
-    }
-}
-
-struct PerfInformer {
-    succeeded: u32,
-    failed: u32,
-}
-
-impl PerfInformer {
-    fn new() -> Self {
-        Self {
-            succeeded: 0,
-            failed: 0,
-        }
-    }
-
-    fn print_summary(&self, task_num: i32, duration_ms: u128) {
-        let duration_secs = duration_ms as f64 / 1000.0;
-        let throughput = if duration_secs > 0.0 {
-            self.succeeded as f64 / duration_secs
-        } else {
-            0.0
-        };
-
-        println!("\n{}", "=".repeat(60));
-        println!("BENCHMARK RESULTS");
-        println!("{}", "=".repeat(60));
-        println!("Duration:        {:.2}s", duration_secs);
-        println!("Succeeded:       {}/{}", self.succeeded, task_num);
-        println!("Failed:          {}", self.failed);
-        println!("Throughput:      {:.2} tasks/sec", throughput);
-        println!("{}\n", "=".repeat(60));
-    }
-}
-
-impl TaskInformer for PerfInformer {
-    fn on_update(&mut self, task: Task) {
-        if task.is_completed() {
-            if task.is_succeed() {
-                self.succeeded += 1;
-            } else {
-                self.failed += 1;
-            }
-        }
-    }
-
-    fn on_error(&mut self, _: FlameError) {
-        self.failed += 1;
-    }
+    println!("\n{}", "=".repeat(60));
+    println!("BENCHMARK RESULTS");
+    println!("{}", "=".repeat(60));
+    println!("Duration:        {:.2}s", duration_secs);
+    println!("Succeeded:       {}/{}", succeeded, task_num);
+    println!("Failed:          {}", task_num - succeeded as i32);
+    println!("Throughput:      {:.2} tasks/sec", throughput);
+    println!("{}\n", "=".repeat(60));
 }

--- a/flmping/src/client.rs
+++ b/flmping/src/client.rs
@@ -35,9 +35,6 @@ use flame_rs::{self as flame};
 #[command(version = "0.5.0")]
 #[command(about = "Flame Ping", long_about = None)]
 struct Cli {
-    #[arg(long)]
-    /// The flame configuration file
-    config: Option<String>,
     /// The number of tasks to run
     #[arg(short, long, default_value = "10")]
     task_num: i32,
@@ -81,8 +78,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
         None => None,
     };
 
-    let conn = flame::connect_with_config(cli.config).await?;
-
     let ssn_creation_start_time = Instant::now();
     let mut options = SessionOptions::new(DEFAULT_APP).priority(cli.priority);
     if let Some(resreq) = cli.resreq.as_deref() {
@@ -91,7 +86,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     if let Some(common_data) = cli.common_data {
         options = options.common_data(&PingCommonData { value: common_data })?;
     }
-    let ssn = conn.create_session_with(options).await?;
+    let ssn = flame::create_session(options).await?;
     let ssn_creation_end_time = Instant::now();
 
     let ssn_creation_time = ssn_creation_end_time

--- a/flmping/src/client.rs
+++ b/flmping/src/client.rs
@@ -26,7 +26,7 @@ use serde_derive::{Deserialize, Serialize};
 
 use crate::apis::{PingRequest, PingResponse};
 
-use flame::client::{Session, SessionOptions};
+use flame::client::{Session, SessionOptions, TaskResult};
 use flame_rs::{self as flame};
 
 #[derive(Parser)]
@@ -115,19 +115,14 @@ async fn run_tasks(
     task_num: i32,
     duration: Option<u64>,
     memory: Option<u64>,
-) -> Result<(u128, Vec<(String, Option<PingResponse>)>), Box<dyn Error>> {
+) -> Result<(u128, Vec<TaskResult<PingResponse>>), Box<dyn Error>> {
     let input = PingRequest { duration, memory };
     let start = Instant::now();
 
     let handles = try_join_all((0..task_num).map(|_| ssn.run::<_, PingResponse>(&input))).await?;
-    let task_ids = handles
-        .iter()
-        .map(|handle| handle.id().clone())
-        .collect::<Vec<_>>();
-    let outputs = try_join_all(handles).await?;
-    let outputs = task_ids.into_iter().zip(outputs).collect();
+    let tasks = try_join_all(handles).await?;
 
-    Ok((start.elapsed().as_millis(), outputs))
+    Ok((start.elapsed().as_millis(), tasks))
 }
 
 async fn run_perf_mode(
@@ -136,8 +131,9 @@ async fn run_perf_mode(
     duration: Option<u64>,
     memory: Option<u64>,
 ) -> Result<(), Box<dyn Error>> {
-    let (duration_ms, outputs) = run_tasks(ssn, task_num, duration, memory).await?;
-    print_perf_summary(outputs.len() as u32, task_num, duration_ms);
+    let (duration_ms, tasks) = run_tasks(ssn, task_num, duration, memory).await?;
+    let succeeded = tasks.iter().filter(|task| task.is_succeed()).count() as u32;
+    print_perf_summary(succeeded, task_num, duration_ms);
 
     Ok(())
 }
@@ -148,8 +144,8 @@ async fn run_output_mode(
     duration: Option<u64>,
     memory: Option<u64>,
 ) -> Result<(), Box<dyn Error>> {
-    let (duration_ms, outputs) = run_tasks(ssn, task_num, duration, memory).await?;
-    print_outputs(ssn, outputs);
+    let (duration_ms, tasks) = run_tasks(ssn, task_num, duration, memory).await?;
+    print_outputs(tasks)?;
 
     println!(
         "\n\n<{}> tasks was completed in <{} ms>.\n",
@@ -160,23 +156,39 @@ async fn run_output_mode(
     Ok(())
 }
 
-fn print_outputs(ssn: &Session, outputs: Vec<(String, Option<PingResponse>)>) {
+fn print_outputs(tasks: Vec<TaskResult<PingResponse>>) -> Result<(), Box<dyn Error>> {
     let mut table = Table::new();
 
     table
         .load_preset(NOTHING)
         .set_header(vec!["Session", "Task", "State", "Output"]);
 
-    for (task_id, output) in outputs {
+    for task in tasks {
+        let output = if task.is_succeed() {
+            task.output.map(|output| output.message).unwrap_or_default()
+        } else {
+            format_task_error(&task)
+        };
+
         table.add_row(vec![
-            ssn.id.to_string(),
-            task_id,
-            "Succeed".to_string(),
-            output.map(|output| output.message).unwrap_or_default(),
+            task.session_id,
+            task.task_id,
+            task.state.to_string(),
+            output,
         ]);
     }
 
     println!("{table}");
+    Ok(())
+}
+
+fn format_task_error(task: &TaskResult<PingResponse>) -> String {
+    match (task.error_code, task.error_message.as_deref()) {
+        (Some(code), Some(message)) => format!("code <{}>: {}", code, message),
+        (Some(code), None) => format!("code <{}>", code),
+        (None, Some(message)) => message.to_string(),
+        (None, None) => String::new(),
+    }
 }
 
 fn print_perf_summary(succeeded: u32, task_num: i32, duration_ms: u128) {

--- a/flmping/src/client.rs
+++ b/flmping/src/client.rs
@@ -120,12 +120,12 @@ async fn run_tasks(
     let start = Instant::now();
 
     let handles = try_join_all((0..task_num).map(|_| ssn.run::<_, PingResponse>(&input))).await?;
-    let outputs = try_join_all(handles.into_iter().map(|handle| async move {
-        let task_id = handle.id().clone();
-        let output = handle.await?;
-        Ok::<_, flame::apis::FlameError>((task_id, output))
-    }))
-    .await?;
+    let task_ids = handles
+        .iter()
+        .map(|handle| handle.id().clone())
+        .collect::<Vec<_>>();
+    let outputs = try_join_all(handles).await?;
+    let outputs = task_ids.into_iter().zip(outputs).collect();
 
     Ok((start.elapsed().as_millis(), outputs))
 }

--- a/flmping/src/service.rs
+++ b/flmping/src/service.rs
@@ -17,66 +17,40 @@ use gethostname::gethostname;
 use std::thread;
 use std::time::{Duration, Instant};
 
-use flame_rs::{
-    self as flame,
-    apis::{FlameError, TaskOutput},
-    service::{SessionContext, TaskContext},
-};
+use flame_rs::{self as flame, apis::FlameError};
 
 use self::apis::{PingRequest, PingResponse};
 
-#[derive(Clone)]
-pub struct FlmpingService {}
+#[flame::entrypoint]
+async fn ping(input: Option<PingRequest>) -> Result<PingResponse, FlameError> {
+    let start_time = Instant::now();
+    let input = input.unwrap_or_default();
 
-#[tonic::async_trait]
-impl flame::service::FlameService for FlmpingService {
-    async fn on_session_enter(&self, _: SessionContext) -> Result<(), FlameError> {
-        Ok(())
+    let mem = match input.memory {
+        Some(memory) => vec![0; memory as usize].into_boxed_slice(),
+        None => Box::new([]),
+    };
+
+    if let Some(duration) = input.duration {
+        thread::sleep(Duration::from_millis(duration));
     }
 
-    async fn on_task_invoke(&self, ctx: TaskContext) -> Result<Option<TaskOutput>, FlameError> {
-        let start_time = Instant::now();
+    let end_time = Instant::now();
+    let duration = end_time.duration_since(start_time).as_millis();
 
-        let input = ctx
-            .input
-            .clone()
-            .map(|input| input.try_into())
-            .unwrap_or(Result::Ok(PingRequest::default()))?;
+    let mem_size = Byte::from_u64(mem.len() as u64).to_string();
 
-        let mem = match input.memory {
-            Some(memory) => vec![0; memory as usize].into_boxed_slice(),
-            None => Box::new([]),
-        };
-
-        if let Some(duration) = input.duration {
-            thread::sleep(Duration::from_millis(duration));
-        }
-
-        let end_time = Instant::now();
-        let duration = end_time.duration_since(start_time).as_millis();
-
-        let mem_size = Byte::from_u64(mem.len() as u64).to_string();
-
-        let output = PingResponse {
-            message: format!(
-                "Completed on <{}> in <{duration}> milliseconds with <{mem_size}> memory",
-                gethostname().to_string_lossy(),
-            ),
-        };
-
-        Ok(Some(output.try_into()?))
-    }
-
-    async fn on_session_leave(&self) -> Result<(), FlameError> {
-        Ok(())
-    }
+    Ok(PingResponse {
+        message: format!(
+            "Completed on <{}> in <{duration}> milliseconds with <{mem_size}> memory",
+            gethostname().to_string_lossy(),
+        ),
+    })
 }
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    flame::apis::init_logger()?;
-
-    flame::service::run(FlmpingService {}).await?;
+    flame::run(ping).await?;
 
     tracing::debug!("FlmpingService was stopped.");
 

--- a/flmping/src/service.rs
+++ b/flmping/src/service.rs
@@ -14,7 +14,6 @@ mod apis;
 
 use byte_unit::Byte;
 use gethostname::gethostname;
-use std::thread;
 use std::time::{Duration, Instant};
 
 use flame_rs::{self as flame, apis::FlameError};
@@ -32,7 +31,7 @@ async fn ping(input: Option<PingRequest>) -> Result<PingResponse, FlameError> {
     };
 
     if let Some(duration) = input.duration {
-        thread::sleep(Duration::from_millis(duration));
+        ::tokio::time::sleep(Duration::from_millis(duration)).await;
     }
 
     let end_time = Instant::now();

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -11,6 +11,7 @@ readme = "../../README.md"
 
 [dependencies]
 stdng = { path = "../../stdng" }
+flame-rs-macros = { path = "macros", optional = true }
 
 tower = { workspace = true }
 prost = { workspace = true, features = ["derive"] }
@@ -38,3 +39,7 @@ serde_derive = { workspace = true }
 [build-dependencies]
 tonic-build = { workspace = true }
 tonic-prost-build = { workspace = true }
+
+[features]
+default = []
+macros = ["dep:flame-rs-macros"]

--- a/sdk/rust/macros/Cargo.toml
+++ b/sdk/rust/macros/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "flame-rs-macros"
+version = "0.5.0"
+edition = "2021"
+
+description = "Proc macros for the Flame Rust SDK"
+repository = "https://github.com/xflops/flame"
+license-file = "../../../LICENSE"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro-crate = { workspace = true }
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
+syn = { workspace = true }

--- a/sdk/rust/macros/src/lib.rs
+++ b/sdk/rust/macros/src/lib.rs
@@ -136,12 +136,12 @@ fn expand_flame_message(input: syn::DeriveInput) -> Result<TokenStream2> {
             ) -> ::std::result::Result<#crate_path::__private::bytes::Bytes, #crate_path::apis::FlameError> {
                 #crate_path::__private::serde_json::to_vec(self)
                     .map(#crate_path::__private::bytes::Bytes::from)
-                    .map_err(|err| #crate_path::apis::FlameError::InvalidConfig(err.to_string()))
+                    .map_err(|err| #crate_path::apis::FlameError::Internal(err.to_string()))
             }
 
             fn decode(bytes: &[u8]) -> ::std::result::Result<Self, #crate_path::apis::FlameError> {
                 #crate_path::__private::serde_json::from_slice(bytes)
-                    .map_err(|err| #crate_path::apis::FlameError::Internal(err.to_string()))
+                    .map_err(|err| #crate_path::apis::FlameError::InvalidConfig(err.to_string()))
             }
         }
     })
@@ -309,7 +309,7 @@ fn expand_instance(args: MacroArgs, mut item: ItemImpl) -> Result<TokenStream2> 
         }
     }
 
-    entrypoint_methods.sort_by(|a, b| a.to_string().cmp(&b.to_string()));
+    entrypoint_methods.sort_by_key(|a| a.to_string());
     entrypoint_methods.dedup_by(|a, b| a == b);
 
     let entrypoint_ident = match entrypoint_methods.as_slice() {

--- a/sdk/rust/macros/src/lib.rs
+++ b/sdk/rust/macros/src/lib.rs
@@ -1,0 +1,821 @@
+/*
+Copyright 2026 The Flame Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use proc_macro::TokenStream;
+use proc_macro2::{Span, TokenStream as TokenStream2};
+use proc_macro_crate::{crate_name, FoundCrate};
+use quote::{format_ident, quote};
+use syn::ext::IdentExt;
+use syn::parse::{Parse, ParseStream};
+use syn::{
+    parse_macro_input, parse_quote, Error, FnArg, GenericArgument, Ident, ImplItem, ImplItemFn,
+    ItemFn, ItemImpl, LitBool, LitStr, Path, PathArguments, Result, ReturnType, Token, Type,
+};
+
+#[proc_macro_derive(FlameMessage)]
+pub fn derive_flame_message(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as syn::DeriveInput);
+    expand_flame_message(input)
+        .unwrap_or_else(Error::into_compile_error)
+        .into()
+}
+
+#[proc_macro_attribute]
+pub fn entrypoint(args: TokenStream, input: TokenStream) -> TokenStream {
+    let args = parse_macro_input!(args as MacroArgs);
+    let input = parse_macro_input!(input as ItemFn);
+    expand_entrypoint(args, input)
+        .unwrap_or_else(Error::into_compile_error)
+        .into()
+}
+
+#[proc_macro_attribute]
+pub fn instance(args: TokenStream, input: TokenStream) -> TokenStream {
+    let args = parse_macro_input!(args as MacroArgs);
+    let input = parse_macro_input!(input as ItemImpl);
+    expand_instance(args, input)
+        .unwrap_or_else(Error::into_compile_error)
+        .into()
+}
+
+#[derive(Default)]
+struct MacroArgs {
+    crate_path: Option<Path>,
+    entrypoint: Option<String>,
+    enter: Option<String>,
+    leave: Option<String>,
+    debug: bool,
+}
+
+impl Parse for MacroArgs {
+    fn parse(input: ParseStream<'_>) -> Result<Self> {
+        let mut args = MacroArgs::default();
+
+        while !input.is_empty() {
+            let key = input.call(Ident::parse_any)?;
+
+            if key == "debug" {
+                if input.peek(Token![=]) {
+                    input.parse::<Token![=]>()?;
+                    args.debug = input.parse::<LitBool>()?.value;
+                } else {
+                    args.debug = true;
+                }
+            } else {
+                input.parse::<Token![=]>()?;
+                match key.to_string().as_str() {
+                    "crate" => args.crate_path = Some(input.parse()?),
+                    "entrypoint" => args.entrypoint = Some(input.parse::<LitStr>()?.value()),
+                    "enter" => args.enter = Some(input.parse::<LitStr>()?.value()),
+                    "leave" => args.leave = Some(input.parse::<LitStr>()?.value()),
+                    _ => return Err(Error::new_spanned(key, "unsupported flame macro argument")),
+                }
+            }
+
+            if input.is_empty() {
+                break;
+            }
+            input.parse::<Token![,]>()?;
+        }
+
+        Ok(args)
+    }
+}
+
+#[derive(Clone)]
+enum HandlerInput {
+    None,
+    Required(Type),
+    Optional(Type),
+}
+
+#[derive(Clone)]
+enum HandlerOutput {
+    Unit,
+    Required,
+    Optional,
+}
+
+struct HandlerSignature {
+    has_instance_handle: bool,
+    input: HandlerInput,
+    output: HandlerOutput,
+}
+
+struct EnterHook {
+    method: Ident,
+    has_instance_handle: bool,
+}
+
+fn expand_flame_message(input: syn::DeriveInput) -> Result<TokenStream2> {
+    let crate_path = flame_crate_path(&MacroArgs::default());
+    let name = input.ident;
+    let mut generics = input.generics;
+
+    generics.make_where_clause().predicates.push(parse_quote!(
+        Self: #crate_path::__private::serde::Serialize
+            + #crate_path::__private::serde::de::DeserializeOwned
+    ));
+
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+    Ok(quote! {
+        impl #impl_generics #crate_path::message::FlameMessage for #name #ty_generics #where_clause {
+            fn encode(
+                &self,
+            ) -> ::std::result::Result<#crate_path::__private::bytes::Bytes, #crate_path::apis::FlameError> {
+                #crate_path::__private::serde_json::to_vec(self)
+                    .map(#crate_path::__private::bytes::Bytes::from)
+                    .map_err(|err| #crate_path::apis::FlameError::InvalidConfig(err.to_string()))
+            }
+
+            fn decode(bytes: &[u8]) -> ::std::result::Result<Self, #crate_path::apis::FlameError> {
+                #crate_path::__private::serde_json::from_slice(bytes)
+                    .map_err(|err| #crate_path::apis::FlameError::Internal(err.to_string()))
+            }
+        }
+    })
+}
+
+fn expand_entrypoint(args: MacroArgs, mut item: ItemFn) -> Result<TokenStream2> {
+    if args.debug {
+        return Err(Error::new(
+            Span::call_site(),
+            "debug mode is reserved for a future Flame Rust macro release",
+        ));
+    }
+
+    let crate_path = flame_crate_path(&args);
+    let handler = analyze_signature(&item.sig, false)?;
+    let original_ident = item.sig.ident.clone();
+    let impl_ident = format_ident!("__flame_{}_impl", original_ident);
+    let wrapper_ident = format_ident!("__Flame_{}_Entrypoint", original_ident);
+    item.sig.ident = impl_ident.clone();
+
+    let vis = item.vis.clone();
+    let task_body = task_invoke_body(
+        &handler,
+        quote!(#impl_ident),
+        &crate_path,
+        quote!(ctx.input),
+    );
+
+    Ok(quote! {
+        #item
+
+        #[allow(non_camel_case_types)]
+        #vis struct #original_ident;
+
+        #[allow(non_camel_case_types)]
+        #[doc(hidden)]
+        #vis struct #wrapper_ident {
+            session: ::std::sync::Mutex<::std::option::Option<#crate_path::service::SessionContext>>,
+        }
+
+        impl ::std::default::Default for #wrapper_ident {
+            fn default() -> Self {
+                Self {
+                    session: ::std::sync::Mutex::new(None),
+                }
+            }
+        }
+
+        impl #wrapper_ident {
+            fn set_session(
+                &self,
+                session: ::std::option::Option<#crate_path::service::SessionContext>,
+            ) -> ::std::result::Result<(), #crate_path::apis::FlameError> {
+                *self.session.lock().map_err(|_| {
+                    #crate_path::apis::FlameError::Internal(
+                        "flame instance session lock poisoned".to_string(),
+                    )
+                })? = session;
+                Ok(())
+            }
+
+            fn flame_instance(
+                &self,
+            ) -> ::std::result::Result<#crate_path::service::FlameInstance, #crate_path::apis::FlameError> {
+                let session = self.session.lock().map_err(|_| {
+                    #crate_path::apis::FlameError::Internal(
+                        "flame instance session lock poisoned".to_string(),
+                    )
+                })?
+                .clone()
+                .ok_or_else(|| {
+                    #crate_path::apis::FlameError::InvalidConfig(
+                        "flame instance is not bound to a session".to_string(),
+                    )
+                })?;
+
+                Ok(#crate_path::service::FlameInstance::new(session))
+            }
+        }
+
+        impl #crate_path::IntoFlameInstance for #original_ident {
+            type Service = #wrapper_ident;
+
+            fn into_flame_instance(self) -> Self::Service {
+                #wrapper_ident::default()
+            }
+        }
+
+        #[#crate_path::service::async_trait]
+        impl #crate_path::service::FlameService for #wrapper_ident {
+            async fn on_session_enter(
+                &self,
+                ctx: #crate_path::service::SessionContext,
+            ) -> ::std::result::Result<(), #crate_path::apis::FlameError> {
+                self.set_session(Some(ctx))
+            }
+
+            async fn on_task_invoke(
+                &self,
+                ctx: #crate_path::service::TaskContext,
+            ) -> ::std::result::Result<
+                ::std::option::Option<#crate_path::apis::TaskOutput>,
+                #crate_path::apis::FlameError,
+            > {
+                #task_body
+            }
+
+            async fn on_session_leave(
+                &self,
+            ) -> ::std::result::Result<(), #crate_path::apis::FlameError> {
+                self.set_session(None)
+            }
+        }
+    })
+}
+
+fn expand_instance(args: MacroArgs, mut item: ItemImpl) -> Result<TokenStream2> {
+    if args.debug {
+        return Err(Error::new(
+            Span::call_site(),
+            "debug mode is reserved for a future Flame Rust macro release",
+        ));
+    }
+    if item.trait_.is_some() {
+        return Err(Error::new_spanned(
+            item.impl_token,
+            "#[flame_rs::instance] only supports inherent impl blocks",
+        ));
+    }
+
+    let crate_path = flame_crate_path(&args);
+    let self_ty = item.self_ty.as_ref().clone();
+    let type_ident = self_type_ident(&self_ty)?;
+    let wrapper_ident = format_ident!("__Flame_{}_Instance", type_ident);
+
+    let mut entrypoint_methods = Vec::new();
+    let configured_entrypoint = args.entrypoint.clone();
+    let enter_name = args.enter.as_deref().unwrap_or("enter");
+    let leave_name = args.leave.as_deref().unwrap_or("leave");
+    let mut enter_hook = None;
+    let mut leave_hook = None;
+
+    for impl_item in &mut item.items {
+        let ImplItem::Fn(method) = impl_item else {
+            continue;
+        };
+
+        let is_marker_entrypoint = has_entrypoint_attr(&method.attrs);
+        if is_marker_entrypoint {
+            entrypoint_methods.push(method.sig.ident.clone());
+        }
+        method.attrs.retain(|attr| !is_entrypoint_attr(attr.path()));
+
+        if let Some(name) = &configured_entrypoint {
+            if method.sig.ident == name.as_str() {
+                entrypoint_methods.push(method.sig.ident.clone());
+            }
+        }
+        if method.sig.ident == enter_name {
+            enter_hook = Some(analyze_enter_hook(method)?);
+        }
+        if method.sig.ident == leave_name {
+            analyze_leave_hook(method)?;
+            leave_hook = Some(method.sig.ident.clone());
+        }
+    }
+
+    entrypoint_methods.sort_by(|a, b| a.to_string().cmp(&b.to_string()));
+    entrypoint_methods.dedup_by(|a, b| a == b);
+
+    let entrypoint_ident = match entrypoint_methods.as_slice() {
+        [ident] => ident.clone(),
+        [] => {
+            return Err(Error::new(
+                Span::call_site(),
+                "expected exactly one #[flame_rs::entrypoint] method",
+            ))
+        }
+        _ => {
+            return Err(Error::new(
+                Span::call_site(),
+                "expected exactly one entrypoint method",
+            ))
+        }
+    };
+
+    let entrypoint_method = item
+        .items
+        .iter()
+        .find_map(|impl_item| match impl_item {
+            ImplItem::Fn(method) if method.sig.ident == entrypoint_ident => Some(method),
+            _ => None,
+        })
+        .ok_or_else(|| Error::new_spanned(&entrypoint_ident, "entrypoint method not found"))?;
+    let handler = analyze_signature(&entrypoint_method.sig, true)?;
+    let task_body = task_invoke_body(
+        &handler,
+        quote!(self.inner.#entrypoint_ident),
+        &crate_path,
+        quote!(ctx.input),
+    );
+    let enter_body = enter_body(enter_hook.as_ref());
+    let leave_body = leave_body(leave_hook.as_ref());
+
+    Ok(quote! {
+        #item
+
+        #[allow(non_camel_case_types)]
+        #[doc(hidden)]
+        pub struct #wrapper_ident {
+            inner: #self_ty,
+            session: ::std::sync::Mutex<::std::option::Option<#crate_path::service::SessionContext>>,
+        }
+
+        impl #wrapper_ident {
+            fn set_session(
+                &self,
+                session: ::std::option::Option<#crate_path::service::SessionContext>,
+            ) -> ::std::result::Result<(), #crate_path::apis::FlameError> {
+                *self.session.lock().map_err(|_| {
+                    #crate_path::apis::FlameError::Internal(
+                        "flame instance session lock poisoned".to_string(),
+                    )
+                })? = session;
+                Ok(())
+            }
+
+            fn flame_instance(
+                &self,
+            ) -> ::std::result::Result<#crate_path::service::FlameInstance, #crate_path::apis::FlameError> {
+                let session = self.session.lock().map_err(|_| {
+                    #crate_path::apis::FlameError::Internal(
+                        "flame instance session lock poisoned".to_string(),
+                    )
+                })?
+                .clone()
+                .ok_or_else(|| {
+                    #crate_path::apis::FlameError::InvalidConfig(
+                        "flame instance is not bound to a session".to_string(),
+                    )
+                })?;
+
+                Ok(#crate_path::service::FlameInstance::new(session))
+            }
+        }
+
+        impl #crate_path::IntoFlameInstance for #self_ty {
+            type Service = #wrapper_ident;
+
+            fn into_flame_instance(self) -> Self::Service {
+                #wrapper_ident {
+                    inner: self,
+                    session: ::std::sync::Mutex::new(None),
+                }
+            }
+        }
+
+        #[#crate_path::service::async_trait]
+        impl #crate_path::service::FlameService for #wrapper_ident {
+            async fn on_session_enter(
+                &self,
+                ctx: #crate_path::service::SessionContext,
+            ) -> ::std::result::Result<(), #crate_path::apis::FlameError> {
+                self.set_session(Some(ctx))?;
+                #enter_body
+            }
+
+            async fn on_task_invoke(
+                &self,
+                ctx: #crate_path::service::TaskContext,
+            ) -> ::std::result::Result<
+                ::std::option::Option<#crate_path::apis::TaskOutput>,
+                #crate_path::apis::FlameError,
+            > {
+                #task_body
+            }
+
+            async fn on_session_leave(
+                &self,
+            ) -> ::std::result::Result<(), #crate_path::apis::FlameError> {
+                #leave_body
+            }
+        }
+    })
+}
+
+fn task_invoke_body(
+    handler: &HandlerSignature,
+    callable: TokenStream2,
+    crate_path: &TokenStream2,
+    input_expr: TokenStream2,
+) -> TokenStream2 {
+    let mut prelude = Vec::new();
+    let mut args = Vec::new();
+
+    if handler.has_instance_handle {
+        prelude.push(quote! {
+            let __flame_instance = self.flame_instance()?;
+        });
+        args.push(quote!(__flame_instance));
+    }
+
+    match &handler.input {
+        HandlerInput::None => {}
+        HandlerInput::Required(ty) => {
+            prelude.push(quote! {
+                let __flame_input = #crate_path::message::decode_optional::<#ty>(#input_expr)?
+                    .ok_or_else(|| {
+                        #crate_path::apis::FlameError::InvalidConfig(
+                            "missing task input".to_string(),
+                        )
+                    })?;
+            });
+            args.push(quote!(__flame_input));
+        }
+        HandlerInput::Optional(ty) => {
+            prelude.push(quote! {
+                let __flame_input = #crate_path::message::decode_optional::<#ty>(#input_expr)?;
+            });
+            args.push(quote!(__flame_input));
+        }
+    }
+
+    match &handler.output {
+        HandlerOutput::Unit => quote! {
+            #(#prelude)*
+            #callable(#(#args),*).await?;
+            #crate_path::message::encode_unit()
+        },
+        HandlerOutput::Required => quote! {
+            #(#prelude)*
+            let __flame_output = #callable(#(#args),*).await?;
+            #crate_path::message::encode(__flame_output)
+        },
+        HandlerOutput::Optional => quote! {
+            #(#prelude)*
+            let __flame_output = #callable(#(#args),*).await?;
+            #crate_path::message::encode_optional(__flame_output)
+        },
+    }
+}
+
+fn enter_body(hook: Option<&EnterHook>) -> TokenStream2 {
+    match hook {
+        Some(hook) if hook.has_instance_handle => {
+            let method = &hook.method;
+            quote! {
+                let __flame_instance = self.flame_instance()?;
+                self.inner.#method(__flame_instance).await
+            }
+        }
+        Some(hook) => {
+            let method = &hook.method;
+            quote!(self.inner.#method().await)
+        }
+        None => quote!(::std::result::Result::Ok(())),
+    }
+}
+
+fn leave_body(hook: Option<&Ident>) -> TokenStream2 {
+    match hook {
+        Some(method) => quote! {
+            let __flame_result = self.inner.#method().await;
+            self.set_session(None)?;
+            __flame_result
+        },
+        None => quote! {
+            self.set_session(None)?;
+            ::std::result::Result::Ok(())
+        },
+    }
+}
+
+fn analyze_signature(sig: &syn::Signature, expects_receiver: bool) -> Result<HandlerSignature> {
+    if sig.asyncness.is_none() {
+        return Err(Error::new_spanned(
+            sig.fn_token,
+            "flame entrypoint must be async",
+        ));
+    }
+
+    let mut args = sig.inputs.iter();
+    if expects_receiver {
+        match args.next() {
+            Some(FnArg::Receiver(receiver))
+                if receiver.reference.is_some() && receiver.mutability.is_none() => {}
+            Some(arg) => {
+                return Err(Error::new_spanned(
+                    arg,
+                    "flame instance methods must take &self",
+                ))
+            }
+            None => {
+                return Err(Error::new_spanned(
+                    sig.ident.clone(),
+                    "flame instance method must take &self",
+                ))
+            }
+        }
+    }
+
+    let mut has_instance_handle = false;
+    let mut input = HandlerInput::None;
+
+    for arg in args {
+        let FnArg::Typed(arg) = arg else {
+            return Err(Error::new_spanned(arg, "unexpected self argument"));
+        };
+
+        let ty = arg.ty.as_ref();
+        if is_type_named(ty, "FlameInstance") {
+            if has_instance_handle || !matches!(input, HandlerInput::None) {
+                return Err(Error::new_spanned(
+                    ty,
+                    "FlameInstance must be the first entrypoint argument",
+                ));
+            }
+            has_instance_handle = true;
+            continue;
+        }
+
+        if !matches!(input, HandlerInput::None) {
+            return Err(Error::new_spanned(
+                ty,
+                "flame entrypoint supports at most one typed input",
+            ));
+        }
+        reject_raw_type(ty)?;
+        input = match extract_option_type(ty) {
+            Some(inner) => {
+                reject_raw_type(&inner)?;
+                HandlerInput::Optional(inner)
+            }
+            None => HandlerInput::Required((*ty).clone()),
+        };
+    }
+
+    let ok_ty = result_ok_type(&sig.output)?;
+    reject_raw_type(&ok_ty)?;
+    let output = if is_unit_type(&ok_ty) {
+        HandlerOutput::Unit
+    } else if let Some(inner) = extract_option_type(&ok_ty) {
+        reject_raw_type(&inner)?;
+        HandlerOutput::Optional
+    } else {
+        HandlerOutput::Required
+    };
+
+    Ok(HandlerSignature {
+        has_instance_handle,
+        input,
+        output,
+    })
+}
+
+fn analyze_enter_hook(method: &ImplItemFn) -> Result<EnterHook> {
+    if method.sig.asyncness.is_none() {
+        return Err(Error::new_spanned(
+            &method.sig.ident,
+            "flame enter hook must be async",
+        ));
+    }
+    ensure_result_unit(&method.sig.output)?;
+
+    let mut args = method.sig.inputs.iter();
+    match args.next() {
+        Some(FnArg::Receiver(receiver))
+            if receiver.reference.is_some() && receiver.mutability.is_none() => {}
+        Some(arg) => return Err(Error::new_spanned(arg, "flame enter hook must take &self")),
+        None => {
+            return Err(Error::new_spanned(
+                &method.sig.ident,
+                "flame enter hook must take &self",
+            ))
+        }
+    }
+
+    let has_instance_handle = match args.next() {
+        Some(FnArg::Typed(arg)) if is_type_named(arg.ty.as_ref(), "FlameInstance") => true,
+        Some(arg) => {
+            return Err(Error::new_spanned(
+                arg,
+                "flame enter hook only supports an optional FlameInstance argument",
+            ))
+        }
+        None => false,
+    };
+
+    if let Some(arg) = args.next() {
+        return Err(Error::new_spanned(
+            arg,
+            "too many flame enter hook arguments",
+        ));
+    }
+
+    Ok(EnterHook {
+        method: method.sig.ident.clone(),
+        has_instance_handle,
+    })
+}
+
+fn analyze_leave_hook(method: &ImplItemFn) -> Result<()> {
+    if method.sig.asyncness.is_none() {
+        return Err(Error::new_spanned(
+            &method.sig.ident,
+            "flame leave hook must be async",
+        ));
+    }
+    ensure_result_unit(&method.sig.output)?;
+
+    let mut args = method.sig.inputs.iter();
+    match args.next() {
+        Some(FnArg::Receiver(receiver))
+            if receiver.reference.is_some() && receiver.mutability.is_none() => {}
+        Some(arg) => return Err(Error::new_spanned(arg, "flame leave hook must take &self")),
+        None => {
+            return Err(Error::new_spanned(
+                &method.sig.ident,
+                "flame leave hook must take &self",
+            ))
+        }
+    }
+
+    if let Some(arg) = args.next() {
+        return Err(Error::new_spanned(
+            arg,
+            "flame leave hook takes no arguments",
+        ));
+    }
+
+    Ok(())
+}
+
+fn result_ok_type(output: &ReturnType) -> Result<Type> {
+    let ReturnType::Type(_, ty) = output else {
+        return Err(Error::new(
+            Span::call_site(),
+            "flame functions must return Result<T, FlameError>",
+        ));
+    };
+
+    let Type::Path(type_path) = ty.as_ref() else {
+        return Err(Error::new_spanned(
+            ty,
+            "flame functions must return Result<T, FlameError>",
+        ));
+    };
+
+    let Some(segment) = type_path.path.segments.last() else {
+        return Err(Error::new_spanned(
+            ty,
+            "flame functions must return Result<T, FlameError>",
+        ));
+    };
+    if segment.ident != "Result" {
+        return Err(Error::new_spanned(
+            ty,
+            "flame functions must return Result<T, FlameError>",
+        ));
+    }
+
+    let PathArguments::AngleBracketed(args) = &segment.arguments else {
+        return Err(Error::new_spanned(
+            ty,
+            "flame functions must return Result<T, FlameError>",
+        ));
+    };
+
+    args.args
+        .iter()
+        .find_map(|arg| match arg {
+            GenericArgument::Type(ty) => Some(ty.clone()),
+            _ => None,
+        })
+        .ok_or_else(|| Error::new_spanned(ty, "flame functions must return Result<T, FlameError>"))
+}
+
+fn ensure_result_unit(output: &ReturnType) -> Result<()> {
+    let ok_ty = result_ok_type(output)?;
+    if is_unit_type(&ok_ty) {
+        Ok(())
+    } else {
+        Err(Error::new_spanned(
+            ok_ty,
+            "flame lifecycle hooks must return Result<(), FlameError>",
+        ))
+    }
+}
+
+fn extract_option_type(ty: &Type) -> Option<Type> {
+    let Type::Path(type_path) = ty else {
+        return None;
+    };
+    let segment = type_path.path.segments.last()?;
+    if segment.ident != "Option" {
+        return None;
+    }
+    let PathArguments::AngleBracketed(args) = &segment.arguments else {
+        return None;
+    };
+    args.args.iter().find_map(|arg| match arg {
+        GenericArgument::Type(ty) => Some(ty.clone()),
+        _ => None,
+    })
+}
+
+fn is_unit_type(ty: &Type) -> bool {
+    matches!(ty, Type::Tuple(tuple) if tuple.elems.is_empty())
+}
+
+fn is_type_named(ty: &Type, name: &str) -> bool {
+    type_last_ident(ty).as_deref() == Some(name)
+}
+
+fn type_last_ident(ty: &Type) -> Option<String> {
+    let Type::Path(type_path) = ty else {
+        return None;
+    };
+    type_path
+        .path
+        .segments
+        .last()
+        .map(|segment| segment.ident.to_string())
+}
+
+fn reject_raw_type(ty: &Type) -> Result<()> {
+    if is_type_named(ty, "TaskInput") || is_type_named(ty, "TaskOutput") {
+        return Err(Error::new_spanned(
+            ty,
+            "raw TaskInput and TaskOutput are not supported by high-level flame macros; implement FlameService directly for raw payloads",
+        ));
+    }
+    Ok(())
+}
+
+fn self_type_ident(ty: &Type) -> Result<Ident> {
+    let Type::Path(type_path) = ty else {
+        return Err(Error::new_spanned(
+            ty,
+            "#[flame_rs::instance] requires a concrete struct type",
+        ));
+    };
+    type_path
+        .path
+        .segments
+        .last()
+        .map(|segment| segment.ident.clone())
+        .ok_or_else(|| {
+            Error::new_spanned(ty, "#[flame_rs::instance] requires a concrete struct type")
+        })
+}
+
+fn has_entrypoint_attr(attrs: &[syn::Attribute]) -> bool {
+    attrs.iter().any(|attr| is_entrypoint_attr(attr.path()))
+}
+
+fn is_entrypoint_attr(path: &Path) -> bool {
+    path.segments
+        .last()
+        .map(|segment| segment.ident == "entrypoint")
+        .unwrap_or(false)
+}
+
+fn flame_crate_path(args: &MacroArgs) -> TokenStream2 {
+    if let Some(path) = &args.crate_path {
+        return quote!(#path);
+    }
+
+    match crate_name("flame-rs") {
+        Ok(FoundCrate::Itself) => quote!(crate),
+        Ok(FoundCrate::Name(name)) => {
+            let ident = Ident::new(&name, Span::call_site());
+            quote!(#ident)
+        }
+        Err(_) => quote!(flame_rs),
+    }
+}

--- a/sdk/rust/src/apis/mod.rs
+++ b/sdk/rust/src/apis/mod.rs
@@ -242,7 +242,8 @@ pub fn init_logger() -> Result<(), FlameError> {
         .with_ansi(false)
         // .with_thread_ids(true)
         // .with_process_ids(true)
-        .init();
+        .try_init()
+        .ok();
 
     Ok(())
 }

--- a/sdk/rust/src/client/mod.rs
+++ b/sdk/rust/src/client/mod.rs
@@ -1371,11 +1371,11 @@ mod tests {
         fn encode(&self) -> Result<Bytes, FlameError> {
             serde_json::to_vec(self)
                 .map(Bytes::from)
-                .map_err(|e| FlameError::InvalidConfig(e.to_string()))
+                .map_err(|e| FlameError::Internal(e.to_string()))
         }
 
         fn decode(bytes: &[u8]) -> Result<Self, FlameError> {
-            serde_json::from_slice(bytes).map_err(|e| FlameError::Internal(e.to_string()))
+            serde_json::from_slice(bytes).map_err(|e| FlameError::InvalidConfig(e.to_string()))
         }
     }
 

--- a/sdk/rust/src/client/mod.rs
+++ b/sdk/rust/src/client/mod.rs
@@ -12,8 +12,10 @@ limitations under the License.
 */
 
 use std::collections::HashMap;
-use std::marker::PhantomData;
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll};
 
 use chrono::{DateTime, Duration, Utc};
 use futures::TryFutureExt;
@@ -43,6 +45,8 @@ use crate::apis::{
 use crate::message::{self, FromTaskOutput, IntoCommonData, IntoTaskInput};
 
 type FlameClient = FlameFrontendClient<Channel>;
+type TaskHandleFuture<O> =
+    Pin<Box<dyn Future<Output = Result<Option<O>, FlameError>> + Send + 'static>>;
 
 /// Connect to a Flame service without TLS (plaintext).
 ///
@@ -424,9 +428,8 @@ pub trait TaskInformer: Send + Sync + 'static {
 }
 
 pub struct TaskHandle<O> {
-    session: Session,
     task_id: TaskID,
-    _output: PhantomData<O>,
+    future: TaskHandleFuture<O>,
 }
 
 impl Task {
@@ -695,22 +698,32 @@ impl Session {
     pub async fn invoke<I, O>(&self, input: I) -> Result<Option<O>, FlameError>
     where
         I: IntoTaskInput,
-        O: FromTaskOutput,
+        O: FromTaskOutput + Send + 'static,
     {
-        self.run(input).await?.wait().await
+        self.run(input).await?.await
     }
 
     pub async fn run<I, O>(&self, input: I) -> Result<TaskHandle<O>, FlameError>
     where
         I: IntoTaskInput,
-        O: FromTaskOutput,
+        O: FromTaskOutput + Send + 'static,
     {
         let task = self.create_task(input.into_task_input()?).await?;
-        Ok(TaskHandle {
-            session: self.clone(),
-            task_id: task.id,
-            _output: PhantomData,
-        })
+        let session = self.clone();
+        let session_id = session.id.clone();
+        let task_id = task.id;
+        let future_task_id = task_id.clone();
+        let future = Box::pin(async move {
+            let task = session.wait_task(session_id, future_task_id).await?;
+
+            if !task.is_succeed() {
+                return Err(task_terminal_error(&task));
+            }
+
+            O::from_task_output(task.output)
+        });
+
+        Ok(TaskHandle { task_id, future })
     }
 
     pub fn common_data<T>(&self) -> Result<Option<T>, FlameError>
@@ -874,25 +887,19 @@ impl Session {
     }
 }
 
-impl<O> TaskHandle<O>
-where
-    O: FromTaskOutput,
-{
+impl<O> TaskHandle<O> {
     pub fn id(&self) -> &TaskID {
         &self.task_id
     }
+}
 
-    pub async fn wait(self) -> Result<Option<O>, FlameError> {
-        let task = self
-            .session
-            .wait_task(self.session.id.clone(), self.task_id)
-            .await?;
+impl<O> Unpin for TaskHandle<O> {}
 
-        if !task.is_succeed() {
-            return Err(task_terminal_error(&task));
-        }
+impl<O> Future for TaskHandle<O> {
+    type Output = Result<Option<O>, FlameError>;
 
-        O::from_task_output(task.output)
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.get_mut().future.as_mut().poll(cx)
     }
 }
 
@@ -1305,6 +1312,17 @@ mod tests {
         assert_eq!(attrs.id, "ssn-1");
         let decoded = TestCommonData::decode(&attrs.common_data.unwrap()).unwrap();
         assert_eq!(decoded, common_data);
+    }
+
+    #[tokio::test]
+    async fn task_handle_is_awaitable() {
+        let handle: TaskHandle<()> = TaskHandle {
+            task_id: "task-1".to_string(),
+            future: Box::pin(async { Ok(Some(())) }),
+        };
+
+        assert_eq!(handle.id(), "task-1");
+        assert_eq!(handle.await.unwrap(), Some(()));
     }
 
     /// Regression test for `Session::try_from` creation_time parsing.

--- a/sdk/rust/src/client/mod.rs
+++ b/sdk/rust/src/client/mod.rs
@@ -46,7 +46,7 @@ use crate::message::{self, FromTaskOutput, IntoCommonData, IntoTaskInput};
 
 type FlameClient = FlameFrontendClient<Channel>;
 type TaskHandleFuture<O> =
-    Pin<Box<dyn Future<Output = Result<Option<O>, FlameError>> + Send + 'static>>;
+    Pin<Box<dyn Future<Output = Result<TaskResult<O>, FlameError>> + Send + 'static>>;
 
 /// Connect to a Flame service without TLS (plaintext).
 ///
@@ -432,6 +432,16 @@ pub struct TaskHandle<O> {
     future: TaskHandleFuture<O>,
 }
 
+#[derive(Clone, Debug)]
+pub struct TaskResult<O> {
+    pub task_id: TaskID,
+    pub session_id: SessionID,
+    pub state: TaskState,
+    pub output: Option<O>,
+    pub error_code: Option<i32>,
+    pub error_message: Option<String>,
+}
+
 impl Task {
     pub fn is_completed(&self) -> bool {
         self.state.is_terminal()
@@ -447,6 +457,48 @@ impl Task {
 
     pub fn is_cancelled(&self) -> bool {
         self.state == TaskState::Cancelled
+    }
+}
+
+impl<O> TaskResult<O> {
+    pub fn is_succeed(&self) -> bool {
+        self.state == TaskState::Succeed
+    }
+
+    pub fn is_failed(&self) -> bool {
+        self.state == TaskState::Failed
+    }
+
+    pub fn is_cancelled(&self) -> bool {
+        self.state == TaskState::Cancelled
+    }
+}
+
+impl<O> TaskResult<O>
+where
+    O: FromTaskOutput,
+{
+    pub fn from_task(task: Task) -> Result<Self, FlameError> {
+        let is_succeed = task.is_succeed();
+        let (error_code, error_message) = if is_succeed {
+            (None, None)
+        } else {
+            (task_error_code(&task), task_error_message(&task))
+        };
+        let output = if is_succeed {
+            O::from_task_output(task.output)?
+        } else {
+            None
+        };
+
+        Ok(Self {
+            task_id: task.id,
+            session_id: task.ssn_id,
+            state: task.state,
+            output,
+            error_code,
+            error_message,
+        })
     }
 }
 
@@ -700,7 +752,12 @@ impl Session {
         I: IntoTaskInput,
         O: FromTaskOutput + Send + 'static,
     {
-        self.run(input).await?.await
+        let result = self.run::<_, O>(input).await?.await?;
+        if result.is_succeed() {
+            Ok(result.output)
+        } else {
+            Err(task_result_error(&result))
+        }
     }
 
     pub async fn run<I, O>(&self, input: I) -> Result<TaskHandle<O>, FlameError>
@@ -713,14 +770,10 @@ impl Session {
         let session_id = session.id.clone();
         let task_id = task.id;
         let future_task_id = task_id.clone();
+
         let future = Box::pin(async move {
             let task = session.wait_task(session_id, future_task_id).await?;
-
-            if !task.is_succeed() {
-                return Err(task_terminal_error(&task));
-            }
-
-            O::from_task_output(task.output)
+            TaskResult::from_task(task)
         });
 
         Ok(TaskHandle { task_id, future })
@@ -896,30 +949,43 @@ impl<O> TaskHandle<O> {
 impl<O> Unpin for TaskHandle<O> {}
 
 impl<O> Future for TaskHandle<O> {
-    type Output = Result<Option<O>, FlameError>;
+    type Output = Result<TaskResult<O>, FlameError>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         self.get_mut().future.as_mut().poll(cx)
     }
 }
 
-fn task_terminal_error(task: &Task) -> FlameError {
-    let messages = task
+fn task_error_code(task: &Task) -> Option<i32> {
+    task.events.last().map(|event| event.code)
+}
+
+fn task_error_message(task: &Task) -> Option<String> {
+    let message = task
         .events
         .iter()
         .filter_map(|event| event.message.as_deref())
         .collect::<Vec<_>>()
         .join("; ");
 
-    let details = if messages.is_empty() {
-        String::new()
+    if message.is_empty() {
+        None
     } else {
-        format!(": {messages}")
+        Some(message)
+    }
+}
+
+fn task_result_error<O>(result: &TaskResult<O>) -> FlameError {
+    let details = match (result.error_code, result.error_message.as_deref()) {
+        (Some(code), Some(message)) => format!(": code <{}>, {}", code, message),
+        (Some(code), None) => format!(": code <{}>", code),
+        (None, Some(message)) => format!(": {}", message),
+        (None, None) => String::new(),
     };
 
     FlameError::Internal(format!(
         "task <{}> in session <{}> finished with state <{}>{}",
-        task.id, task.ssn_id, task.state, details
+        result.task_id, result.session_id, result.state, details
     ))
 }
 
@@ -1276,6 +1342,17 @@ mod tests {
         }
     }
 
+    fn test_task(id: &str, state: TaskState) -> Task {
+        Task {
+            id: id.to_string(),
+            ssn_id: "ssn-1".to_string(),
+            state,
+            input: None,
+            output: None,
+            events: Vec::new(),
+        }
+    }
+
     #[test]
     fn session_options_generate_default_attributes() {
         let attrs = SessionOptions::new("model-app")
@@ -1315,14 +1392,44 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn task_handle_is_awaitable() {
-        let handle: TaskHandle<()> = TaskHandle {
+    async fn task_handle_await_returns_task_result() {
+        let payload = TestCommonData {
+            value: "done".to_string(),
+        };
+        let mut task = test_task("task-1", TaskState::Succeed);
+        task.output = Some(payload.encode().unwrap());
+        let handle = TaskHandle {
             task_id: "task-1".to_string(),
-            future: Box::pin(async { Ok(Some(())) }),
+            future: Box::pin(async move { TaskResult::<TestCommonData>::from_task(task) }),
         };
 
         assert_eq!(handle.id(), "task-1");
-        assert_eq!(handle.await.unwrap(), Some(()));
+        let result = handle.await.unwrap();
+        assert_eq!(result.task_id, "task-1");
+        assert_eq!(result.session_id, "ssn-1");
+        assert!(result.is_succeed());
+        assert_eq!(result.output.unwrap().value, "done");
+        assert_eq!(result.error_code, None);
+        assert_eq!(result.error_message, None);
+    }
+
+    #[test]
+    fn task_result_records_failed_task_error_details() {
+        let mut task = test_task("task-2", TaskState::Failed);
+        task.events.push(Event {
+            code: 42,
+            message: Some("remote failure".to_string()),
+            creation_time: Utc.with_ymd_and_hms(2026, 5, 8, 10, 0, 0).unwrap(),
+        });
+
+        let result = TaskResult::<TestCommonData>::from_task(task).unwrap();
+
+        assert_eq!(result.task_id, "task-2");
+        assert_eq!(result.session_id, "ssn-1");
+        assert!(result.is_failed());
+        assert!(result.output.is_none());
+        assert_eq!(result.error_code, Some(42));
+        assert_eq!(result.error_message.as_deref(), Some("remote failure"));
     }
 
     /// Regression test for `Session::try_from` creation_time parsing.

--- a/sdk/rust/src/client/mod.rs
+++ b/sdk/rust/src/client/mod.rs
@@ -12,6 +12,7 @@ limitations under the License.
 */
 
 use std::collections::HashMap;
+use std::marker::PhantomData;
 use std::sync::{Arc, Mutex};
 
 use chrono::{DateTime, Duration, Utc};
@@ -39,6 +40,7 @@ use crate::apis::{
     ApplicationID, ApplicationState, CommonData, ExecutorState, FlameError, SessionID,
     SessionState, Shim, TaskID, TaskInput, TaskOutput, TaskState,
 };
+use crate::message::{self, FromTaskOutput, IntoCommonData, IntoTaskInput};
 
 type FlameClient = FlameFrontendClient<Channel>;
 
@@ -108,7 +110,7 @@ pub struct Connection {
     pub(crate) channel: Channel,
 }
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SessionAttributes {
     pub id: SessionID,
     pub application: String,
@@ -126,6 +128,108 @@ pub struct SessionAttributes {
 
 fn default_batch_size() -> u32 {
     1
+}
+
+#[derive(Clone, Debug)]
+pub struct SessionOptions {
+    pub id: Option<SessionID>,
+    pub application: String,
+    common_data: Option<CommonData>,
+    pub min_instances: u32,
+    pub max_instances: Option<u32>,
+    pub batch_size: u32,
+    pub priority: u32,
+    pub resreq: Option<ResourceRequirement>,
+}
+
+impl SessionOptions {
+    pub fn new(application: impl Into<String>) -> Self {
+        Self {
+            id: None,
+            application: application.into(),
+            common_data: None,
+            min_instances: 0,
+            max_instances: None,
+            batch_size: 1,
+            priority: 0,
+            resreq: None,
+        }
+    }
+
+    pub fn id(mut self, id: impl Into<SessionID>) -> Self {
+        self.id = Some(id.into());
+        self
+    }
+
+    pub fn common_data(mut self, data: impl IntoCommonData) -> Result<Self, FlameError> {
+        self.common_data = Some(data.into_common_data()?);
+        Ok(self)
+    }
+
+    pub fn min_instances(mut self, value: u32) -> Self {
+        self.min_instances = value;
+        self
+    }
+
+    pub fn max_instances(mut self, value: u32) -> Self {
+        self.max_instances = Some(value);
+        self
+    }
+
+    pub fn batch_size(mut self, value: u32) -> Self {
+        self.batch_size = value;
+        self
+    }
+
+    pub fn priority(mut self, value: u32) -> Self {
+        self.priority = value;
+        self
+    }
+
+    pub fn resreq(mut self, value: impl Into<ResourceRequirement>) -> Self {
+        self.resreq = Some(value.into());
+        self
+    }
+
+    pub fn into_session_attributes(self) -> Result<SessionAttributes, FlameError> {
+        if self.application.trim().is_empty() {
+            return Err(FlameError::InvalidConfig(
+                "session application must not be empty".to_string(),
+            ));
+        }
+        Ok(SessionAttributes::from(self))
+    }
+}
+
+impl From<&str> for SessionOptions {
+    fn from(application: &str) -> Self {
+        Self::new(application)
+    }
+}
+
+impl From<String> for SessionOptions {
+    fn from(application: String) -> Self {
+        Self::new(application)
+    }
+}
+
+impl From<SessionOptions> for SessionAttributes {
+    fn from(options: SessionOptions) -> Self {
+        let id = options
+            .id
+            .unwrap_or_else(|| format!("{}-{}", options.application, stdng::rand::short_name()));
+
+        Self {
+            id,
+            application: options.application,
+            common_data: options.common_data,
+            min_instances: options.min_instances,
+            max_instances: options.max_instances,
+            batch_size: options.batch_size.max(1),
+            priority: options.priority,
+            resreq: options.resreq,
+        }
+    }
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
@@ -156,6 +260,12 @@ impl ResourceRequirement {
 impl From<&str> for ResourceRequirement {
     fn from(s: &str) -> Self {
         Self::from(&s.to_string())
+    }
+}
+
+impl From<String> for ResourceRequirement {
+    fn from(s: String) -> Self {
+        Self::from(&s)
     }
 }
 
@@ -273,6 +383,8 @@ pub struct Session {
 
     pub id: SessionID,
     pub application: String,
+    #[serde(with = "serde_message")]
+    pub common_data: Option<CommonData>,
     #[serde(with = "serde_utc")]
     pub creation_time: DateTime<Utc>,
 
@@ -311,6 +423,12 @@ pub trait TaskInformer: Send + Sync + 'static {
     fn on_error(&mut self, e: FlameError);
 }
 
+pub struct TaskHandle<O> {
+    session: Session,
+    task_id: TaskID,
+    _output: PhantomData<O>,
+}
+
 impl Task {
     pub fn is_completed(&self) -> bool {
         self.state.is_terminal()
@@ -330,6 +448,14 @@ impl Task {
 }
 
 impl Connection {
+    pub async fn create_session_with(
+        &self,
+        options: impl Into<SessionOptions>,
+    ) -> Result<Session, FlameError> {
+        let attrs = options.into().into_session_attributes()?;
+        self.create_session(&attrs).await
+    }
+
     pub async fn create_session(&self, attrs: &SessionAttributes) -> Result<Session, FlameError> {
         trace_fn!("Connection::create_session");
 
@@ -406,6 +532,28 @@ impl Connection {
         let mut ssn = Session::try_from(&inner_ssn)?;
         ssn.client = Some(client);
         Ok(ssn)
+    }
+
+    pub async fn open_or_create_session_with(
+        &self,
+        id: impl Into<SessionID>,
+        options: impl Into<SessionOptions>,
+    ) -> Result<Session, FlameError> {
+        let id = id.into();
+        let mut options = options.into();
+
+        if let Some(option_id) = &options.id {
+            if option_id != &id {
+                return Err(FlameError::InvalidConfig(format!(
+                    "session id <{}> does not match options id <{}>",
+                    id, option_id
+                )));
+            }
+        }
+
+        options.id = Some(id.clone());
+        let attrs = options.into_session_attributes()?;
+        self.open_session(&id, Some(&attrs)).await
     }
 
     pub async fn close_session(&self, id: &str) -> Result<(), FlameError> {
@@ -544,6 +692,34 @@ impl Connection {
 }
 
 impl Session {
+    pub async fn invoke<I, O>(&self, input: I) -> Result<Option<O>, FlameError>
+    where
+        I: IntoTaskInput,
+        O: FromTaskOutput,
+    {
+        self.run(input).await?.wait().await
+    }
+
+    pub async fn run<I, O>(&self, input: I) -> Result<TaskHandle<O>, FlameError>
+    where
+        I: IntoTaskInput,
+        O: FromTaskOutput,
+    {
+        let task = self.create_task(input.into_task_input()?).await?;
+        Ok(TaskHandle {
+            session: self.clone(),
+            task_id: task.id,
+            _output: PhantomData,
+        })
+    }
+
+    pub fn common_data<T>(&self) -> Result<Option<T>, FlameError>
+    where
+        T: crate::message::FlameMessage,
+    {
+        message::decode_common_data(self.common_data.as_ref())
+    }
+
     pub async fn create_task(&self, input: Option<TaskInput>) -> Result<Task, FlameError> {
         trace_fn!("Session::create_task");
         let mut client = self
@@ -653,6 +829,34 @@ impl Session {
         Ok(())
     }
 
+    async fn wait_task(&self, session_id: SessionID, task_id: TaskID) -> Result<Task, FlameError> {
+        trace_fn!("Session::wait_task");
+        let mut client = self
+            .client
+            .clone()
+            .ok_or(FlameError::Internal("no flame client".to_string()))?;
+
+        let watch_task_req = WatchTaskRequest {
+            session_id,
+            task_id: task_id.clone(),
+        };
+        let mut task_stream = client.watch_task(watch_task_req).await?.into_inner();
+        let mut last_task = None;
+
+        while let Some(task) = task_stream.next().await {
+            let parsed = Task::try_from(&task?)?;
+            if parsed.is_completed() {
+                return Ok(parsed);
+            }
+            last_task = Some(parsed);
+        }
+
+        match last_task {
+            Some(task) if task.is_completed() => Ok(task),
+            _ => self.get_task(&task_id).await,
+        }
+    }
+
     pub async fn close(&self) -> Result<(), FlameError> {
         trace_fn!("Session::close");
         let mut client = self
@@ -668,6 +872,48 @@ impl Session {
 
         Ok(())
     }
+}
+
+impl<O> TaskHandle<O>
+where
+    O: FromTaskOutput,
+{
+    pub fn id(&self) -> &TaskID {
+        &self.task_id
+    }
+
+    pub async fn wait(self) -> Result<Option<O>, FlameError> {
+        let task = self
+            .session
+            .wait_task(self.session.id.clone(), self.task_id)
+            .await?;
+
+        if !task.is_succeed() {
+            return Err(task_terminal_error(&task));
+        }
+
+        O::from_task_output(task.output)
+    }
+}
+
+fn task_terminal_error(task: &Task) -> FlameError {
+    let messages = task
+        .events
+        .iter()
+        .filter_map(|event| event.message.as_deref())
+        .collect::<Vec<_>>()
+        .join("; ");
+
+    let details = if messages.is_empty() {
+        String::new()
+    } else {
+        format!(": {messages}")
+    };
+
+    FlameError::Internal(format!(
+        "task <{}> in session <{}> finished with state <{}>{}",
+        task.id, task.ssn_id, task.state, details
+    ))
 }
 
 impl TryFrom<&rpc::Task> for Task {
@@ -734,6 +980,7 @@ impl TryFrom<&rpc::Session> for Session {
             client: None,
             id: metadata.id,
             application: spec.application,
+            common_data: spec.common_data.map(CommonData::from),
             creation_time,
             state: SessionState::try_from(status.state).unwrap_or(SessionState::default()),
             pending: status.pending,
@@ -1000,7 +1247,65 @@ mod serde_message {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::message::FlameMessage;
+    use bytes::Bytes;
     use chrono::TimeZone;
+    use serde_derive::{Deserialize, Serialize};
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    struct TestCommonData {
+        value: String,
+    }
+
+    impl crate::message::FlameMessage for TestCommonData {
+        fn encode(&self) -> Result<Bytes, FlameError> {
+            serde_json::to_vec(self)
+                .map(Bytes::from)
+                .map_err(|e| FlameError::InvalidConfig(e.to_string()))
+        }
+
+        fn decode(bytes: &[u8]) -> Result<Self, FlameError> {
+            serde_json::from_slice(bytes).map_err(|e| FlameError::Internal(e.to_string()))
+        }
+    }
+
+    #[test]
+    fn session_options_generate_default_attributes() {
+        let attrs = SessionOptions::new("model-app")
+            .min_instances(1)
+            .batch_size(0)
+            .priority(7)
+            .resreq("cpu=4,mem=16g")
+            .into_session_attributes()
+            .unwrap();
+
+        assert!(attrs.id.starts_with("model-app-"));
+        assert_eq!(attrs.application, "model-app");
+        assert_eq!(attrs.min_instances, 1);
+        assert_eq!(attrs.batch_size, 1);
+        assert_eq!(attrs.priority, 7);
+        let resreq = attrs.resreq.unwrap();
+        assert_eq!(resreq.cpu, 4);
+        assert_eq!(resreq.memory, 16 * 1024 * 1024 * 1024);
+    }
+
+    #[test]
+    fn session_options_encode_typed_common_data() {
+        let common_data = TestCommonData {
+            value: "ctx".to_string(),
+        };
+
+        let attrs = SessionOptions::new("model-app")
+            .id("ssn-1")
+            .common_data(&common_data)
+            .unwrap()
+            .into_session_attributes()
+            .unwrap();
+
+        assert_eq!(attrs.id, "ssn-1");
+        let decoded = TestCommonData::decode(&attrs.common_data.unwrap()).unwrap();
+        assert_eq!(decoded, common_data);
+    }
 
     /// Regression test for `Session::try_from` creation_time parsing.
     ///

--- a/sdk/rust/src/client/mod.rs
+++ b/sdk/rust/src/client/mod.rs
@@ -45,7 +45,9 @@ use crate::apis::{
 use crate::message::{self, FromTaskOutput, IntoCommonData, IntoTaskInput};
 
 type FlameClient = FlameFrontendClient<Channel>;
-type TaskHandleFuture<O> =
+type TaskHandleInner<O> =
+    Pin<Box<dyn Future<Output = Result<Option<O>, FlameError>> + Send + 'static>>;
+type TaskFutureInner<O> =
     Pin<Box<dyn Future<Output = Result<TaskResult<O>, FlameError>> + Send + 'static>>;
 
 /// Connect to a Flame service without TLS (plaintext).
@@ -429,7 +431,12 @@ pub trait TaskInformer: Send + Sync + 'static {
 
 pub struct TaskHandle<O> {
     task_id: TaskID,
-    future: TaskHandleFuture<O>,
+    future: TaskHandleInner<O>,
+}
+
+pub struct TaskFuture<O> {
+    task_id: TaskID,
+    future: TaskFutureInner<O>,
 }
 
 #[derive(Clone, Debug)]
@@ -747,20 +754,15 @@ impl Connection {
 }
 
 impl Session {
-    pub async fn invoke<I, O>(&self, input: I) -> Result<Option<O>, FlameError>
+    pub async fn invoke<I, O>(&self, input: I) -> Result<TaskHandle<O>, FlameError>
     where
         I: IntoTaskInput,
         O: FromTaskOutput + Send + 'static,
     {
-        let result = self.run::<_, O>(input).await?.await?;
-        if result.is_succeed() {
-            Ok(result.output)
-        } else {
-            Err(task_result_error(&result))
-        }
+        self.run(input).await.map(TaskHandle::from)
     }
 
-    pub async fn run<I, O>(&self, input: I) -> Result<TaskHandle<O>, FlameError>
+    pub async fn run<I, O>(&self, input: I) -> Result<TaskFuture<O>, FlameError>
     where
         I: IntoTaskInput,
         O: FromTaskOutput + Send + 'static,
@@ -776,7 +778,7 @@ impl Session {
             TaskResult::from_task(task)
         });
 
-        Ok(TaskHandle { task_id, future })
+        Ok(TaskFuture { task_id, future })
     }
 
     pub fn common_data<T>(&self) -> Result<Option<T>, FlameError>
@@ -949,6 +951,41 @@ impl<O> TaskHandle<O> {
 impl<O> Unpin for TaskHandle<O> {}
 
 impl<O> Future for TaskHandle<O> {
+    type Output = Result<Option<O>, FlameError>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.get_mut().future.as_mut().poll(cx)
+    }
+}
+
+impl<O> From<TaskFuture<O>> for TaskHandle<O>
+where
+    O: Send + 'static,
+{
+    fn from(task_future: TaskFuture<O>) -> Self {
+        let task_id = task_future.id().clone();
+        let future = Box::pin(async move {
+            let result = task_future.await?;
+            if result.is_succeed() {
+                Ok(result.output)
+            } else {
+                Err(task_result_error(&result))
+            }
+        });
+
+        Self { task_id, future }
+    }
+}
+
+impl<O> TaskFuture<O> {
+    pub fn id(&self) -> &TaskID {
+        &self.task_id
+    }
+}
+
+impl<O> Unpin for TaskFuture<O> {}
+
+impl<O> Future for TaskFuture<O> {
     type Output = Result<TaskResult<O>, FlameError>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
@@ -1392,25 +1429,64 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn task_handle_await_returns_task_result() {
+    async fn task_future_await_returns_task_result() {
         let payload = TestCommonData {
             value: "done".to_string(),
         };
         let mut task = test_task("task-1", TaskState::Succeed);
         task.output = Some(payload.encode().unwrap());
-        let handle = TaskHandle {
+        let task_future = TaskFuture {
             task_id: "task-1".to_string(),
             future: Box::pin(async move { TaskResult::<TestCommonData>::from_task(task) }),
         };
 
-        assert_eq!(handle.id(), "task-1");
-        let result = handle.await.unwrap();
+        assert_eq!(task_future.id(), "task-1");
+        let result = task_future.await.unwrap();
         assert_eq!(result.task_id, "task-1");
         assert_eq!(result.session_id, "ssn-1");
         assert!(result.is_succeed());
         assert_eq!(result.output.unwrap().value, "done");
         assert_eq!(result.error_code, None);
         assert_eq!(result.error_message, None);
+    }
+
+    #[tokio::test]
+    async fn task_handle_await_returns_success_output() {
+        let payload = TestCommonData {
+            value: "done".to_string(),
+        };
+        let mut task = test_task("task-1", TaskState::Succeed);
+        task.output = Some(payload.encode().unwrap());
+        let task_future = TaskFuture {
+            task_id: "task-1".to_string(),
+            future: Box::pin(async move { TaskResult::<TestCommonData>::from_task(task) }),
+        };
+
+        let handle = TaskHandle::from(task_future);
+
+        assert_eq!(handle.id(), "task-1");
+        let output = handle.await.unwrap().unwrap();
+        assert_eq!(output.value, "done");
+    }
+
+    #[tokio::test]
+    async fn task_handle_await_returns_error_for_failed_task() {
+        let mut task = test_task("task-2", TaskState::Failed);
+        task.events.push(Event {
+            code: 42,
+            message: Some("remote failure".to_string()),
+            creation_time: Utc.with_ymd_and_hms(2026, 5, 8, 10, 0, 0).unwrap(),
+        });
+        let task_future = TaskFuture {
+            task_id: "task-2".to_string(),
+            future: Box::pin(async move { TaskResult::<TestCommonData>::from_task(task) }),
+        };
+
+        let err = TaskHandle::from(task_future).await.unwrap_err();
+
+        assert!(err.to_string().contains("task <task-2>"));
+        assert!(err.to_string().contains("code <42>"));
+        assert!(err.to_string().contains("remote failure"));
     }
 
     #[test]

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -16,7 +16,7 @@ pub mod client;
 pub mod message;
 pub mod service;
 
-pub use client::{Connection, Session, SessionOptions, TaskHandle};
+pub use client::{Connection, Session, SessionOptions, TaskHandle, TaskResult};
 pub use message::{FlameMessage, FromTaskOutput, IntoCommonData, IntoTaskInput};
 
 #[cfg(feature = "macros")]

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -13,4 +13,80 @@ limitations under the License.
 
 pub mod apis;
 pub mod client;
+pub mod message;
 pub mod service;
+
+pub use client::{Connection, Session, SessionOptions, TaskHandle};
+pub use message::{FlameMessage, FromTaskOutput, IntoCommonData, IntoTaskInput};
+
+#[cfg(feature = "macros")]
+pub use flame_rs_macros::{entrypoint, instance, FlameMessage};
+
+#[doc(hidden)]
+pub mod __private {
+    pub use bytes;
+    pub use serde;
+    pub use serde_json;
+}
+
+pub trait IntoFlameInstance {
+    type Service: service::FlameService;
+
+    fn into_flame_instance(self) -> Self::Service;
+}
+
+impl<T> IntoFlameInstance for T
+where
+    T: service::FlameService,
+{
+    type Service = T;
+
+    fn into_flame_instance(self) -> Self::Service {
+        self
+    }
+}
+
+pub async fn run<T>(target: T) -> Result<(), Box<dyn std::error::Error>>
+where
+    T: IntoFlameInstance,
+{
+    apis::init_logger()?;
+    service::run(target.into_flame_instance()).await
+}
+
+pub async fn connect() -> Result<Connection, apis::FlameError> {
+    connect_with_config(None).await
+}
+
+pub async fn connect_with_context(
+    context: apis::FlameContext,
+) -> Result<Connection, apis::FlameError> {
+    let current = context.get_current_context()?;
+    client::connect_with_tls(&current.cluster.endpoint, current.cluster.tls.as_ref()).await
+}
+
+pub async fn connect_with_config(path: Option<String>) -> Result<Connection, apis::FlameError> {
+    let context = apis::FlameContext::from_file_with_env(path)?;
+    connect_with_context(context).await
+}
+
+pub async fn create_session(
+    options: impl Into<SessionOptions>,
+) -> Result<Session, apis::FlameError> {
+    connect().await?.create_session_with(options).await
+}
+
+pub async fn open_session(id: impl Into<apis::SessionID>) -> Result<Session, apis::FlameError> {
+    let id = id.into();
+    connect().await?.open_session(&id, None).await
+}
+
+pub async fn open_or_create_session(
+    id: impl Into<apis::SessionID>,
+    options: impl Into<SessionOptions>,
+) -> Result<Session, apis::FlameError> {
+    connect()
+        .await?
+        .open_or_create_session_with(id, options)
+        .await
+}

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -16,7 +16,7 @@ pub mod client;
 pub mod message;
 pub mod service;
 
-pub use client::{Connection, Session, SessionOptions, TaskHandle, TaskResult};
+pub use client::{Connection, Session, SessionOptions, TaskFuture, TaskHandle, TaskResult};
 pub use message::{FlameMessage, FromTaskOutput, IntoCommonData, IntoTaskInput};
 
 #[cfg(feature = "macros")]

--- a/sdk/rust/src/message.rs
+++ b/sdk/rust/src/message.rs
@@ -134,11 +134,11 @@ mod tests {
         fn encode(&self) -> Result<Bytes, FlameError> {
             serde_json::to_vec(self)
                 .map(Bytes::from)
-                .map_err(|e| FlameError::InvalidConfig(e.to_string()))
+                .map_err(|e| FlameError::Internal(e.to_string()))
         }
 
         fn decode(bytes: &[u8]) -> Result<Self, FlameError> {
-            serde_json::from_slice(bytes).map_err(|e| FlameError::Internal(e.to_string()))
+            serde_json::from_slice(bytes).map_err(|e| FlameError::InvalidConfig(e.to_string()))
         }
     }
 

--- a/sdk/rust/src/message.rs
+++ b/sdk/rust/src/message.rs
@@ -1,0 +1,169 @@
+/*
+Copyright 2026 The Flame Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use bytes::Bytes;
+
+use crate::apis::{CommonData, FlameError, TaskInput, TaskOutput};
+
+pub trait FlameMessage: Sized {
+    fn encode(&self) -> Result<Bytes, FlameError>;
+    fn decode(bytes: &[u8]) -> Result<Self, FlameError>;
+}
+
+pub trait IntoTaskInput {
+    fn into_task_input(self) -> Result<Option<TaskInput>, FlameError>;
+}
+
+impl<T> IntoTaskInput for &T
+where
+    T: FlameMessage,
+{
+    fn into_task_input(self) -> Result<Option<TaskInput>, FlameError> {
+        Ok(Some(self.encode()?))
+    }
+}
+
+impl<T> IntoTaskInput for Option<&T>
+where
+    T: FlameMessage,
+{
+    fn into_task_input(self) -> Result<Option<TaskInput>, FlameError> {
+        self.map(FlameMessage::encode).transpose()
+    }
+}
+
+impl IntoTaskInput for () {
+    fn into_task_input(self) -> Result<Option<TaskInput>, FlameError> {
+        Ok(None)
+    }
+}
+
+pub trait FromTaskOutput: Sized {
+    fn from_task_output(output: Option<TaskOutput>) -> Result<Option<Self>, FlameError>;
+}
+
+impl<T> FromTaskOutput for T
+where
+    T: FlameMessage,
+{
+    fn from_task_output(output: Option<TaskOutput>) -> Result<Option<Self>, FlameError> {
+        output.map(|output| T::decode(&output)).transpose()
+    }
+}
+
+impl FromTaskOutput for () {
+    fn from_task_output(_: Option<TaskOutput>) -> Result<Option<Self>, FlameError> {
+        Ok(Some(()))
+    }
+}
+
+pub trait IntoCommonData {
+    fn into_common_data(self) -> Result<CommonData, FlameError>;
+}
+
+impl<T> IntoCommonData for &T
+where
+    T: FlameMessage,
+{
+    fn into_common_data(self) -> Result<CommonData, FlameError> {
+        self.encode()
+    }
+}
+
+pub fn decode<T>(input: TaskInput) -> Result<T, FlameError>
+where
+    T: FlameMessage,
+{
+    T::decode(&input)
+}
+
+pub fn decode_optional<T>(input: Option<TaskInput>) -> Result<Option<T>, FlameError>
+where
+    T: FlameMessage,
+{
+    input.map(decode).transpose()
+}
+
+pub fn encode<T>(output: T) -> Result<Option<TaskOutput>, FlameError>
+where
+    T: FlameMessage,
+{
+    Ok(Some(output.encode()?))
+}
+
+pub fn encode_optional<T>(output: Option<T>) -> Result<Option<TaskOutput>, FlameError>
+where
+    T: FlameMessage,
+{
+    output.map(|output| output.encode()).transpose()
+}
+
+pub fn encode_unit() -> Result<Option<TaskOutput>, FlameError> {
+    Ok(None)
+}
+
+pub fn decode_common_data<T>(common_data: Option<&CommonData>) -> Result<Option<T>, FlameError>
+where
+    T: FlameMessage,
+{
+    common_data.map(|data| T::decode(data)).transpose()
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_derive::{Deserialize, Serialize};
+
+    use super::*;
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    struct TestMessage {
+        value: String,
+    }
+
+    impl FlameMessage for TestMessage {
+        fn encode(&self) -> Result<Bytes, FlameError> {
+            serde_json::to_vec(self)
+                .map(Bytes::from)
+                .map_err(|e| FlameError::InvalidConfig(e.to_string()))
+        }
+
+        fn decode(bytes: &[u8]) -> Result<Self, FlameError> {
+            serde_json::from_slice(bytes).map_err(|e| FlameError::Internal(e.to_string()))
+        }
+    }
+
+    #[test]
+    fn message_round_trips_task_payloads() {
+        let input = TestMessage {
+            value: "hello".to_string(),
+        };
+
+        let task_input = (&input).into_task_input().unwrap().unwrap();
+        let decoded = decode::<TestMessage>(task_input).unwrap();
+        assert_eq!(decoded, input);
+
+        let output = encode(input).unwrap();
+        let decoded = TestMessage::from_task_output(output).unwrap().unwrap();
+        assert_eq!(decoded.value, "hello");
+    }
+
+    #[test]
+    fn optional_and_unit_payloads_map_to_absent_bytes() {
+        let input: Option<&TestMessage> = None;
+        assert!(input.into_task_input().unwrap().is_none());
+        assert!(decode_optional::<TestMessage>(None).unwrap().is_none());
+        assert!(encode_optional::<TestMessage>(None).unwrap().is_none());
+        assert!(encode_unit().unwrap().is_none());
+        assert_eq!(<()>::from_task_output(None).unwrap(), Some(()));
+    }
+}

--- a/sdk/rust/src/service/mod.rs
+++ b/sdk/rust/src/service/mod.rs
@@ -26,27 +26,66 @@ use tonic::{Request, Response, Status};
 use self::rpc::instance_server::{Instance, InstanceServer};
 use crate::apis::flame::v1 as rpc;
 
-use crate::apis::{CommonData, FlameError, TaskInput, TaskOutput};
+use crate::apis::{ApplicationID, CommonData, FlameError, TaskInput, TaskOutput};
+
+pub use tonic::async_trait;
+
+pub mod message {
+    pub use crate::message::*;
+}
 
 #[cfg(unix)]
 const FLAME_INSTANCE_ENDPOINT: &str = "FLAME_INSTANCE_ENDPOINT";
 
+#[derive(Clone, Debug)]
 pub struct ApplicationContext {
     pub name: String,
     pub image: Option<String>,
     pub command: Option<String>,
 }
 
+#[derive(Clone, Debug)]
 pub struct SessionContext {
     pub session_id: String,
     pub application: ApplicationContext,
     pub common_data: Option<CommonData>,
 }
 
+#[derive(Clone, Debug)]
 pub struct TaskContext {
     pub task_id: String,
     pub session_id: String,
     pub input: Option<TaskInput>,
+}
+
+#[derive(Clone, Debug)]
+pub struct FlameInstance {
+    session: SessionContext,
+}
+
+impl FlameInstance {
+    pub fn new(session: SessionContext) -> Self {
+        Self { session }
+    }
+
+    pub fn session_id(&self) -> &str {
+        &self.session.session_id
+    }
+
+    pub fn application(&self) -> &ApplicationContext {
+        &self.session.application
+    }
+
+    pub fn application_name(&self) -> &ApplicationID {
+        &self.session.application.name
+    }
+
+    pub fn common_data<T>(&self) -> Result<Option<T>, FlameError>
+    where
+        T: crate::message::FlameMessage,
+    {
+        crate::message::decode_common_data(self.session.common_data.as_ref())
+    }
 }
 
 #[tonic::async_trait]

--- a/sdk/rust/tests/rfe455_macro_test.rs
+++ b/sdk/rust/tests/rfe455_macro_test.rs
@@ -8,6 +8,7 @@ use flame_rs::service::{
     ApplicationContext, FlameInstance, FlameService, SessionContext, TaskContext,
 };
 use flame_rs::{FlameMessage, IntoFlameInstance};
+use serde::Serializer;
 use serde_derive::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, FlameMessage)]
@@ -33,6 +34,18 @@ struct Factor {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, FlameMessage)]
 struct Number {
     value: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, FlameMessage)]
+struct EncodeFailure;
+
+impl serde::Serialize for EncodeFailure {
+    fn serialize<S>(&self, _: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        Err(serde::ser::Error::custom("encode failure"))
+    }
 }
 
 #[derive(Default)]
@@ -157,4 +170,11 @@ fn flame_message_decode_errors_are_invalid_config() {
     let err = EchoRequest::decode(b"{").unwrap_err();
 
     assert!(matches!(err, FlameError::InvalidConfig(_)));
+}
+
+#[test]
+fn flame_message_encode_errors_are_internal() {
+    let err = EncodeFailure.encode().unwrap_err();
+
+    assert!(matches!(err, FlameError::Internal(_)));
 }

--- a/sdk/rust/tests/rfe455_macro_test.rs
+++ b/sdk/rust/tests/rfe455_macro_test.rs
@@ -1,0 +1,153 @@
+#![cfg(feature = "macros")]
+
+use std::sync::Mutex;
+
+use flame_rs as flame;
+use flame_rs::apis::{CommonData, FlameError};
+use flame_rs::service::{
+    ApplicationContext, FlameInstance, FlameService, SessionContext, TaskContext,
+};
+use flame_rs::{FlameMessage, IntoFlameInstance};
+use serde_derive::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, FlameMessage)]
+struct EchoRequest {
+    value: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, FlameMessage)]
+struct EchoResponse {
+    value: String,
+}
+
+#[flame::entrypoint]
+async fn echo(req: EchoRequest) -> Result<EchoResponse, FlameError> {
+    Ok(EchoResponse { value: req.value })
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, FlameMessage)]
+struct Factor {
+    value: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, FlameMessage)]
+struct Number {
+    value: u32,
+}
+
+#[derive(Default)]
+struct Multiplier {
+    factor: Mutex<u32>,
+}
+
+#[flame::instance]
+impl Multiplier {
+    async fn enter(&self, instance: FlameInstance) -> Result<(), FlameError> {
+        let factor = instance
+            .common_data::<Factor>()?
+            .map(|factor| factor.value)
+            .unwrap_or(1);
+        *self.factor.lock().unwrap() = factor;
+        Ok(())
+    }
+
+    #[flame::entrypoint]
+    async fn multiply(&self, req: Number) -> Result<Number, FlameError> {
+        let factor = *self.factor.lock().unwrap();
+        Ok(Number {
+            value: req.value * factor,
+        })
+    }
+
+    async fn leave(&self) -> Result<(), FlameError> {
+        *self.factor.lock().unwrap() = 1;
+        Ok(())
+    }
+}
+
+fn session_context(common_data: Option<CommonData>) -> SessionContext {
+    SessionContext {
+        session_id: "ssn-1".to_string(),
+        application: ApplicationContext {
+            name: "test-app".to_string(),
+            image: None,
+            command: None,
+        },
+        common_data,
+    }
+}
+
+fn task_context(input: Option<flame::apis::TaskInput>) -> TaskContext {
+    TaskContext {
+        task_id: "task-1".to_string(),
+        session_id: "ssn-1".to_string(),
+        input,
+    }
+}
+
+#[tokio::test]
+async fn free_function_entrypoint_decodes_and_encodes_typed_payloads() {
+    let service = echo.into_flame_instance();
+    service
+        .on_session_enter(session_context(None))
+        .await
+        .unwrap();
+
+    let input = EchoRequest {
+        value: "hello".to_string(),
+    }
+    .encode()
+    .unwrap();
+
+    let output = service
+        .on_task_invoke(task_context(Some(input)))
+        .await
+        .unwrap()
+        .unwrap();
+    let decoded = EchoResponse::decode(&output).unwrap();
+
+    assert_eq!(
+        decoded,
+        EchoResponse {
+            value: "hello".to_string()
+        }
+    );
+    service.on_session_leave().await.unwrap();
+}
+
+#[tokio::test]
+async fn instance_entrypoint_can_use_typed_common_data() {
+    let service = Multiplier::default().into_flame_instance();
+    let common_data = Factor { value: 3 }.encode().unwrap();
+    service
+        .on_session_enter(session_context(Some(common_data)))
+        .await
+        .unwrap();
+
+    let input = Number { value: 7 }.encode().unwrap();
+    let output = service
+        .on_task_invoke(task_context(Some(input)))
+        .await
+        .unwrap()
+        .unwrap();
+    let decoded = Number::decode(&output).unwrap();
+
+    assert_eq!(decoded, Number { value: 21 });
+    service.on_session_leave().await.unwrap();
+}
+
+#[tokio::test]
+async fn required_macro_input_reports_missing_task_input() {
+    let service = echo.into_flame_instance();
+    service
+        .on_session_enter(session_context(None))
+        .await
+        .unwrap();
+
+    let err = service
+        .on_task_invoke(task_context(None))
+        .await
+        .expect_err("required input should be rejected");
+
+    assert!(err.to_string().contains("missing task input"));
+}

--- a/sdk/rust/tests/rfe455_macro_test.rs
+++ b/sdk/rust/tests/rfe455_macro_test.rs
@@ -151,3 +151,10 @@ async fn required_macro_input_reports_missing_task_input() {
 
     assert!(err.to_string().contains("missing task input"));
 }
+
+#[test]
+fn flame_message_decode_errors_are_invalid_config() {
+    let err = EchoRequest::decode(b"{").unwrap_err();
+
+    assert!(matches!(err, FlameError::InvalidConfig(_)));
+}


### PR DESCRIPTION
## Summary

- add the RFE455 design report and implement the simplified `flame-rs` client API
- add `FlameMessage`, typed task/common-data helpers, `SessionOptions`, `Session::invoke`, `Session::run`, and `TaskHandle`
- add optional `flame-rs-macros` support for `#[derive(FlameMessage)]`, `#[entrypoint]`, and `#[instance]`
- polish `flmping` to use the typed macro path and update `flmexec` to use the new session/root runner helpers

## Validation

- `cargo fmt`
- `cargo check -p flame-rs`
- `cargo check -p flame-rs --features macros`
- `cargo check -p flmping`
- `cargo check -p flmexec`
- `cargo test -p flame-rs --lib --features macros`
- `cargo test -p flame-rs --features macros --test rfe455_macro_test`
- `cargo metadata --no-deps --format-version 1`
- `git diff --check`
