### PR TITLE
[codex] Simplify flmexec new API usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1977,13 +1977,9 @@ dependencies = [
  "rand 0.9.4",
  "serde",
  "serde_derive",
- "serde_json",
  "stdng",
- "tempfile",
  "tokio",
- "tonic",
  "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]

--- a/flmexec/Cargo.toml
+++ b/flmexec/Cargo.toml
@@ -6,20 +6,16 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-flame-rs = { path = "../sdk/rust" }
+flame-rs = { path = "../sdk/rust", features = ["macros"] }
 stdng = { path = "../stdng" }
 
 tokio = { workspace = true }
-tonic = { workspace = true }
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true }
 serde = { workspace = true }
-serde_json = { workspace = true }
 serde_derive = { workspace = true }
 futures = { workspace = true }
 clap = { workspace = true }
 indicatif = {version = "*", features = ["rayon"]}
-tempfile = { workspace = true }
 rand = { workspace = true }
 
 [[bin]]

--- a/flmexec/src/api/mod.rs
+++ b/flmexec/src/api/mod.rs
@@ -11,21 +11,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::collections::HashMap;
-
+use flame_rs::FlameMessage;
 use serde_derive::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, FlameMessage)]
 pub struct Script {
     pub language: String,
     pub code: String,
     pub input: Option<Vec<u8>>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ScriptRuntime {
-    pub entrypoint: String,
-    pub work_dir: String,
-    pub input: Option<Vec<u8>>,
-    pub env: HashMap<String, String>,
+#[derive(Debug, Clone, Serialize, Deserialize, FlameMessage)]
+pub struct ScriptOutput {
+    pub data: Vec<u8>,
 }

--- a/flmexec/src/client.rs
+++ b/flmexec/src/client.rs
@@ -11,25 +11,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+mod api;
+
+use api::{Script, ScriptOutput};
 use futures::future::try_join_all;
 use std::error::Error;
-use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
 use clap::Parser;
 use indicatif::HumanCount;
-use serde_derive::{Deserialize, Serialize};
 
 use flame_rs as flame;
-use flame_rs::apis::FlameError;
-use flame_rs::client::{SessionOptions, Task, TaskInformer};
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct Script {
-    language: String,
-    code: String,
-    input: Option<Vec<u8>>,
-}
+use flame_rs::client::SessionOptions;
 
 #[derive(Parser)]
 #[command(name = "flmexec")]
@@ -37,8 +30,6 @@ struct Script {
 #[command(version = "0.5.0")]
 #[command(about = "Flame Executor CLI", long_about = None)]
 struct Cli {
-    #[arg(long)]
-    config: Option<String>,
     #[arg(short, long)]
     task_num: Option<i32>,
     /// The code to execute on worker nodes
@@ -70,20 +61,13 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let task_num = cli.task_num.unwrap_or(DEFAULT_TASK_NUM);
 
-    let conn = flame::connect_with_config(cli.config).await?;
-
     let ssn_creation_start_time = Instant::now();
-    let ssn = conn
-        .create_session_with(SessionOptions::new(DEFAULT_APP))
-        .await?;
+    let ssn = flame::create_session(SessionOptions::new(DEFAULT_APP)).await?;
 
     let ssn_creation_time = ssn_creation_start_time.elapsed().as_millis();
     println!("Session <{}> was created in <{ssn_creation_time} ms>, start to run <{}> tasks in the session:\n", ssn.id, HumanCount(task_num as u64));
 
-    let mut tasks = vec![];
     let tasks_creations_start_time = Instant::now();
-
-    let info = Arc::new(Mutex::new(ExecInfo {}));
 
     let script = Script {
         language: cli.language.clone(),
@@ -91,13 +75,22 @@ async fn main() -> Result<(), Box<dyn Error>> {
         input: cli.input.clone(),
     };
 
-    let input = serde_json::to_string(&script)?;
+    let handles =
+        try_join_all((0..task_num).map(|_| ssn.invoke::<_, ScriptOutput>(&script))).await?;
+    let task_ids = handles
+        .iter()
+        .map(|handle| handle.id().clone())
+        .collect::<Vec<_>>();
+    let outputs = try_join_all(handles).await?;
 
-    for _ in 0..task_num {
-        tasks.push(ssn.run_task(Some(input.clone().into()), info.clone()));
+    for (task_id, output) in task_ids.into_iter().zip(outputs) {
+        println!(
+            "Task {:<10}: {:?}",
+            task_id,
+            output.map(|output| output.data).unwrap_or_default()
+        );
     }
 
-    try_join_all(tasks).await?;
     let tasks_creation_time = tasks_creations_start_time.elapsed().as_millis();
 
     println!(
@@ -109,22 +102,4 @@ async fn main() -> Result<(), Box<dyn Error>> {
     ssn.close().await?;
 
     Ok(())
-}
-
-struct ExecInfo {}
-
-impl TaskInformer for ExecInfo {
-    fn on_update(&mut self, task: Task) {
-        if task.is_completed() {
-            println!(
-                "Task {:<10}: {:?}",
-                task.id,
-                task.output.unwrap_or_default()
-            );
-        }
-    }
-
-    fn on_error(&mut self, e: FlameError) {
-        println!("Got an error: {e}")
-    }
 }

--- a/flmexec/src/script/lang/python.rs
+++ b/flmexec/src/script/lang/python.rs
@@ -25,8 +25,8 @@ use rand::Rng;
 use flame_rs::apis::FlameError;
 use stdng::trace_fn;
 
-use crate::api::{Script, ScriptRuntime};
-use crate::script::ScriptEngine;
+use crate::api::Script;
+use crate::script::{ScriptEngine, ScriptRuntime};
 
 const DEFAULT_ENTRYPOINT: &str = "main.py";
 

--- a/flmexec/src/script/lang/shell.rs
+++ b/flmexec/src/script/lang/shell.rs
@@ -25,8 +25,8 @@ use rand::Rng;
 use flame_rs::apis::FlameError;
 use stdng::trace_fn;
 
-use crate::api::{Script, ScriptRuntime};
-use crate::script::ScriptEngine;
+use crate::api::Script;
+use crate::script::{ScriptEngine, ScriptRuntime};
 
 const DEFAULT_ENTRYPOINT: &str = "main.sh";
 const SHELL_CMD: &str = "/bin/bash";

--- a/flmexec/src/script/mod.rs
+++ b/flmexec/src/script/mod.rs
@@ -13,10 +13,20 @@ limitations under the License.
 
 mod lang;
 
+use std::collections::HashMap;
+
 use flame_rs::apis::FlameError;
 
 use crate::api::Script;
 use lang::{python::PythonScript, shell::ShellScript};
+
+#[derive(Debug, Clone)]
+pub struct ScriptRuntime {
+    pub entrypoint: String,
+    pub work_dir: String,
+    pub input: Option<Vec<u8>>,
+    pub env: HashMap<String, String>,
+}
 
 pub trait ScriptEngine {
     fn run(&self) -> Result<Option<Vec<u8>>, FlameError>;

--- a/flmexec/src/service.rs
+++ b/flmexec/src/service.rs
@@ -14,60 +14,26 @@ limitations under the License.
 mod api;
 mod script;
 
-use flame_rs::{
-    self as flame,
-    apis::{FlameError, TaskOutput},
-    service::{SessionContext, TaskContext},
-};
-use stdng::trace_fn;
+use flame_rs::{self as flame, apis::FlameError};
 
-use api::Script;
+use api::{Script, ScriptOutput};
 
-#[derive(Clone)]
-pub struct FlmexecService {}
+#[flame::entrypoint]
+async fn exec(script: Script) -> Result<Option<ScriptOutput>, FlameError> {
+    tracing::debug!("Try to create engine for script: {:?}", script);
+    let engine = script::new(&script)?;
+    tracing::debug!("Created engine for language: {}", script.language);
+    tracing::debug!("Code:\n{}", script.code);
+    let output = engine.run()?;
 
-#[tonic::async_trait]
-impl flame::service::FlameService for FlmexecService {
-    async fn on_session_enter(&self, _: SessionContext) -> Result<(), FlameError> {
-        trace_fn!("FlmexecService::on_session_enter");
-        Ok(())
-    }
-
-    async fn on_task_invoke(&self, ctx: TaskContext) -> Result<Option<TaskOutput>, FlameError> {
-        trace_fn!("FlmexecService::on_task_invoke");
-
-        tracing::debug!("Try to get task input from context");
-        let input = ctx
-            .input
-            .as_ref()
-            .ok_or(FlameError::Internal("No task input".to_string()))?;
-        tracing::debug!(
-            "Try to parse script from input:\n{}",
-            String::from_utf8_lossy(input)
-        );
-        let script: Script = serde_json::from_slice(input)
-            .map_err(|e| FlameError::Internal(format!("failed to parse script: {e}")))?;
-        tracing::debug!("Try to create engine for script: {:?}", script);
-        let engine = script::new(&script)?;
-        tracing::debug!("Created engine for language: {}", script.language);
-        tracing::debug!("Code:\n{}", script.code);
-        let output = engine.run()?;
-
-        Ok(output.map(TaskOutput::from))
-    }
-
-    async fn on_session_leave(&self) -> Result<(), FlameError> {
-        trace_fn!("FlmexecService::on_session_leave");
-
-        Ok(())
-    }
+    Ok(output.map(|data| ScriptOutput { data }))
 }
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    flame::run(FlmexecService {}).await?;
+    flame::run(exec).await?;
 
-    tracing::debug!("FlmexecService was stopped.");
+    tracing::debug!("flmexec service was stopped.");
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
- remove flmexec's explicit config option and default-context connection setup
- switch the flmexec client to flame::create_session and ssn.invoke task handles
- convert flmexec-service to a typed flame::entrypoint and shared FlameMessage payloads
- remove now-unused flmexec direct dependencies

## Verification
- cargo fmt --all -- --check
- cargo check -p flmexec
- cargo clippy -p flmexec --all-targets --all-features -- -D warnings
- cargo test -p flmexec
- cargo run -p flmexec --bin flmexec -- --help
- git diff --check