### PR TITLE
[codex] add flmctl deploy and object helpers

### DIFF
--- a/.github/workflows/code-verify.yaml
+++ b/.github/workflows/code-verify.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Install cargo-tarpaulin
         run: cargo install cargo-tarpaulin
       - name: Generate coverage report
-        run: cargo tarpaulin --workspace --exclude flame-rs --exclude cri-rs --out xml --output-dir coverage
+        run: cargo tarpaulin --workspace --exclude flame-rs --exclude cri-rs --exclude candle-based-example --out xml --output-dir coverage
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,7 +272,7 @@ dependencies = [
  "arrow-schema",
  "arrow-select",
  "atoi",
- "base64",
+ "base64 0.22.1",
  "chrono",
  "half",
  "lexical-core",
@@ -319,7 +319,7 @@ dependencies = [
  "arrow-cast",
  "arrow-ipc",
  "arrow-schema",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures",
  "prost 0.14.3",
@@ -531,6 +531,12 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -658,7 +664,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969a9ba84b0ff843813e7249eed1678d9b6607ce5a3b8f0a47af3fcf7978e6e"
 dependencies = [
  "ahash 0.8.12",
- "base64",
+ "base64 0.22.1",
  "bitvec",
  "getrandom 0.2.17",
  "getrandom 0.3.4",
@@ -728,6 +734,20 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "byteorder"
@@ -764,6 +784,83 @@ checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
 dependencies = [
  "cc",
  "pkg-config",
+]
+
+[[package]]
+name = "candle-based-example"
+version = "0.1.0"
+dependencies = [
+ "candle-core",
+ "candle-nn",
+ "candle-transformers",
+ "clap",
+ "flame-rs",
+ "hf-hub",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tokenizers",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "candle-core"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bd9895436c1ba5dc1037a19935d084b838db066ff4e15ef7dded020b7c12a4a"
+dependencies = [
+ "byteorder",
+ "float8",
+ "gemm",
+ "half",
+ "libm",
+ "memmap2",
+ "num-traits",
+ "num_cpus",
+ "rand 0.9.4",
+ "rand_distr",
+ "rayon",
+ "safetensors",
+ "thiserror 2.0.18",
+ "tokenizers",
+ "yoke",
+ "zip 7.2.0",
+]
+
+[[package]]
+name = "candle-nn"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9317a09d6530b758990ed7f625ac69ff43653bc9ee28b0464644ad1169ada87"
+dependencies = [
+ "candle-core",
+ "half",
+ "libc",
+ "num-traits",
+ "rayon",
+ "safetensors",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "candle-transformers"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f59d08c89e9f4af9c464e2f3a8e16199e7cc601e6f34538c2cfbb42b623b1783"
+dependencies = [
+ "byteorder",
+ "candle-core",
+ "candle-nn",
+ "fancy-regex 0.17.0",
+ "num-traits",
+ "rand 0.9.4",
+ "rayon",
+ "serde",
+ "serde_json",
+ "serde_plain",
+ "tracing",
 ]
 
 [[package]]
@@ -842,6 +939,15 @@ dependencies = [
  "once_cell",
  "rustix 1.1.4",
  "winx",
+]
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -1002,6 +1108,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "compact_str"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "serde",
+ "static_assertions",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1066,6 +1187,16 @@ name = "constant_time_eq"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "core-foundation"
@@ -1430,6 +1561,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dary_heap"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1e3a325bc115f096c8b77bbf027a7c2592230e70be2d985be950d3d5e60ebe"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "debugid"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1472,6 +1612,37 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
  "syn 2.0.117",
 ]
 
@@ -1575,6 +1746,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "dyn-stack"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c4713e43e2886ba72b8271aa66c93d722116acf7a75555cce11dcde84388fe8"
+dependencies = [
+ "bytemuck",
+ "dyn-stack-macros",
+]
+
+[[package]]
+name = "dyn-stack-macros"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d926b4d407d372f141f93bb444696142c29d32962ccbd3531117cf3aa0bfa9"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1620,6 +1807,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-as-inner"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "equator"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1656,6 +1855,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "esaxx-rs"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
+
+[[package]]
 name = "etcetera"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1682,6 +1887,17 @@ name = "fancy-regex"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "998b056554fbe42e03ae0e152895cd1a7e1002aec800fdc6635d20270260c46f"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
 dependencies = [
  "bit-set",
  "regex-automata",
@@ -1770,6 +1986,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+ "sha2",
  "shellexpand",
  "stdng",
  "tar",
@@ -1784,7 +2001,7 @@ dependencies = [
  "uuid",
  "wasmtime",
  "wasmtime-wasi",
- "zip",
+ "zip 2.4.2",
 ]
 
 [[package]]
@@ -1795,12 +2012,13 @@ dependencies = [
  "arrow-flight",
  "arrow-ipc",
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "bson",
  "bytes",
  "bytesize",
  "clap",
  "common",
+ "flame-rs",
  "futures",
  "network-interface",
  "prost 0.14.3",
@@ -1813,6 +2031,7 @@ dependencies = [
  "stdng",
  "tempfile",
  "tokio",
+ "tokio-stream",
  "tonic",
  "tracing",
  "tracing-appender",
@@ -1825,7 +2044,10 @@ dependencies = [
 name = "flame-rs"
 version = "0.5.0"
 dependencies = [
+ "arrow",
+ "arrow-flight",
  "bincode",
+ "bson",
  "bytes",
  "chrono",
  "flame-rs-macros",
@@ -1850,6 +2072,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+ "uuid",
 ]
 
 [[package]]
@@ -1930,7 +2153,7 @@ dependencies = [
  "console 0.15.11",
  "dialoguer",
  "fs_extra",
- "indicatif",
+ "indicatif 0.18.4",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -1951,15 +2174,21 @@ dependencies = [
  "clap",
  "clap_complete",
  "comfy-table",
+ "common",
  "flame-rs",
+ "flate2",
  "jsonschema",
  "serde",
  "serde_derive",
  "serde_json",
  "serde_yaml",
+ "sha2",
  "sqlx",
  "stdng",
+ "tar",
+ "tempfile",
  "tokio",
+ "toml",
  "tonic",
  "tracing",
  "tracing-subscriber",
@@ -1973,7 +2202,7 @@ dependencies = [
  "clap",
  "flame-rs",
  "futures",
- "indicatif",
+ "indicatif 0.18.4",
  "rand 0.9.4",
  "serde",
  "serde_derive",
@@ -1996,11 +2225,23 @@ dependencies = [
  "flame-rs",
  "futures",
  "gethostname",
- "indicatif",
+ "indicatif 0.18.4",
  "serde",
  "serde_derive",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "float8"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2d1f04709a8ac06e8e8042875a3c466cc4832d3c1a18dbcb9dba3c6e83046bc"
+dependencies = [
+ "half",
+ "num-traits",
+ "rand 0.9.4",
+ "rand_distr",
 ]
 
 [[package]]
@@ -2214,6 +2455,125 @@ dependencies = [
 ]
 
 [[package]]
+name = "gemm"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa0673db364b12263d103b68337a68fbecc541d6f6b61ba72fe438654709eacb"
+dependencies = [
+ "dyn-stack",
+ "gemm-c32",
+ "gemm-c64",
+ "gemm-common",
+ "gemm-f16",
+ "gemm-f32",
+ "gemm-f64",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-c32"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "086936dbdcb99e37aad81d320f98f670e53c1e55a98bee70573e83f95beb128c"
+dependencies = [
+ "dyn-stack",
+ "gemm-common",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-c64"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20c8aeeeec425959bda4d9827664029ba1501a90a0d1e6228e48bef741db3a3f"
+dependencies = [
+ "dyn-stack",
+ "gemm-common",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-common"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88027625910cc9b1085aaaa1c4bc46bb3a36aad323452b33c25b5e4e7c8e2a3e"
+dependencies = [
+ "bytemuck",
+ "dyn-stack",
+ "half",
+ "libm",
+ "num-complex",
+ "num-traits",
+ "once_cell",
+ "paste",
+ "pulp",
+ "raw-cpuid",
+ "rayon",
+ "seq-macro",
+ "sysctl",
+]
+
+[[package]]
+name = "gemm-f16"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3df7a55202e6cd6739d82ae3399c8e0c7e1402859b30e4cb780e61525d9486e"
+dependencies = [
+ "dyn-stack",
+ "gemm-common",
+ "gemm-f32",
+ "half",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "rayon",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-f32"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02e0b8c9da1fbec6e3e3ab2ce6bc259ef18eb5f6f0d3e4edf54b75f9fd41a81c"
+dependencies = [
+ "dyn-stack",
+ "gemm-common",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-f64"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "056131e8f2a521bfab322f804ccd652520c79700d81209e9d9275bbdecaadc6a"
+dependencies = [
+ "dyn-stack",
+ "gemm-common",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2316,9 +2676,12 @@ version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
+ "bytemuck",
  "cfg-if",
  "crunchy",
  "num-traits",
+ "rand 0.9.4",
+ "rand_distr",
  "zerocopy",
 ]
 
@@ -2348,6 +2711,8 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.2.0",
  "serde",
  "serde_core",
@@ -2385,6 +2750,30 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hf-hub"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "629d8f3bbeda9d148036d6b0de0a3ab947abd08ce90626327fc3547a49d59d97"
+dependencies = [
+ "dirs",
+ "futures",
+ "http",
+ "indicatif 0.17.11",
+ "libc",
+ "log",
+ "native-tls",
+ "num_cpus",
+ "rand 0.9.4",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "ureq",
+ "windows-sys 0.60.2",
+]
 
 [[package]]
 name = "hkdf"
@@ -2493,7 +2882,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -2510,12 +2899,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -2527,9 +2932,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -2699,6 +3106,19 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
+version = "0.17.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+dependencies = [
+ "console 0.15.11",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width",
+ "web-time",
+]
+
+[[package]]
+name = "indicatif"
 version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
@@ -2860,10 +3280,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d46662859bc5f60a145b75f4632fbadc84e829e45df6c5de74cfc8e05acb96b5"
 dependencies = [
  "ahash 0.8.12",
- "base64",
+ "base64 0.22.1",
  "bytecount",
  "email_address",
- "fancy-regex",
+ "fancy-regex 0.16.2",
  "fraction",
  "idna",
  "itoa",
@@ -3079,6 +3499,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "macro_rules_attribute"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65049d7923698040cd0b1ddcced9b0eb14dd22c5f86ae59c3740eab64a676520"
+dependencies = [
+ "macro_rules_attribute-proc_macro",
+ "paste",
+]
+
+[[package]]
+name = "macro_rules_attribute-proc_macro"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670fdfda89751bc4a84ac13eaa63e205cf0fd22b4c9a5fbfa085b63c1f1d3a30"
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3131,6 +3567,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
 dependencies = [
  "libc",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -3138,6 +3575,12 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -3158,6 +3601,28 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "monostate"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3341a273f6c9d5bef1908f17b7267bbab0e95c9bf69a0d4dcf8e9e1b2c76ef67"
+dependencies = [
+ "monostate-impl",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "monostate-impl"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4db6d5580af57bf992f59068d4ea26fd518574ff48d7639b255a36f9de6e7e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3216,6 +3681,16 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -3279,6 +3754,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
+ "bytemuck",
  "num-traits",
 ]
 
@@ -3359,6 +3835,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
 name = "nvml-wrapper"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3413,6 +3895,28 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "onig"
+version = "6.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc3cbf698f9438986c11a880c90a6d04b9de27575afd28bbf45b154b6c709e2"
+dependencies = [
+ "bitflags 2.11.1",
+ "libc",
+ "once_cell",
+ "onig_sys",
+]
+
+[[package]]
+name = "onig_sys"
+version = "69.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e68317604e77e53b85896388e1a803c1d21b74c899ec9e5e1112db90735edd7"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "openssl"
@@ -3500,6 +4004,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "pbkdf2"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3553,12 +4063,10 @@ dependencies = [
  "flame-rs",
  "futures",
  "rand 0.9.4",
- "rand_distr",
- "stdng",
+ "serde",
+ "serde_derive",
  "tokio",
- "tonic",
  "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -3886,6 +4394,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulp"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e205bb30d5b916c55e584c22201771bcf2bad9aabd5d4127f38387140c38632"
+dependencies = [
+ "bytemuck",
+ "cfg-if",
+ "libm",
+ "num-complex",
+ "paste",
+ "pulp-wasm-simd-flag",
+ "raw-cpuid",
+ "reborrow",
+ "version_check",
+]
+
+[[package]]
+name = "pulp-wasm-simd-flag"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40e24eee682d89fb193496edf918a7f407d30175b2e785fe057e4392dfd182e0"
+
+[[package]]
 name = "quick-xml"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3998,16 +4529,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
-dependencies = [
- "getrandom 0.4.2",
- "rand_core 0.10.1",
-]
-
-[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4046,19 +4567,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_core"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
-
-[[package]]
 name = "rand_distr"
-version = "0.6.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d431c2703ccf129de4d45253c03f49ebb22b97d6ad79ee3ecfc7e3f4862c1d8"
+checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
 dependencies = [
  "num-traits",
- "rand 0.10.1",
+ "rand 0.9.4",
 ]
 
 [[package]]
@@ -4068,6 +4583,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
 dependencies = [
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -4081,6 +4605,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon-cond"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2964d0cf57a3e7a06e8183d14a8b527195c706b7983549cd5462d5aa3747438f"
+dependencies = [
+ "either",
+ "itertools 0.14.0",
+ "rayon",
+]
+
+[[package]]
 name = "rayon-core"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4089,6 +4624,12 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
 ]
+
+[[package]]
+name = "reborrow"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03251193000f4bd3b042892be858ee50e8b3719f2b08e5833ac4353724632430"
 
 [[package]]
 name = "redox_syscall"
@@ -4222,19 +4763,24 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
+ "encoding_rs",
  "futures-channel",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
+ "mime",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -4245,6 +4791,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower",
@@ -4255,7 +4802,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -4466,6 +5013,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "safetensors"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "675656c1eabb620b921efea4f9199f97fc86e36dd6ffd1fbbe48d0f59a4987f5"
+dependencies = [
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4514,7 +5072,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags 2.11.1",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -4539,6 +5097,12 @@ dependencies = [
  "serde",
  "serde_core",
 ]
+
+[[package]]
+name = "seq-macro"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
 
 [[package]]
 name = "serde"
@@ -4603,6 +5167,15 @@ dependencies = [
  "itoa",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "serde_plain"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce1fc6db65a611022b23a0dec6975d63fb80a302cb3388835ff02c097258d50"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -4759,6 +5332,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "socks"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c3dbbd9ae980613c6dd8e28a9407b50509d3803b57624d5dfe8315218cd58b"
+dependencies = [
+ "byteorder",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4787,6 +5371,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "spm_precompiled"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5851699c4033c63636f7ea4cf7b7c1f1bf06d0cc03cfb42e711de5a5c46cf326"
+dependencies = [
+ "base64 0.13.1",
+ "nom",
+ "serde",
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "sqlx"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4805,7 +5401,7 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "crc",
  "crossbeam-queue",
@@ -4879,7 +5475,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
- "base64",
+ "base64 0.22.1",
  "bitflags 2.11.1",
  "byteorder",
  "bytes",
@@ -4921,7 +5517,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
- "base64",
+ "base64 0.22.1",
  "bitflags 2.11.1",
  "byteorder",
  "crc",
@@ -5120,6 +5716,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysctl"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01198a2debb237c62b6826ec7081082d951f46dbb64b0e8c7649a452230d1dfc"
+dependencies = [
+ "bitflags 2.11.1",
+ "byteorder",
+ "enum-as-inner",
+ "libc",
+ "thiserror 1.0.69",
+ "walkdir",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "system-interface"
 version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5297,6 +5928,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "tokenizers"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b238e22d44a15349529690fb07bd645cf58149a1b1e44d6cb5bd1641ff1a6223"
+dependencies = [
+ "ahash 0.8.12",
+ "aho-corasick",
+ "compact_str",
+ "dary_heap",
+ "derive_builder",
+ "esaxx-rs",
+ "getrandom 0.3.4",
+ "itertools 0.14.0",
+ "log",
+ "macro_rules_attribute",
+ "monostate",
+ "onig",
+ "paste",
+ "rand 0.9.4",
+ "rayon",
+ "rayon-cond",
+ "regex",
+ "regex-syntax",
+ "serde",
+ "serde_json",
+ "spm_precompiled",
+ "thiserror 2.0.18",
+ "unicode-normalization-alignments",
+ "unicode-segmentation",
+ "unicode_categories",
+]
+
+[[package]]
 name = "tokio"
 version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5322,6 +5986,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -5438,7 +6112,7 @@ checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
 dependencies = [
  "async-trait",
  "axum",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "h2",
  "http",
@@ -5631,6 +6305,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
+
+[[package]]
 name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5664,6 +6344,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-normalization-alignments"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43f613e4fa046e69818dd287fdc4bc78175ff20331479dab6e1b0f98d57062de"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "unicode-properties"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5688,6 +6377,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "unicode_categories"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
+
+[[package]]
 name = "unit-prefix"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5710,6 +6405,26 @@ name = "unty"
 version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
+
+[[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64 0.22.1",
+ "flate2",
+ "log",
+ "native-tls",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "socks",
+ "url",
+ "webpki-roots 0.26.11",
+]
 
 [[package]]
 name = "url"
@@ -6122,7 +6837,7 @@ version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e4fd4103ba413c0da2e636f73490c6c8e446d708cbde7573703941bc3d6a448"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "directories-next",
  "log",
  "postcard",
@@ -6385,6 +7100,15 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "webpki-roots"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
@@ -6546,6 +7270,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6592,6 +7327,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -6623,11 +7367,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -6643,6 +7404,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6653,6 +7420,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6667,10 +7440,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -6685,6 +7470,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6695,6 +7486,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -6709,6 +7506,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6719,6 +7522,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -7067,6 +7876,18 @@ dependencies = [
  "zeroize",
  "zopfli",
  "zstd",
+]
+
+[[package]]
+name = "zip"
+version = "7.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c42e33efc22a0650c311c2ef19115ce232583abbe80850bc8b66509ebef02de0"
+dependencies = [
+ "crc32fast",
+ "indexmap",
+ "memchr",
+ "typed-path",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "sdk/rust",
     "sdk/rust/macros",
     "examples/pi/rust",
+    "examples/candle/based",
     "cri",
     "stdng",
     "object_cache",

--- a/docker/Dockerfile.console
+++ b/docker/Dockerfile.console
@@ -9,11 +9,12 @@ RUN cargo build --release
 # Copy uv before flmadm install (flmadm will detect and copy it to FLAME_HOME/bin)
 COPY --from=ghcr.io/astral-sh/uv:0.9.26 /uv /uvx /usr/bin/
 
-# Install using flmadm with client profile
+# Install using flmadm with client profile and all example binaries
 RUN ./target/release/flmadm install \
     --src-dir /usr/src/flame \
     --prefix /usr/local/flame \
     --client \
+    --with-examples \
     --skip-build \
     --force
 

--- a/docs/designs/RFE458-flmctl-deploy/FS.md
+++ b/docs/designs/RFE458-flmctl-deploy/FS.md
@@ -1,0 +1,984 @@
+# RFE458: Simplify Application Deployment by `flmctl deploy`
+
+GitHub issue: https://github.com/xflops/flame/issues/458
+
+## Summary
+
+Add a parameter-driven `flmctl deploy` command that accepts one local
+application path, uploads a normalized package to Flame object cache, detects
+the application command and installer when possible, and registers the
+application through the existing application API.
+
+The command does not add a new manifest section. It is intentionally centered
+on one artifact parameter:
+
+```bash
+flmctl deploy --name <app-name> --application <path>
+```
+
+`--application` can be:
+
+- an executable binary file
+- a `.tar.gz` or `.tgz` package
+- a directory
+
+`flmctl deploy` classifies the path, normalizes it into a `.tar.gz` package,
+uploads the package to object cache, sets `spec.url`, and renders
+`ApplicationAttributes` from parameters plus detection results.
+
+## 1. Motivation
+
+**Background:**
+
+Users currently deploy applications through a multi-step manual flow:
+
+- build an application binary or package
+- upload the artifact to object cache
+- construct a `grpc://` or `grpcs://` package URL
+- decide the right application command and installer
+- write application YAML with `spec.url`, `spec.installer`, command,
+  arguments, environment, and limits
+- run `flmctl register`
+
+That is too much ceremony for the common case. Flame already has the core
+pieces: object-cache upload/download, application specs with `url` and
+`installer`, and executor-manager package download for installer-backed
+applications. The missing piece is one CLI command that wires those pieces
+together from a local application path.
+
+There is also a deployment correctness concern to handle while designing this:
+executor managers currently cache application installation state by application
+name, and package download skips existing filenames. If a user redeploys new
+bytes under the same package filename, an executor can continue using stale
+content. `flmctl deploy` should generate content-addressed object keys, and the
+executor install cache should include the package URL in its identity.
+
+**Target:**
+
+`flmctl deploy` should make the common deployment flow one command:
+
+- Accept a local application path through `--application`.
+- Detect whether the path is a binary file, `.tar.gz` package, or directory.
+- Detect `command` and `installer` when possible.
+- Package or repackage the application into a normalized `.tar.gz`.
+- Upload the package to Flame object cache.
+- Register the application using CLI parameters plus detected values.
+- Avoid introducing a `deploy` manifest section or another YAML schema.
+- Avoid generic HTTP/file storage in this command.
+- Keep the implementation compatible with existing application registration
+  APIs.
+
+Success criteria:
+
+- A user can deploy a Python project directory with:
+
+```bash
+flmctl deploy --name image-classifier --application .
+```
+
+- A user can deploy an executable binary with:
+
+```bash
+flmctl deploy \
+  --name candle-based-example \
+  --application ./target/release/candle-based-example-service
+```
+
+- A user can deploy an existing tar package with:
+
+```bash
+flmctl deploy --name batch-worker --application ./dist/batch-worker.tar.gz
+```
+
+- The command uploads the normalized package to object cache and registers the
+  application with `spec.url` set to the uploaded object-cache URL.
+- Re-running deploy after changing the application bytes produces a different
+  URL.
+
+## 2. Function Specification
+
+### User Model
+
+`flmctl deploy` is a parameter-driven deployment command. It is not a YAML
+replacement for `register`; it is the command users run when the application
+can be described by CLI parameters and a local application path.
+
+Required inputs:
+
+- `--name <NAME>`
+- `--application <PATH>`
+
+`--application` is classified as:
+
+| Input | Behavior |
+|-------|----------|
+| Executable file | Pack into `<app-name>.tar.gz` containing `bin/<filename>`, then default `command=<filename>` and `installer=binary`. |
+| `.tar.gz` or `.tgz` file | Unpack to a temporary directory for detection, then repackage the detected root into a normalized `.tar.gz`. |
+| Directory | Detect from the directory, then package the directory into a normalized `.tar.gz`. |
+
+Generated output:
+
+- detected application kind
+- detected or overridden command
+- detected or overridden installer
+- object-cache key in the package namespace
+- `grpc://` or `grpcs://` package URL
+- registered application spec
+
+### Detection Rules
+
+Detection fills omitted values. Explicit CLI parameters take precedence over
+detected values.
+
+Command override:
+
+- `--command <COMMAND>` overrides the detected command.
+- repeated `--argument <ARG>` overrides detected arguments when `--command` is
+  provided.
+
+Installer override:
+
+- `--installer <TYPE>` overrides the detected installer.
+- Supported installer types for this design are `binary` and `python`.
+
+Detection output:
+
+```rust
+struct DetectedApplication {
+    installer: String,
+    command: String,
+    arguments: Vec<String>,
+}
+```
+
+Executable file detection:
+
+- A regular executable file is treated as a binary application.
+- The package layout is normalized to:
+
+```text
+bin/<filename>
+```
+
+- Detected installer: `binary`
+- Detected command: `<filename>`
+- Detected arguments: `[]`
+
+Directory and tarball detection:
+
+1. If the detection root has a Python project marker, detect a Python
+   application.
+2. Otherwise, if it has an executable bundle marker, detect a binary
+   application.
+3. Otherwise, fail with a message asking the user to pass `--command` and
+   `--installer`.
+
+Python project markers:
+
+- `pyproject.toml`
+- `setup.py`
+- `setup.cfg`
+
+Python command detection:
+
+1. If `pyproject.toml` has `[project.scripts]` and exactly one script, use that
+   script name as the command.
+2. If `[project.scripts]` contains a script whose name matches `--name`, use
+   that script.
+3. If a Python package matching the normalized application name has
+   `__main__.py`, use `command=python` and `arguments=["-m", "<module>"]`.
+4. If command detection is ambiguous, fail and ask the user to pass
+   `--command` and `--argument`.
+
+Detected installer for Python projects: `python`.
+
+Binary bundle markers:
+
+- `bin/<name>` where `<name>` matches `--name`
+- exactly one executable file under `bin/`
+- exactly one executable file at the root
+
+Binary command detection:
+
+- For `bin/<name>`, use command `<name>` because `BinaryInstaller` prepends the
+  extracted `bin/` directory to `PATH`.
+- For a root executable, use the executable filename.
+- If multiple executable candidates exist, fail and ask the user to pass
+  `--command`.
+
+Detected installer for binary bundles: `binary`.
+
+Tarball root handling:
+
+- `flmctl deploy` unpacks `.tar.gz` and `.tgz` inputs into a temporary
+  directory.
+- If the tarball contains exactly one top-level directory, that directory is
+  the detection root.
+- Otherwise, the temporary extraction root is the detection root.
+- After detection, `flmctl deploy` repackages the detection root into a
+  normalized `.tar.gz` before upload. This keeps executor-side package layout
+  consistent across binary files, tarballs, and directories.
+
+### Object Cache URL
+
+`flmctl deploy` uploads the normalized `.tar.gz` package to Flame object cache
+using the current context's cache endpoint:
+
+```yaml
+cache:
+  endpoint: grpc://flame-object-cache:9090
+```
+
+No cache endpoint CLI override is provided. Users select the target object
+cache by selecting the current Flame context.
+
+Object keys use the RFE429 package namespace:
+
+```text
+<application-name>/pkg/<filename>
+```
+
+Directory and tarball filenames are content-addressed:
+
+```text
+<application-name>-<sha256-16>.tar.gz
+```
+
+Executable-file archives are created as `<application-name>.tar.gz`, while the
+object id remains content-addressed and still uses the same three-part object
+key shape as FlamePy and object-cache:
+
+```text
+<application-name>/pkg/<application-name>-<sha256-16>.tar.gz
+```
+
+Generated URLs:
+
+```text
+grpc://flame-object-cache:9090/image-classifier/pkg/image-classifier-82e0f0d2d68f9341.tar.gz
+grpcs://cache.example.com:9090/candle-based-example/pkg/candle-based-example-953bf914bd839f80.tar.gz
+```
+
+The object-cache upload uses the Rust SDK object helper API. The object is
+stored as raw package bytes through the existing object-cache protocol, matching
+the Python `upload_object()` behavior.
+
+### CLI
+
+New command:
+
+```bash
+flmctl deploy [OPTIONS]
+```
+
+Artifact and cache options:
+
+| Option | Description |
+|--------|-------------|
+| `--name <NAME>` | Application name. Required. |
+| `--application <PATH>` | Application path. Required. Can be an executable file, `.tar.gz`/`.tgz`, or directory. |
+| `--dry-run` | Render the deploy plan without uploading or writing to the cluster. |
+| `-o, --output <FORMAT>` | `summary`, `yaml`, or `json`. Default: `summary`. |
+
+Application registration parameters:
+
+| Option | Description |
+|--------|-------------|
+| `--shim <Host|Wasm>` | Application shim. Default: `Host`. |
+| `--image <IMAGE>` | Optional runtime image. |
+| `--description <TEXT>` | Application description. |
+| `--label <LABEL>` | Application label. Repeatable. |
+| `--command <COMMAND>` | Application command. Overrides detected command. |
+| `--argument <ARG>` | Add one command argument. Repeatable. |
+| `--env <NAME=VALUE>` | Add one environment variable. Repeatable. |
+| `--working-directory <DIR>` | Runtime working directory. |
+| `--max-instances <N>` | Application maximum instances. |
+| `--delay-release <SECONDS>` | Application delay-release value. |
+| `--installer <TYPE>` | Installer type. Overrides detected installer. |
+| `--schema-input <SCHEMA>` | Optional input schema string. |
+| `--schema-output <SCHEMA>` | Optional output schema string. |
+| `--schema-common-data <SCHEMA>` | Optional common-data schema string. |
+
+Dry-run behavior:
+
+- validates CLI parameters
+- validates and classifies the application path
+- detects command and installer
+- resolves the cache endpoint
+- computes the package object key and target object-cache URL
+- renders the application spec that would be sent
+- does not upload bytes
+- does not call the application API
+
+Exit codes:
+
+| Code | Meaning |
+|------|---------|
+| `0` | Success. |
+| `1` | Invalid CLI arguments or context. |
+| `2` | Application validation, detection, or packaging failed. |
+| `3` | Object-cache upload failed. |
+| `4` | Application API request failed. |
+
+### Rendered Application Spec
+
+The command builds `ApplicationAttributes` from parameters and detection
+results.
+
+Python directory example:
+
+```bash
+flmctl deploy --name image-classifier --application .
+```
+
+If the directory contains `pyproject.toml` with one project script named
+`image-classifier`, `flmctl deploy` registers the equivalent of:
+
+```yaml
+metadata:
+  name: image-classifier
+spec:
+  shim: Host
+  command: image-classifier
+  installer: python
+  url: grpc://flame-object-cache:9090/image-classifier/pkg/image-classifier-82e0f0d2d68f9341.tar.gz
+```
+
+Executable file example:
+
+```bash
+flmctl deploy \
+  --name candle-based-example \
+  --application ./target/release/candle-based-example-service
+```
+
+`flmctl deploy` registers the equivalent of:
+
+```yaml
+metadata:
+  name: candle-based-example
+spec:
+  shim: Host
+  command: candle-based-example-service
+  installer: binary
+  url: grpc://flame-object-cache:9090/candle-based-example/pkg/candle-based-example-953bf914bd839f80.tar.gz
+```
+
+Tarball example with overrides:
+
+```bash
+flmctl deploy \
+  --name image-classifier \
+  --application ./dist/image-classifier.tar.gz \
+  --installer python \
+  --command python \
+  --argument -m \
+  --argument image_classifier.service
+```
+
+Explicit command and installer values override detection.
+
+### Installer Behavior
+
+`installer: python`
+
+- Existing behavior from RFE420.
+- Executor manager downloads and extracts the package, then runs the Python
+  installer through `uv`.
+- To support detected Python project scripts, `PythonInstaller` should prepend
+  the app dependency `bin/` directory to `PATH` when it exists.
+
+`installer: binary`
+
+- New installer type for executable binaries and self-contained bundles.
+- Executor manager downloads and extracts the package.
+- No language package installation is run.
+- Returned environment variables:
+  - `FLAME_APP_DIR=<release>/src`
+  - `PATH=<release>/src/bin:<release>/src:$PATH`
+  - `LD_LIBRARY_PATH=<release>/src/libs:$LD_LIBRARY_PATH`
+
+`flmctl deploy` must not register an uploaded package without an installer.
+If `--installer` is omitted and detection cannot infer one, the command fails.
+
+### API
+
+No new session-manager API is required.
+
+`flmctl deploy` uses the existing `register_application(name, attributes)`
+API. If an application with the same name already exists, the command returns
+the existing registration error. Users who need to change an existing
+application continue to use the existing update flow.
+
+`ApplicationSpec.url` stores the object-cache package URL.
+`ApplicationSpec.installer` stores the selected or detected installer type.
+
+### Scope
+
+**In Scope:**
+
+- `flmctl deploy` CLI command
+- single `--application <PATH>` artifact input
+- parameter-driven application registration
+- directory detection and packaging
+- tarball unpacking for detection and normalized repackaging
+- executable file packaging into `.tar.gz`
+- object-cache upload through `grpc://` and `grpcs://`
+- content-addressed object-cache keys
+- command and installer detection
+- `binary` installer for executable binaries and self-contained artifacts
+- executor install identity keyed by application name, installer, and URL
+- dry-run output
+
+**Out of Scope:**
+
+- a new `deploy` section in application YAML
+- generic `file://`, `http://`, or `https://` storage upload
+- container image build/push
+- package garbage collection in object cache
+- rollback command
+- multi-artifact application deployment
+- signing or signature verification
+- source builds; `--application` must point at runnable source/package content
+  or an already-built binary
+
+**Limitations:**
+
+- The first implementation depends on an accessible Flame object cache.
+- Binary-file deployment assumes the binary is already built for executor
+  nodes.
+- Detection is intentionally conservative. Ambiguous applications require
+  explicit `--command`, `--argument`, or `--installer`.
+- Updating an application does not affect sessions that are already bound.
+- Package garbage collection remains a future operation.
+
+### Feature Interaction
+
+**Related Features:**
+
+- `flmctl register`: remains the YAML registration command.
+- `flmctl update`: remains the YAML update command.
+- RFE420 application installer: deploy uses installer-backed package download.
+- RFE429 cache upload/download: deploy uses the same object-cache key format
+  and URL scheme.
+
+**Compatibility:**
+
+- Existing application YAML stays unchanged.
+- Existing `flmctl register` and `flmctl update` behavior stays unchanged.
+- Existing `installer: python` behavior stays unchanged, except for the
+  additive `PATH` entry when Python scripts are installed.
+- Existing applications without uploaded artifacts are unaffected.
+- Existing applications with the same name are not modified by `flmctl deploy`.
+
+**Breaking Changes:**
+
+None for public control APIs or existing CLI commands.
+
+## 3. Implementation Detail
+
+### Architecture
+
+```text
+flmctl deploy
+    |
+    +-- parse CLI parameters
+    +-- load current Flame context
+    +-- resolve object-cache endpoint
+    +-- classify --application path
+    +-- unpack tarball if needed
+    +-- detect command and installer
+    +-- apply explicit CLI overrides
+    +-- create normalized .tar.gz package
+    +-- compute sha256 and package object key
+    +-- upload package to object cache through flame-rs object helpers
+    +-- build ApplicationAttributes
+    +-- dry-run output or register application
+```
+
+Executor install path:
+
+```text
+executor binds a session
+    |
+    +-- receives ApplicationContext { name, url, installer }
+    +-- build InstallKey { name, installer, url }
+    +-- reuse matching install or install a new release
+    +-- download package from object cache URL
+    +-- extract to content-addressed release directory
+    +-- run selected installer
+    +-- return env vars to shim
+```
+
+### Components
+
+`flmctl/src/main.rs`
+
+- Add `Deploy(deploy::Options)` subcommand.
+
+`flmctl/src/deploy.rs`
+
+- Own CLI options and command orchestration.
+- Build the deploy plan from parameters and detection results.
+- Render `ApplicationAttributes`.
+- Call `register_application`.
+
+`flmctl/src/deploy/artifact.rs`
+
+- Classify `--application` as executable file, tarball, or directory.
+- Safely unpack `.tar.gz` and `.tgz` inputs for detection.
+- Create normalized `.tar.gz` packages.
+- Compute SHA-256 digests.
+- Produce package filenames and object keys.
+
+`flmctl/src/deploy/detect.rs`
+
+- Detect Python project markers.
+- Parse `pyproject.toml` for `[project.scripts]`.
+- Detect executable bundle markers.
+- Return `DetectedApplication`.
+
+`sdk/rust/src/object.rs`
+
+- Provide `upload_object_with_context` for package upload.
+- Use object-cache `ObjectRef` metadata from the upload response.
+- Share TLS handling with the current Flame context where possible.
+
+`flmctl/src/deploy/render.rs`
+
+- Merge CLI parameters with `DetectedApplication`.
+- CLI values override detection.
+- Convert the merged result into `ApplicationAttributes`.
+- Validate command/installer combinations.
+
+`executor_manager/src/appmgr/installer.rs`
+
+- Add `InstallerType::Binary`.
+- Accept `binary` in `FromStr`.
+- Update supported-installer error text.
+
+`executor_manager/src/appmgr/binary.rs`
+
+- Implement `BinaryInstaller`.
+- Return `FLAME_APP_DIR`, `PATH`, and `LD_LIBRARY_PATH`.
+- Add the extracted package `bin/` directory to `PATH`.
+- Add the extracted package `libs/` directory to `LD_LIBRARY_PATH`.
+- Merge application-provided environment variables consistently with existing
+  installer behavior.
+
+`executor_manager/src/appmgr/python.rs`
+
+- Preserve existing Python installer behavior.
+- Add the app dependency `bin/` directory to `PATH` when present so detected
+  `pyproject.toml` scripts can run by command name.
+
+`executor_manager/src/appmgr/mod.rs`
+
+- Change installed app identity from application name only to:
+
+```rust
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+struct InstallKey {
+    app_name: String,
+    installer: String,
+    url: Option<String>,
+}
+```
+
+- Use URL/content-addressed release paths:
+
+```text
+$FLAME_HOME/data/apps/<app-name>/releases/<url-digest>/src
+$FLAME_HOME/data/apps/<app-name>/releases/<url-digest>/download/<filename>
+```
+
+- Keep the per-install lock so concurrent binds for the same release install
+  once.
+
+### Data Structures
+
+Deploy plan:
+
+```rust
+#[derive(Debug, Clone)]
+struct DeployPlan {
+    app_name: String,
+    cache_endpoint: CacheEndpoint,
+    input: ApplicationInput,
+    detected: DetectedApplication,
+    application: ApplicationSpecParams,
+    output: OutputFormat,
+    dry_run: bool,
+}
+
+#[derive(Debug, Clone)]
+struct ApplicationInput {
+    original_path: PathBuf,
+    kind: ApplicationInputKind,
+    detection_root: PathBuf,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum ApplicationInputKind {
+    ExecutableFile,
+    TarGz,
+    Directory,
+}
+
+#[derive(Debug, Clone)]
+struct DetectedApplication {
+    installer: String,
+    command: String,
+    arguments: Vec<String>,
+}
+
+```
+
+Uploaded package:
+
+```rust
+#[derive(Debug, Clone)]
+struct UploadedPackage {
+    key: String,
+    url: String,
+    filename: String,
+    sha256: String,
+    local_path: PathBuf,
+}
+```
+
+Application parameters:
+
+```rust
+#[derive(Debug, Clone)]
+struct ApplicationSpecParams {
+    shim: Option<Shim>,
+    image: Option<String>,
+    description: Option<String>,
+    labels: Vec<String>,
+    command: Option<String>,
+    arguments: Vec<String>,
+    environments: HashMap<String, String>,
+    working_directory: Option<String>,
+    max_instances: Option<u32>,
+    delay_release: Option<Duration>,
+    schema: Option<ApplicationSchema>,
+    installer: Option<String>,
+}
+```
+
+### Algorithms
+
+**Deploy plan construction:**
+
+1. Parse CLI parameters.
+2. Validate `--name`.
+3. Validate `--application`.
+4. Load current `FlameContext`.
+5. Resolve cache endpoint from context `cache.endpoint`.
+6. Validate cache endpoint scheme is `grpc` or `grpcs`.
+7. Classify the application input.
+8. Detect command and installer.
+9. Apply explicit CLI overrides.
+10. Validate the merged command and installer.
+11. Produce a `DeployPlan`.
+
+**Application path classification:**
+
+1. If the path is a directory, classify as `Directory`.
+2. If the path is a `.tar.gz` or `.tgz` file, classify as `TarGz`.
+3. If the path is a regular executable file, classify as `ExecutableFile`.
+4. Otherwise, return `InvalidConfig`.
+
+**Tarball handling:**
+
+1. Unpack into a temporary directory.
+2. Reject archive entries with absolute paths or `..` traversal.
+3. Pick the single top-level directory as detection root when there is exactly
+   one; otherwise use the temporary extraction root.
+4. Detect command and installer from the detection root.
+5. Repackage the detection root as a normalized `.tar.gz`.
+
+**Directory handling:**
+
+1. Detect command and installer from the directory.
+2. Package the directory as a normalized `.tar.gz`.
+3. Reject symlinks that resolve outside the directory.
+4. Store only relative archive paths.
+
+**Executable-file handling:**
+
+1. Validate the file exists.
+2. On Unix, validate at least one executable bit is set.
+3. Create a normalized `<app-name>.tar.gz` containing `bin/<filename>`.
+4. Preserve executable mode in the tar entry.
+5. Detect `installer=binary`, `command=<filename>`, `arguments=[]`.
+
+**Object cache upload:**
+
+1. Compute SHA-256 over the normalized `.tar.gz` bytes.
+2. For executable-file input, create archive `<app-name>.tar.gz` and upload it
+   under object key `<app>/pkg/<app-name>-<sha256-16>.tar.gz`.
+3. For directory and tarball input, build filename
+   `<app-name>-<sha256-16>.tar.gz` and object key `<app>/pkg/<filename>`.
+4. Upload package bytes through `flame-rs` object helpers.
+5. Use raw bytes, not serde/cloudpickle encoding.
+6. Return object-cache URL `<scheme>://<host>:<port>/<key>`.
+
+**Application write:**
+
+1. Build `ApplicationAttributes` from CLI parameters and detection results.
+2. Set `url` to the uploaded package URL.
+3. Set `installer` to the selected or detected installer.
+4. Set `command` and `arguments` to explicit overrides or detected values.
+5. If `--dry-run`, print the rendered result and return.
+6. Call `register_application`.
+
+### System Considerations
+
+**Performance:**
+
+- Hashing and upload should stream package bytes rather than reading large
+  artifacts fully into memory.
+- Tarball and directory inputs are normalized into one temporary `.tar.gz`
+  before upload.
+- Object-cache upload is client-side work and does not add control-plane load
+  beyond the final application API call.
+
+**Scalability:**
+
+- Content-addressed keys avoid overwriting package objects.
+- Repeated deploys of identical normalized bytes reuse the same key.
+- Executor installation remains node-local.
+
+**Reliability:**
+
+- The application API call happens only after upload succeeds.
+- A failed API call can leave an unused object-cache package; cleanup is out of
+  scope.
+- Executor install identity includes URL so a new deploy does not reuse an old
+  in-memory install.
+
+**Security:**
+
+- `flmctl deploy` does not execute uploaded artifacts locally.
+- Packaging must store relative archive paths only.
+- Tarball unpacking and executor extraction must reject absolute paths and
+  `..` traversal.
+- Directory packaging must reject symlinks that escape the application root.
+- `grpcs://` should honor current TLS configuration.
+
+**Observability:**
+
+- Summary output includes app name, input kind, detected installer, detected
+  command, object key, URL, and digest.
+- JSON output is suitable for CI.
+- Dry-run output clearly marks that no upload happened.
+- Executor logs include install key, package URL, release path, and installer
+  type.
+
+**Operational:**
+
+- Object-cache package garbage collection is future work.
+- Content-addressed package names make repeated deployments auditable.
+- Existing applications are not mutated by `flmctl deploy`; registration
+  conflict errors are surfaced directly.
+
+### Dependencies
+
+Potential `flmctl` dependencies:
+
+- `tar` and `flate2` for package creation and tarball inspection
+- `sha2` for package digests
+- `toml` for `pyproject.toml` detection
+- existing `flame-rs` object helper support for object-cache upload
+
+Potential executor dependencies:
+
+- No new archive dependencies are needed if existing `tar`, `flate2`, and
+  `zip` usage remains.
+
+### Verification Plan
+
+Unit tests:
+
+- CLI requires `--name`.
+- CLI requires `--application`.
+- cache endpoint resolution from context.
+- missing cache endpoint returns an invalid-config error.
+- cache endpoint rejects non-`grpc`/`grpcs` schemes.
+- executable-file classification.
+- `.tar.gz` and `.tgz` classification.
+- directory classification.
+- tarball unpack rejects path traversal.
+- directory packaging rejects symlinks outside the root.
+- executable file package layout and executable mode preservation.
+- Python project detection from `pyproject.toml`.
+- Python command detection from `[project.scripts]`.
+- binary bundle detection from `bin/`.
+- ambiguous detection asks for explicit command or installer.
+- explicit `--command`, `--argument`, and `--installer` override detection.
+- normalized package digest, filename, and object-key generation.
+- rendered `ApplicationAttributes` contains uploaded URL and selected
+  installer.
+- application registration call path.
+- `binary` installer environment variables.
+- Python installer adds dependency `bin/` to `PATH` when present.
+- executor install key changes when URL changes.
+
+Integration tests:
+
+- `flmctl deploy --dry-run -o yaml` renders expected application YAML without
+  upload.
+- `flmctl deploy --dry-run -o json` renders expected machine-readable plan.
+- object-cache upload writes the normalized package to a local
+  flame-object-cache when the test environment provides one.
+- executor manager installs two different object-cache URLs for the same
+  application name as two different releases.
+
+Manual verification:
+
+```bash
+cargo fmt --all -- --check
+cargo check -p flmctl
+cargo test -p flmctl deploy
+cargo test -p flame-executor-manager appmgr
+git diff --check
+```
+
+## 4. Use Cases
+
+### Example 1: Deploy a Python Project Directory
+
+Command:
+
+```bash
+flmctl deploy --name image-classifier --application .
+```
+
+Workflow:
+
+1. `flmctl` detects a Python project from `pyproject.toml`.
+2. `flmctl` detects the command from `[project.scripts]`.
+3. `flmctl` packages the directory as a normalized `.tar.gz`.
+4. `flmctl` uploads it to object cache under
+   `image-classifier/pkg/image-classifier-<sha>.tar.gz`.
+5. `flmctl` registers `image-classifier` with `installer=python` and the
+   generated `grpc://` URL.
+
+Expected outcome:
+
+- The application is registered without manual object-cache upload or YAML.
+
+### Example 2: Deploy a Rust Binary File
+
+Command:
+
+```bash
+flmctl deploy \
+  --name candle-based-example \
+  --application ./target/release/candle-based-example-service
+```
+
+Workflow:
+
+1. `flmctl` detects an executable file.
+2. `flmctl` creates `candle-based-example.tar.gz` containing
+   `bin/candle-based-example-service`.
+3. `flmctl` uploads the normalized package to object cache.
+4. `flmctl` registers the application with `command:
+   candle-based-example-service` and `installer: binary`.
+5. Executor manager extracts the package, prepends the extracted `bin/`
+   directory to `PATH`, and adds extracted `libs/` to `LD_LIBRARY_PATH`.
+
+Expected outcome:
+
+- A self-contained executable binary is deployable with one command.
+
+### Example 3: Deploy an Existing Tarball
+
+Command:
+
+```bash
+flmctl deploy \
+  --name batch-worker \
+  --application ./dist/batch-worker.tar.gz
+```
+
+Workflow:
+
+1. `flmctl` unpacks the tarball into a temporary directory.
+2. `flmctl` detects command and installer from the extracted package.
+3. `flmctl` repackages the detected root as a normalized `.tar.gz`.
+4. `flmctl` uploads the package to a content-addressed object-cache key.
+5. `flmctl` registers the application with the generated URL.
+
+Expected outcome:
+
+- A tarball package is registered without manual object-cache URL construction.
+
+### Example 4: Override Detection
+
+Command:
+
+```bash
+flmctl deploy \
+  --name image-classifier \
+  --application ./dist/image-classifier.tar.gz \
+  --installer python \
+  --command python \
+  --argument -m \
+  --argument image_classifier.service
+```
+
+Workflow:
+
+1. `flmctl` unpacks and inspects the tarball.
+2. Explicit `--installer`, `--command`, and `--argument` values override
+   detection.
+3. `flmctl` uploads the normalized package and registers the application.
+
+Expected outcome:
+
+- Users can deploy ambiguous packages without writing YAML.
+
+### Example 5: Dry Run
+
+Command:
+
+```bash
+flmctl deploy \
+  --name image-classifier \
+  --application ./dist/image-classifier.tar.gz \
+  --dry-run \
+  -o yaml
+```
+
+Workflow:
+
+1. `flmctl` validates parameters and classifies the application path.
+2. `flmctl` detects command and installer.
+3. `flmctl` computes the target object key and URL.
+4. `flmctl` prints the application spec that would be registered.
+5. No upload or application API write occurs.
+
+Expected outcome:
+
+- Users can review the deploy result before changing the cluster.
+
+## 5. References
+
+Related documents:
+
+- [RFE420: Application Installer in Executor Manager](../RFE420-app-installer/FS.md)
+- [RFE429: Support Upload/Download in flame-object-cache](../RFE429-cache-upload-download/FS.md)
+
+Implementation references:
+
+- `flmctl/src/main.rs`
+- `flmctl/src/register.rs`
+- `sdk/rust/src/apis/ctx.rs`
+- `sdk/python/src/flamepy/core/cache.py`
+- `executor_manager/src/appmgr/mod.rs`
+- `executor_manager/src/appmgr/installer.rs`
+- `executor_manager/src/appmgr/downloader.rs`

--- a/examples/candle/based/Cargo.toml
+++ b/examples/candle/based/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "candle-based-example"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+flame-rs = { path = "../../../sdk/rust", features = ["macros"] }
+
+tokio = { workspace = true }
+tracing = { workspace = true }
+serde = { workspace = true }
+serde_derive = { workspace = true }
+serde_json = { workspace = true }
+clap = { workspace = true }
+
+candle = { package = "candle-core", version = "0.10.2" }
+candle-nn = "0.10.2"
+candle-transformers = "0.10.2"
+hf-hub = { version = "0.4.1", features = ["tokio"] }
+tokenizers = { version = "0.22.0", default-features = false, features = ["onig"] }
+
+[[bin]]
+name = "candle-based-example-service"
+path = "src/service.rs"
+
+[[bin]]
+name = "candle-based-example"
+path = "src/client.rs"

--- a/examples/candle/based/README.md
+++ b/examples/candle/based/README.md
@@ -1,0 +1,30 @@
+# Candle Based Example
+
+This example runs the HazyResearch Based language model through a Flame Rust service. It is adapted from the current Hugging Face Candle `candle-examples/examples/based` example and uses the current Flame Rust typed API.
+
+Based is a completion model, not an instruction-tuned chat model. The client defaults use sampled decoding (`--temperature 0.8 --top-p 0.95 --repeat-penalty 1.3`) because deterministic argmax decoding can fall into repeated text. Use `--temperature 0` when deterministic output is required.
+
+## Binaries
+
+- `candle-based-example-service` loads the model once per Flame service instance and serves typed generation requests.
+- `candle-based-example` creates a Flame session, sends model options as typed common data, invokes one generation task, prints the generated text, and closes the session.
+
+## Build
+
+```bash
+cargo build -p candle-based-example --release
+```
+
+## Run
+
+Register or deploy `candle-based-example.yaml` so the `candle-based-example` application starts `/usr/local/flame/examples/candle/based/candle-based-example-service`, then run:
+
+```bash
+cargo run -p candle-based-example --bin candle-based-example --release -- \
+  --app candle-based-example \
+  --prompt "The future of distributed inference is" \
+  --sample-len 64 \
+  --which 360m
+```
+
+The first service start downloads the model config, safetensors file, and GPT-2 tokenizer from Hugging Face unless local files are provided with `--config-file`, `--weight-files`, and `--tokenizer-file`.

--- a/examples/candle/based/candle-based-example.yaml
+++ b/examples/candle/based/candle-based-example.yaml
@@ -1,0 +1,4 @@
+metadata:
+  name: candle-based-example
+spec:
+  command: /usr/local/flame/examples/candle/based/candle-based-example-service

--- a/examples/candle/based/src/api.rs
+++ b/examples/candle/based/src/api.rs
@@ -1,0 +1,91 @@
+/*
+Copyright 2026 The Flame Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use clap::ValueEnum;
+use serde_derive::{Deserialize, Serialize};
+
+pub const DEFAULT_REVISION: &str = "refs/pr/1";
+pub const DEFAULT_TOKENIZER_ID: &str = "openai-community/gpt2";
+pub const DEFAULT_TEMPERATURE: f64 = 0.8;
+pub const DEFAULT_TOP_P: f64 = 0.95;
+
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    Default,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    ValueEnum,
+    flame_rs::FlameMessage,
+)]
+pub enum BasedModelSize {
+    #[serde(rename = "360m")]
+    #[value(name = "360m")]
+    #[default]
+    W360m,
+    #[serde(rename = "1b")]
+    #[value(name = "1b")]
+    W1b,
+    #[serde(rename = "1b-50b")]
+    #[value(name = "1b-50b")]
+    W1b50b,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, flame_rs::FlameMessage)]
+pub struct BasedModelOptions {
+    pub which: BasedModelSize,
+    pub model_id: Option<String>,
+    pub revision: String,
+    pub tokenizer_id: String,
+    pub config_file: Option<String>,
+    pub tokenizer_file: Option<String>,
+    pub weight_files: Option<Vec<String>>,
+    pub cpu: bool,
+}
+
+impl Default for BasedModelOptions {
+    fn default() -> Self {
+        Self {
+            which: BasedModelSize::default(),
+            model_id: None,
+            revision: DEFAULT_REVISION.to_string(),
+            tokenizer_id: DEFAULT_TOKENIZER_ID.to_string(),
+            config_file: None,
+            tokenizer_file: None,
+            weight_files: None,
+            cpu: false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, flame_rs::FlameMessage)]
+pub struct GenerateRequest {
+    pub prompt: String,
+    pub sample_len: usize,
+    pub temperature: Option<f64>,
+    pub top_p: Option<f64>,
+    pub seed: u64,
+    pub repeat_penalty: f32,
+    pub repeat_last_n: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, flame_rs::FlameMessage)]
+pub struct GenerateResponse {
+    pub text: String,
+    pub generated_tokens: usize,
+    pub elapsed_ms: u64,
+    pub tokens_per_second: f64,
+}

--- a/examples/candle/based/src/client.rs
+++ b/examples/candle/based/src/client.rs
@@ -1,0 +1,155 @@
+/*
+Copyright 2026 The Flame Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+mod api;
+
+use std::error::Error;
+
+use clap::Parser;
+use flame_rs::{self as flame, SessionOptions};
+
+use self::api::{
+    BasedModelOptions, BasedModelSize, GenerateRequest, GenerateResponse, DEFAULT_REVISION,
+    DEFAULT_TEMPERATURE, DEFAULT_TOKENIZER_ID, DEFAULT_TOP_P,
+};
+
+const DEFAULT_SAMPLE_LEN: usize = 128;
+const DEFAULT_SEED: u64 = 299_792_458;
+const DEFAULT_REPEAT_PENALTY: f32 = 1.3;
+const DEFAULT_REPEAT_LAST_N: usize = 64;
+
+#[derive(Parser, Debug)]
+#[command(name = "candle-based-example")]
+#[command(author = "Xflops <support@xflops.io>")]
+#[command(version = "0.1.0")]
+#[command(about = "Flame Candle Based text generation example", long_about = None)]
+struct Cli {
+    /// Prompt to complete.
+    #[arg(long)]
+    prompt: String,
+    /// Generated sample length in tokens.
+    #[arg(long, short = 'n', default_value_t = DEFAULT_SAMPLE_LEN)]
+    sample_len: usize,
+    /// Temperature used to generate samples. Use 0 for deterministic argmax.
+    #[arg(long, default_value_t = DEFAULT_TEMPERATURE)]
+    temperature: f64,
+    /// Nucleus sampling probability cutoff. Use 1 to sample from the full distribution.
+    #[arg(long, default_value_t = DEFAULT_TOP_P)]
+    top_p: f64,
+    /// Random seed used when sampling.
+    #[arg(long, default_value_t = DEFAULT_SEED)]
+    seed: u64,
+    /// Penalty applied for repeating tokens, 1.0 means no penalty.
+    #[arg(long, default_value_t = DEFAULT_REPEAT_PENALTY)]
+    repeat_penalty: f32,
+    /// Context size considered for repeat penalty.
+    #[arg(long, default_value_t = DEFAULT_REPEAT_LAST_N)]
+    repeat_last_n: usize,
+    /// Based model variant to run.
+    #[arg(long, value_enum, default_value_t = BasedModelSize::default())]
+    which: BasedModelSize,
+    /// Override the Hugging Face model id.
+    #[arg(long)]
+    model_id: Option<String>,
+    /// Hugging Face model revision.
+    #[arg(long, default_value = DEFAULT_REVISION)]
+    revision: String,
+    /// Hugging Face tokenizer repository.
+    #[arg(long, default_value = DEFAULT_TOKENIZER_ID)]
+    tokenizer_id: String,
+    /// Local config.json path.
+    #[arg(long)]
+    config_file: Option<String>,
+    /// Local tokenizer.json path.
+    #[arg(long)]
+    tokenizer_file: Option<String>,
+    /// Comma-separated local safetensors paths.
+    #[arg(long, value_delimiter = ',')]
+    weight_files: Vec<String>,
+    /// Force CPU execution even when an accelerator is available.
+    #[arg(long)]
+    cpu: bool,
+    /// Flame application name.
+    #[arg(long)]
+    app: String,
+    /// Flame session id. Defaults to an auto-generated id.
+    #[arg(long)]
+    session_id: Option<String>,
+    /// Minimum service instances to warm for this session.
+    #[arg(long, default_value_t = 1)]
+    min_instances: u32,
+    /// Maximum service instances for this session.
+    #[arg(long, default_value_t = 1)]
+    max_instances: u32,
+    /// Explicit resource request, for example "cpu=4,mem=16g,gpu=1".
+    #[arg(short, long)]
+    resreq: Option<String>,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    flame::apis::init_logger()?;
+    let cli = Cli::parse();
+
+    let model_options = BasedModelOptions {
+        which: cli.which,
+        model_id: cli.model_id,
+        revision: cli.revision,
+        tokenizer_id: cli.tokenizer_id,
+        config_file: cli.config_file,
+        tokenizer_file: cli.tokenizer_file,
+        weight_files: if cli.weight_files.is_empty() {
+            None
+        } else {
+            Some(cli.weight_files)
+        },
+        cpu: cli.cpu,
+    };
+
+    let mut options = SessionOptions::new(cli.app)
+        .min_instances(cli.min_instances)
+        .max_instances(cli.max_instances);
+    if let Some(session_id) = cli.session_id {
+        options = options.id(session_id);
+    }
+    if let Some(resreq) = cli.resreq {
+        options = options.resreq(resreq);
+    }
+    options = options.common_data(&model_options)?;
+
+    let session = flame::create_session(options).await?;
+    let request = GenerateRequest {
+        prompt: cli.prompt,
+        sample_len: cli.sample_len,
+        temperature: Some(cli.temperature),
+        top_p: Some(cli.top_p),
+        seed: cli.seed,
+        repeat_penalty: cli.repeat_penalty,
+        repeat_last_n: cli.repeat_last_n,
+    };
+    let response: GenerateResponse = session.invoke(&request).await?.await?.ok_or_else(|| {
+        flame::apis::FlameError::Internal(
+            "candle-based-example-service returned no output".to_string(),
+        )
+    })?;
+
+    println!("{}", response.text);
+    println!(
+        "\n{} tokens generated in {} ms ({:.2} token/s)",
+        response.generated_tokens, response.elapsed_ms, response.tokens_per_second
+    );
+
+    session.close().await?;
+
+    Ok(())
+}

--- a/examples/candle/based/src/service.rs
+++ b/examples/candle/based/src/service.rs
@@ -1,0 +1,267 @@
+/*
+Copyright 2026 The Flame Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+mod api;
+
+use std::path::PathBuf;
+use std::sync::Mutex;
+use std::time::Instant;
+
+use candle::{DType, Device, Tensor};
+use candle_nn::VarBuilder;
+use candle_transformers::generation::LogitsProcessor;
+use candle_transformers::models::based::{Config, Model};
+use flame::apis::FlameError;
+use flame::service::FlameInstance;
+use flame_rs::{self as flame};
+use hf_hub::{api::sync::Api, Repo, RepoType};
+use tokenizers::Tokenizer;
+
+use self::api::{
+    BasedModelOptions, BasedModelSize, GenerateRequest, GenerateResponse, DEFAULT_TEMPERATURE,
+    DEFAULT_TOP_P,
+};
+
+#[derive(Default)]
+struct BasedService {
+    model: Mutex<Option<ModelBundle>>,
+}
+
+#[derive(Clone)]
+struct ModelBundle {
+    model: Model,
+    device: Device,
+    tokenizer: Tokenizer,
+    eos_token: u32,
+}
+
+impl ModelBundle {
+    fn generate(mut self, req: GenerateRequest) -> Result<GenerateResponse, FlameError> {
+        if req.prompt.trim().is_empty() {
+            return Err(FlameError::InvalidConfig(
+                "prompt must not be empty".to_string(),
+            ));
+        }
+
+        let mut tokens = self
+            .tokenizer
+            .encode(req.prompt.as_str(), true)
+            .map_err(internal)?
+            .get_ids()
+            .to_vec();
+        let prompt_tokens = tokens.len();
+        if prompt_tokens == 0 {
+            return Err(FlameError::InvalidConfig(
+                "prompt produced no tokens".to_string(),
+            ));
+        }
+
+        let temperature = req.temperature.or(Some(DEFAULT_TEMPERATURE));
+        let top_p = req.top_p.or(Some(DEFAULT_TOP_P));
+        let mut logits_processor = LogitsProcessor::new(req.seed, temperature, top_p);
+        let start = Instant::now();
+        let mut generated_tokens = 0usize;
+
+        for index in 0..req.sample_len {
+            let context_size = if index > 0 { 1 } else { tokens.len() };
+            let start_pos = tokens.len().saturating_sub(context_size);
+            let context = &tokens[start_pos..];
+            let input = Tensor::new(context, &self.device)
+                .map_err(internal)?
+                .unsqueeze(0)
+                .map_err(internal)?;
+            let logits = self
+                .model
+                .forward(&input, start_pos)
+                .map_err(internal)?
+                .squeeze(0)
+                .map_err(internal)?
+                .squeeze(0)
+                .map_err(internal)?
+                .to_dtype(DType::F32)
+                .map_err(internal)?;
+            let logits = if req.repeat_penalty == 1.0 {
+                logits
+            } else {
+                let start_at = tokens.len().saturating_sub(req.repeat_last_n);
+                candle_transformers::utils::apply_repeat_penalty(
+                    &logits,
+                    req.repeat_penalty,
+                    &tokens[start_at..],
+                )
+                .map_err(internal)?
+            };
+
+            let next_token = logits_processor.sample(&logits).map_err(internal)?;
+            tokens.push(next_token);
+            generated_tokens += 1;
+            if next_token == self.eos_token {
+                break;
+            }
+        }
+
+        let elapsed = start.elapsed();
+        let text = self.tokenizer.decode(&tokens, true).map_err(internal)?;
+        let tokens_per_second = if elapsed.as_secs_f64() > 0.0 {
+            generated_tokens as f64 / elapsed.as_secs_f64()
+        } else {
+            0.0
+        };
+
+        Ok(GenerateResponse {
+            text,
+            generated_tokens,
+            elapsed_ms: elapsed.as_millis() as u64,
+            tokens_per_second,
+        })
+    }
+}
+
+#[flame::instance]
+impl BasedService {
+    async fn enter(&self, instance: FlameInstance) -> Result<(), FlameError> {
+        let options = instance
+            .common_data::<BasedModelOptions>()?
+            .unwrap_or_default();
+        tracing::info!(
+            model = %options.model_id.as_deref().unwrap_or(default_model_id(options.which)),
+            revision = %options.revision,
+            "loading Based model"
+        );
+        let bundle = load_model(options)?;
+
+        *self.model.lock().map_err(lock_error)? = Some(bundle);
+        Ok(())
+    }
+
+    #[flame::entrypoint]
+    async fn generate(&self, req: GenerateRequest) -> Result<GenerateResponse, FlameError> {
+        let bundle = self
+            .model
+            .lock()
+            .map_err(lock_error)?
+            .as_ref()
+            .cloned()
+            .ok_or_else(|| FlameError::InvalidConfig("Based model is not loaded".to_string()))?;
+        bundle.generate(req)
+    }
+
+    async fn leave(&self) -> Result<(), FlameError> {
+        *self.model.lock().map_err(lock_error)? = None;
+        Ok(())
+    }
+}
+
+fn load_model(options: BasedModelOptions) -> Result<ModelBundle, FlameError> {
+    let start = Instant::now();
+    let api = Api::new().map_err(internal)?;
+    let model_id = options
+        .model_id
+        .clone()
+        .unwrap_or_else(|| default_model_id(options.which).to_string());
+    let repo = api.repo(Repo::with_revision(
+        model_id.clone(),
+        RepoType::Model,
+        options.revision.clone(),
+    ));
+
+    let config_file = match options.config_file {
+        Some(path) => PathBuf::from(path),
+        None => repo.get("config.json").map_err(internal)?,
+    };
+    let weight_files = match options.weight_files {
+        Some(files) => files.into_iter().map(PathBuf::from).collect(),
+        None => vec![repo.get("model.safetensors").map_err(internal)?],
+    };
+
+    let tokenizer_repo = api.model(options.tokenizer_id.clone());
+    let tokenizer_file = match options.tokenizer_file {
+        Some(path) => PathBuf::from(path),
+        None => tokenizer_repo.get("tokenizer.json").map_err(internal)?,
+    };
+
+    let tokenizer = Tokenizer::from_file(tokenizer_file).map_err(internal)?;
+    let eos_token = tokenizer
+        .get_vocab(true)
+        .get("<|endoftext|>")
+        .copied()
+        .ok_or_else(|| {
+            FlameError::InvalidConfig("tokenizer is missing <|endoftext|>".to_string())
+        })?;
+    let config_file = std::fs::File::open(config_file).map_err(internal)?;
+    let config: Config = serde_json::from_reader(config_file).map_err(internal)?;
+    let device = candle_device(options.cpu).map_err(internal)?;
+    let dtype = if device.is_cuda() || device.is_metal() {
+        DType::BF16
+    } else {
+        DType::F32
+    };
+    let mut vb = unsafe { VarBuilder::from_mmaped_safetensors(&weight_files, dtype, &device) }
+        .map_err(internal)?;
+    if options.which == BasedModelSize::W1b50b {
+        vb = vb.pp("model");
+    }
+
+    let model = Model::new(&config, vb).map_err(internal)?;
+
+    tracing::info!(
+        model = %model_id,
+        device = ?device,
+        elapsed_ms = start.elapsed().as_millis(),
+        "loaded Based model"
+    );
+
+    Ok(ModelBundle {
+        model,
+        device,
+        tokenizer,
+        eos_token,
+    })
+}
+
+fn candle_device(cpu: bool) -> candle::Result<Device> {
+    if cpu {
+        Ok(Device::Cpu)
+    } else if candle::utils::cuda_is_available() {
+        Device::new_cuda(0)
+    } else if candle::utils::metal_is_available() {
+        Device::new_metal(0)
+    } else {
+        Ok(Device::Cpu)
+    }
+}
+
+fn default_model_id(which: BasedModelSize) -> &'static str {
+    match which {
+        BasedModelSize::W360m => "hazyresearch/based-360m",
+        BasedModelSize::W1b => "hazyresearch/based-1b",
+        BasedModelSize::W1b50b => "hazyresearch/based-1b-50b",
+    }
+}
+
+fn internal(err: impl std::fmt::Display) -> FlameError {
+    FlameError::Internal(err.to_string())
+}
+
+fn lock_error(_: std::sync::PoisonError<impl Sized>) -> FlameError {
+    FlameError::Internal("Based model lock poisoned".to_string())
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    flame::run(BasedService::default()).await?;
+
+    tracing::debug!("BasedService was stopped.");
+
+    Ok(())
+}

--- a/examples/pi/rust/Cargo.toml
+++ b/examples/pi/rust/Cargo.toml
@@ -4,14 +4,12 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-flame-rs = { path = "../../../sdk/rust" }
-stdng = { path = "../../../stdng" }
+flame-rs = { path = "../../../sdk/rust", features = ["macros"] }
 
 tokio = { workspace = true }
-tonic = { workspace = true }
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true }
-rand_distr = "*"
+serde = { workspace = true }
+serde_derive = { workspace = true }
 rand = { workspace = true }
 futures = { workspace = true }
 clap = { workspace = true }

--- a/examples/pi/rust/README.md
+++ b/examples/pi/rust/README.md
@@ -1,0 +1,20 @@
+# Flame Rust Pi Example
+
+This example estimates pi with Monte Carlo sampling on Flame. The client starts a Flame session, submits multiple typed tasks, and combines the number of sampled points that landed inside the unit circle. The service receives each typed request and performs the random sampling for that task.
+
+Deploy the service binary from the installed examples directory:
+
+```bash
+source /usr/local/flame/sbin/flmenv.sh
+flmctl deploy \
+  --name pi \
+  --application /usr/local/flame/examples/pi/rust/pi-service
+```
+
+Run the client with the same application name:
+
+```bash
+/usr/local/flame/examples/pi/rust/pi --app pi
+```
+
+`flmctl deploy` uploads the service binary package to object cache and registers the `pi` application so executors download the package instead of relying on a local worker-image path. Use another `--name` value when deploying and pass the same value to `pi --app <name>` for a custom registration.

--- a/examples/pi/rust/pi-app.yaml
+++ b/examples/pi/rust/pi-app.yaml
@@ -1,4 +1,0 @@
-metadata:
-  name: pi-app
-spec:
-  command: /usr/local/flame/bin/pi-service

--- a/examples/pi/rust/src/api.rs
+++ b/examples/pi/rust/src/api.rs
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Flame Authors.
+Copyright 2026 The Flame Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -11,24 +11,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use flame_rs::apis::FlameError;
+use serde_derive::{Deserialize, Serialize};
 
-#[allow(dead_code)]
-pub fn zero_u32() -> Vec<u8> {
-    vec![0u8, 0u8, 0u8, 0u8]
+#[derive(Debug, Clone, Serialize, Deserialize, flame_rs::FlameMessage)]
+pub struct PiRequest {
+    pub samples: u32,
 }
 
-pub fn u32_to_bytes(i: u32) -> Vec<u8> {
-    i.to_be_bytes().to_vec()
-}
-
-pub fn bytes_to_u32(v: Vec<u8>) -> Result<u32, FlameError> {
-    if v.len() != 4 {
-        return Err(FlameError::InvalidConfig(
-            "Vec<u8> must contain exactly 4 bytes".to_string(),
-        ));
-    }
-
-    let byte_array: [u8; 4] = v.try_into().unwrap();
-    Ok(u32::from_be_bytes(byte_array))
+#[derive(Debug, Clone, Serialize, Deserialize, flame_rs::FlameMessage)]
+pub struct PiResponse {
+    pub inside: u32,
 }

--- a/examples/pi/rust/src/client.rs
+++ b/examples/pi/rust/src/client.rs
@@ -11,17 +11,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-mod util;
+mod api;
 
 use std::error::Error;
 
 use clap::Parser;
-use futures::future::try_join_all;
-use stdng::{lock_ptr, new_ptr};
-
-use flame_rs::apis::{FlameContext, FlameError, TaskInput};
-use flame_rs::client::{SessionAttributes, Task, TaskInformer};
+use flame_rs::apis::FlameError;
+use flame_rs::client::{SessionOptions, TaskResult};
 use flame_rs::{self as flame};
+use futures::future::try_join_all;
+
+use api::{PiRequest, PiResponse};
 
 #[derive(Parser)]
 #[command(name = "pi")]
@@ -29,15 +29,17 @@ use flame_rs::{self as flame};
 #[command(version = "0.1.0")]
 #[command(about = "Flame Pi Example", long_about = None)]
 struct Cli {
+    /// Application name deployed with flmctl deploy.
     #[arg(short, long)]
-    app: Option<String>,
-    #[arg(long)]
-    task_num: Option<u32>,
-    #[arg(long)]
-    task_input: Option<u32>,
+    app: String,
+    /// Number of tasks to run.
+    #[arg(long, default_value_t = DEFAULT_TASK_NUM)]
+    task_num: u32,
+    /// Number of random points sampled by each task.
+    #[arg(long, default_value_t = DEFAULT_TASK_INPUT)]
+    task_input: u32,
 }
 
-const DEFAULT_APP: &str = "pi-app";
 const DEFAULT_TASK_NUM: u32 = 10;
 const DEFAULT_TASK_INPUT: u32 = 10000;
 
@@ -46,72 +48,58 @@ async fn main() -> Result<(), Box<dyn Error>> {
     flame::apis::init_logger()?;
     let cli = Cli::parse();
 
-    let app = cli.app.unwrap_or(DEFAULT_APP.to_string());
-    let task_num = cli.task_num.unwrap_or(DEFAULT_TASK_NUM);
-    let task_input = cli.task_input.unwrap_or(DEFAULT_TASK_INPUT);
+    validate_args(&cli)?;
 
-    let ctx = FlameContext::from_file(None)?;
+    let ssn = flame::create_session(SessionOptions::new(cli.app.clone())).await?;
 
-    let current_ctx = ctx.get_current_context()?;
-    let conn = flame::client::connect_with_tls(
-        &current_ctx.cluster.endpoint,
-        current_ctx.cluster.tls.as_ref(),
-    )
-    .await?;
-    let ssn = conn
-        .create_session(&SessionAttributes {
-            id: format!("{app}-{}", stdng::rand::short_name()),
-            application: app,
-            common_data: None,
-            min_instances: 0,
-            max_instances: None,
-            batch_size: 1,
-            priority: 0,
-            resreq: None,
-        })
-        .await?;
+    let request = PiRequest {
+        samples: cli.task_input,
+    };
+    let handles =
+        try_join_all((0..cli.task_num).map(|_| ssn.run::<_, PiResponse>(&request))).await?;
+    let tasks = try_join_all(handles).await?;
+    let area = count_inside(&tasks)?;
 
-    let informer = new_ptr(PiInfo { area: 0 });
-    let mut tasks = vec![];
-    for _ in 0..task_num {
-        let task_input = util::u32_to_bytes(task_input);
-        let task = ssn.run_task(Some(TaskInput::from(task_input)), informer.clone());
-        tasks.push(task);
-    }
-
-    try_join_all(tasks).await?;
-
-    {
-        // Get the number of points in the circle.
-        let informer = lock_ptr!(informer)?;
-        let pi = 4_f64 * informer.area as f64 / ((task_num as f64) * (task_input as f64));
-
-        println!(
-            "pi = 4*({}/{}) = {}",
-            informer.area,
-            task_num * task_input,
-            pi
-        );
-    }
+    let total = cli.task_num as u64 * cli.task_input as u64;
+    let pi = 4_f64 * area as f64 / total as f64;
+    println!("pi = 4*({area}/{total}) = {pi}");
 
     ssn.close().await?;
 
     Ok(())
 }
 
-pub struct PiInfo {
-    pub area: u64,
+fn validate_args(cli: &Cli) -> Result<(), FlameError> {
+    if cli.task_num == 0 {
+        return Err(FlameError::InvalidConfig(
+            "--task-num must be greater than 0".to_string(),
+        ));
+    }
+    if cli.task_input == 0 {
+        return Err(FlameError::InvalidConfig(
+            "--task-input must be greater than 0".to_string(),
+        ));
+    }
+    Ok(())
 }
 
-impl TaskInformer for PiInfo {
-    fn on_update(&mut self, task: Task) {
-        if let Some(output) = task.output {
-            let output = util::bytes_to_u32(output.to_vec()).ok().unwrap_or_default();
-            self.area += output as u64;
+fn count_inside(tasks: &[TaskResult<PiResponse>]) -> Result<u64, FlameError> {
+    let mut area = 0_u64;
+    for task in tasks {
+        if !task.is_succeed() {
+            return Err(FlameError::Internal(format_task_error(task)));
         }
+        area += task
+            .output
+            .as_ref()
+            .map(|output| output.inside as u64)
+            .unwrap_or(0);
     }
+    Ok(area)
+}
 
-    fn on_error(&mut self, _: FlameError) {
-        print!("Got an error")
-    }
+fn format_task_error(task: &TaskResult<PiResponse>) -> String {
+    task.error_message
+        .clone()
+        .unwrap_or_else(|| format!("task {} ended in state {}", task.task_id, task.state))
 }

--- a/examples/pi/rust/src/service.rs
+++ b/examples/pi/rust/src/service.rs
@@ -11,59 +11,36 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-mod util;
+mod api;
 
 use rand::distr::{Distribution, Uniform};
 
-use flame_rs::{
-    self as flame,
-    apis::{FlameError, TaskInput, TaskOutput},
-    service::{SessionContext, TaskContext},
-};
+use flame_rs::{self as flame, apis::FlameError};
 
-#[derive(Clone)]
-pub struct PiService {}
+use api::{PiRequest, PiResponse};
 
-#[tonic::async_trait]
-impl flame::service::FlameService for PiService {
-    async fn on_session_enter(&self, _: SessionContext) -> Result<(), FlameError> {
-        Ok(())
-    }
+#[flame::entrypoint]
+async fn estimate_pi(input: PiRequest) -> Result<PiResponse, FlameError> {
+    let mut rng = rand::rng();
+    let die = Uniform::try_from(0.0..1.0).unwrap();
+    let mut inside = 0u32;
 
-    async fn on_task_invoke(&self, ctx: TaskContext) -> Result<Option<TaskOutput>, FlameError> {
-        let mut rng = rand::rng();
-        let die = Uniform::try_from(0.0..1.0).unwrap();
+    for _ in 0..input.samples {
+        let x: f64 = die.sample(&mut rng);
+        let y: f64 = die.sample(&mut rng);
+        let dist = (x * x + y * y).sqrt();
 
-        let input = ctx
-            .input
-            .clone()
-            .unwrap_or(TaskInput::from(util::zero_u32()));
-        let total = util::bytes_to_u32(input.to_vec())?;
-        let mut sum = 0u32;
-
-        for _ in 0..total {
-            let x: f64 = die.sample(&mut rng);
-            let y: f64 = die.sample(&mut rng);
-            let dist = (x * x + y * y).sqrt();
-
-            if dist <= 1.0 {
-                sum += 1;
-            }
+        if dist <= 1.0 {
+            inside += 1;
         }
-
-        Ok(Some(TaskOutput::from(util::u32_to_bytes(sum))))
     }
 
-    async fn on_session_leave(&self) -> Result<(), FlameError> {
-        Ok(())
-    }
+    Ok(PiResponse { inside })
 }
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    flame::apis::init_logger()?;
-
-    flame::service::run(PiService {}).await?;
+    flame::run(estimate_pi).await?;
 
     tracing::debug!("PiService was stopped.");
 

--- a/executor_manager/Cargo.toml
+++ b/executor_manager/Cargo.toml
@@ -30,6 +30,7 @@ uuid = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_derive = { workspace = true }
+sha2 = "0.10"
 
 bytes = { workspace = true }
 flate2 = "1"

--- a/executor_manager/src/appmgr/binary.rs
+++ b/executor_manager/src/appmgr/binary.rs
@@ -1,0 +1,111 @@
+/*
+Copyright 2026 The Flame Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use async_trait::async_trait;
+use common::FlameError;
+
+use super::installer::Installer;
+
+pub struct BinaryInstaller;
+
+impl BinaryInstaller {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for BinaryInstaller {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Installer for BinaryInstaller {
+    async fn install(
+        &self,
+        _app_name: &str,
+        src_path: &Path,
+        _flame_home: &Path,
+        app_environments: &HashMap<String, String>,
+    ) -> Result<HashMap<String, String>, FlameError> {
+        let mut env_vars = HashMap::new();
+
+        env_vars.insert(
+            "FLAME_APP_DIR".to_string(),
+            src_path.to_string_lossy().to_string(),
+        );
+
+        let mut paths = Vec::new();
+        let bin_path = src_path.join("bin");
+        paths.push(bin_path.to_string_lossy().to_string());
+        paths.push(src_path.to_string_lossy().to_string());
+        if let Some(app_path) = app_environments.get("PATH") {
+            paths.push(app_path.clone());
+        }
+        if let Ok(current_path) = std::env::var("PATH") {
+            paths.push(current_path);
+        }
+        env_vars.insert("PATH".to_string(), paths.join(":"));
+
+        let mut ld_paths = vec![src_path.join("libs").to_string_lossy().to_string()];
+        let lib_path = src_path.join("lib");
+        if lib_path.exists() {
+            ld_paths.push(lib_path.to_string_lossy().to_string());
+        }
+        if let Some(app_ld_path) = app_environments.get("LD_LIBRARY_PATH") {
+            ld_paths.push(app_ld_path.clone());
+        }
+        if let Ok(current_ld_path) = std::env::var("LD_LIBRARY_PATH") {
+            ld_paths.push(current_ld_path);
+        }
+        env_vars.insert("LD_LIBRARY_PATH".to_string(), ld_paths.join(":"));
+
+        Ok(env_vars)
+    }
+
+    fn name(&self) -> &'static str {
+        "binary"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[tokio::test]
+    async fn binary_installer_adds_app_paths() {
+        let temp = TempDir::new().unwrap();
+        let envs = BinaryInstaller::new()
+            .install("demo", temp.path(), temp.path(), &HashMap::new())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            envs.get("FLAME_APP_DIR").map(String::as_str),
+            Some(temp.path().to_string_lossy().as_ref())
+        );
+        assert!(envs
+            .get("PATH")
+            .unwrap()
+            .contains(&temp.path().join("bin").to_string_lossy().to_string()));
+        assert!(envs
+            .get("LD_LIBRARY_PATH")
+            .unwrap()
+            .contains(&temp.path().join("libs").to_string_lossy().to_string()));
+    }
+}

--- a/executor_manager/src/appmgr/downloader.rs
+++ b/executor_manager/src/appmgr/downloader.rs
@@ -24,6 +24,7 @@ use common::FlameError;
 
 const HTTP_TIMEOUT_SECS: u64 = 300;
 const GRPC_CONNECT_TIMEOUT_SECS: u64 = 30;
+const GRPC_MAX_MESSAGE_SIZE: usize = usize::MAX;
 
 #[async_trait]
 pub trait PackageDownloader: Send + Sync {
@@ -132,6 +133,7 @@ impl GrpcDownloader {
 impl PackageDownloader for GrpcDownloader {
     async fn download(&self, url: &url::Url, dest_path: &Path) -> Result<(), FlameError> {
         use arrow::array::{Array, BinaryArray};
+        use arrow_flight::flight_service_client::FlightServiceClient;
         use arrow_flight::FlightClient;
         use futures_util::TryStreamExt;
         use tonic::transport::Channel;
@@ -168,7 +170,10 @@ impl PackageDownloader for GrpcDownloader {
                 .map_err(|e| FlameError::Internal(format!("failed to connect to cache: {}", e)))?
         };
 
-        let mut client = FlightClient::new(channel);
+        let inner = FlightServiceClient::new(channel)
+            .max_decoding_message_size(GRPC_MAX_MESSAGE_SIZE)
+            .max_encoding_message_size(GRPC_MAX_MESSAGE_SIZE);
+        let mut client = FlightClient::new_from_inner(inner);
 
         let ticket = arrow_flight::Ticket::new(format!("{}:0", key));
         let mut stream = client

--- a/executor_manager/src/appmgr/installer.rs
+++ b/executor_manager/src/appmgr/installer.rs
@@ -20,6 +20,7 @@ use std::str::FromStr;
 use async_trait::async_trait;
 use common::FlameError;
 
+use super::binary::BinaryInstaller;
 use super::python::PythonInstaller;
 
 /// Installer trait - implemented by each installer type.
@@ -54,15 +55,17 @@ pub trait Installer: Send + Sync {
 /// Supported installer types.
 #[derive(Clone, Debug, PartialEq)]
 pub enum InstallerType {
+    /// Binary package installer for self-contained executables
+    Binary,
     /// Python package installer using uv
     Python,
-    // Future: Node, Rust, etc.
 }
 
 impl InstallerType {
     /// Create the corresponding Installer implementation.
     pub fn create_installer(&self) -> Box<dyn Installer> {
         match self {
+            InstallerType::Binary => Box::new(BinaryInstaller::new()),
             InstallerType::Python => Box::new(PythonInstaller::new()),
         }
     }
@@ -73,9 +76,10 @@ impl FromStr for InstallerType {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
+            "binary" => Ok(InstallerType::Binary),
             "python" => Ok(InstallerType::Python),
             _ => Err(FlameError::InvalidConfig(format!(
-                "Unknown installer type: {}. Supported types: python",
+                "Unknown installer type: {}. Supported types: binary, python",
                 s
             ))),
         }
@@ -85,6 +89,7 @@ impl FromStr for InstallerType {
 impl std::fmt::Display for InstallerType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            InstallerType::Binary => write!(f, "binary"),
             InstallerType::Python => write!(f, "python"),
         }
     }
@@ -96,6 +101,14 @@ mod tests {
 
     #[test]
     fn test_installer_type_from_str() {
+        assert_eq!(
+            "binary".parse::<InstallerType>().unwrap(),
+            InstallerType::Binary
+        );
+        assert_eq!(
+            "Binary".parse::<InstallerType>().unwrap(),
+            InstallerType::Binary
+        );
         assert_eq!(
             "python".parse::<InstallerType>().unwrap(),
             InstallerType::Python
@@ -113,6 +126,7 @@ mod tests {
 
     #[test]
     fn test_installer_type_display() {
+        assert_eq!(InstallerType::Binary.to_string(), "binary");
         assert_eq!(InstallerType::Python.to_string(), "python");
     }
 }

--- a/executor_manager/src/appmgr/mod.rs
+++ b/executor_manager/src/appmgr/mod.rs
@@ -11,10 +11,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+mod binary;
 mod downloader;
 mod installer;
 mod python;
 
+pub use binary::BinaryInstaller;
 pub use downloader::{DownloaderRegistry, PackageDownloader};
 pub use installer::{Installer, InstallerType};
 pub use python::PythonInstaller;
@@ -22,11 +24,13 @@ pub use python::PythonInstaller;
 use std::collections::HashMap;
 use std::env;
 use std::fs;
+use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
 use flate2::read::GzDecoder;
+use sha2::{Digest, Sha256};
 use stdng::{lock_ptr, MutexPtr};
 use tar::Archive;
 use tokio::sync::RwLock;
@@ -34,6 +38,66 @@ use tonic::transport::ClientTlsConfig;
 
 use common::apis::ApplicationContext;
 use common::FlameError;
+
+#[derive(Clone, Debug, Eq)]
+struct InstallKey {
+    app_name: String,
+    installer: String,
+    url: Option<String>,
+}
+
+impl InstallKey {
+    fn new(app_name: &str, installer: &InstallerType, url: Option<&String>) -> Self {
+        Self {
+            app_name: app_name.to_string(),
+            installer: installer.to_string(),
+            url: url.cloned(),
+        }
+    }
+
+    fn release_id(&self) -> String {
+        let mut hasher = Sha256::new();
+        update_release_hash(&mut hasher, "app", Some(&self.app_name));
+        update_release_hash(&mut hasher, "installer", Some(&self.installer));
+        update_release_hash(&mut hasher, "url", self.url.as_deref());
+        hasher
+            .finalize()
+            .iter()
+            .map(|byte| format!("{byte:02x}"))
+            .collect()
+    }
+}
+
+fn update_release_hash(hasher: &mut Sha256, label: &str, value: Option<&str>) {
+    hasher.update(label.as_bytes());
+    hasher.update([0]);
+    match value {
+        Some(value) => {
+            hasher.update([1]);
+            hasher.update(value.len().to_be_bytes());
+            hasher.update(value.as_bytes());
+        }
+        None => {
+            hasher.update([0]);
+        }
+    }
+}
+
+impl PartialEq for InstallKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.app_name == other.app_name
+            && self.installer == other.installer
+            && self.url == other.url
+    }
+}
+
+impl Hash for InstallKey {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.app_name.hash(state);
+        self.installer.hash(state);
+        self.url.hash(state);
+    }
+}
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum InstallState {
@@ -66,7 +130,7 @@ impl AppInstaller {
 }
 
 pub struct ApplicationManager {
-    apps: MutexPtr<HashMap<String, Arc<RwLock<AppInstaller>>>>,
+    apps: MutexPtr<HashMap<InstallKey, Arc<RwLock<AppInstaller>>>>,
     flame_home: PathBuf,
     downloader: DownloaderRegistry,
 }
@@ -99,11 +163,12 @@ impl ApplicationManager {
             }
             Some(installer_str) => installer_str.parse::<InstallerType>()?,
         };
+        let install_key = InstallKey::new(&app.name, &installer_type, app.url.as_ref());
 
         {
             let app_entry = {
                 let apps = lock_ptr!(self.apps)?;
-                apps.get(&app.name).cloned()
+                apps.get(&install_key).cloned()
             };
             if let Some(installed) = app_entry {
                 let installed = installed.read().await;
@@ -115,7 +180,7 @@ impl ApplicationManager {
 
         let app_entry = {
             let mut apps = lock_ptr!(self.apps)?;
-            apps.entry(app.name.clone())
+            apps.entry(install_key.clone())
                 .or_insert_with(|| {
                     Arc::new(RwLock::new(AppInstaller::new(
                         &app.name,
@@ -153,13 +218,15 @@ impl ApplicationManager {
             Some(url) => url,
         };
 
-        let package_path = self.download_package(url, &app.name).await?;
-
-        let src_path = self
+        let release_path = self
             .flame_home
             .join("data/apps")
             .join(&app.name)
-            .join("src");
+            .join("releases")
+            .join(install_key.release_id());
+        let package_path = self.download_package(url, &release_path).await?;
+
+        let src_path = release_path.join("src");
         self.extract_package(&package_path, &src_path)?;
 
         let installer = installer_type.create_installer();
@@ -190,9 +257,13 @@ impl ApplicationManager {
 
     pub fn is_installed(&self, app_name: &str) -> bool {
         if let Ok(apps) = lock_ptr!(self.apps) {
-            if let Some(installed) = apps.get(app_name) {
-                if let Ok(installed) = installed.try_read() {
-                    return installed.state == InstallState::Installed;
+            for (key, installed) in apps.iter() {
+                if key.app_name == app_name {
+                    if let Ok(installed) = installed.try_read() {
+                        if installed.state == InstallState::Installed {
+                            return true;
+                        }
+                    }
                 }
             }
         }
@@ -269,12 +340,12 @@ impl ApplicationManager {
         paths.into_iter().collect()
     }
 
-    async fn download_package(&self, url: &str, app_name: &str) -> Result<PathBuf, FlameError> {
-        let download_dir = self
-            .flame_home
-            .join("data/apps")
-            .join(app_name)
-            .join("download");
+    async fn download_package(
+        &self,
+        url: &str,
+        release_path: &Path,
+    ) -> Result<PathBuf, FlameError> {
+        let download_dir = release_path.join("download");
         fs::create_dir_all(&download_dir).map_err(|e| {
             FlameError::Internal(format!("failed to create download directory: {}", e))
         })?;
@@ -357,5 +428,37 @@ impl ApplicationManager {
 impl Default for ApplicationManager {
     fn default() -> Self {
         Self::new().expect("failed to create ApplicationManager")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn release_id_is_stable_sha256() {
+        let key = InstallKey::new(
+            "demo",
+            &InstallerType::Binary,
+            Some(&"grpc://cache/demo/pkg/demo.tar.gz".to_string()),
+        );
+
+        assert_eq!(
+            key.release_id(),
+            "e39adc06cdb2124e255005866affce6fb279d816c4549a6a6a8c9dc03ac4674a"
+        );
+    }
+
+    #[test]
+    fn release_id_distinguishes_missing_url() {
+        let with_url = InstallKey::new(
+            "demo",
+            &InstallerType::Binary,
+            Some(&"grpc://cache/demo/pkg/demo.tar.gz".to_string()),
+        );
+        let without_url = InstallKey::new("demo", &InstallerType::Binary, None);
+
+        assert_ne!(with_url.release_id(), without_url.release_id());
+        assert_eq!(without_url.release_id().len(), 64);
     }
 }

--- a/executor_manager/src/appmgr/python.rs
+++ b/executor_manager/src/appmgr/python.rs
@@ -87,8 +87,12 @@ impl Installer for PythonInstaller {
         flame_home: &Path,
         app_environments: &HashMap<String, String>,
     ) -> Result<HashMap<String, String>, FlameError> {
-        let app_data_path = flame_home.join("data/apps").join(app_name);
+        let app_data_path = src_path
+            .parent()
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| flame_home.join("data/apps").join(app_name));
         let deps_path = app_data_path.join("deps");
+        let deps_bin_path = deps_path.join("bin");
         let uv_cache_path = flame_home.join("data/cache/uv");
         let pip_cache_path = flame_home.join("data/cache/pip");
         let log_path = flame_home
@@ -177,6 +181,17 @@ impl Installer for PythonInstaller {
         }
         if !ld_paths.is_empty() {
             env_vars.insert("LD_LIBRARY_PATH".to_string(), ld_paths.join(":"));
+        }
+
+        if deps_bin_path.exists() {
+            let mut paths = vec![deps_bin_path.to_string_lossy().to_string()];
+            if let Some(app_path) = app_environments.get("PATH") {
+                paths.push(app_path.clone());
+            }
+            if let Ok(current_path) = std::env::var("PATH") {
+                paths.push(current_path);
+            }
+            env_vars.insert("PATH".to_string(), paths.join(":"));
         }
 
         env_vars.insert(

--- a/flmadm/README.md
+++ b/flmadm/README.md
@@ -97,6 +97,9 @@ sudo flmadm install --worker --force
 # Client installation (no systemd needed)
 flmadm install --client --prefix ~/flame
 
+# Client installation with all example binaries
+flmadm install --client --with-examples --prefix ~/flame
+
 # ERROR: Cannot use --enable with client-only
 # flmadm install --client --enable  # This will fail with an error
 
@@ -140,6 +143,7 @@ sudo flmadm uninstall --backup-dir /backups/flame-backup-2026-01-28
 - `--worker`: Install worker components only (flame-executor-manager, flmping-service, flmexec-service, flamepy)
 - `--cache`: Install cache component only (flame-object-cache)
 - `--client`: Install client components only (flmping, flmexec, flamepy)
+- `--with-examples`: Install all supported example binaries under `${PREFIX}/examples`
 - `--no-systemd`: Skip systemd service generation (for user-local installs)
 - `--enable`: Enable and start systemd services after installation
 - `--skip-build`: Skip building from source (use pre-built binaries)
@@ -238,6 +242,9 @@ ${PREFIX}/
 │   ├── flmctl
 │   └── flmadm
 ├── sdk/python/             # Python SDK
+├── examples/               # Optional example binaries, docs, and manifests from --with-examples
+│   ├── pi/rust/
+│   └── candle/based/
 ├── work/                   # Working directory
 │   ├── sessions/
 │   └── executors/

--- a/flmadm/src/commands/install.rs
+++ b/flmadm/src/commands/install.rs
@@ -3,7 +3,7 @@ use crate::managers::{
     installation::InstallationManager, source::SourceManager, systemd::SystemdManager,
     user::UserManager,
 };
-use crate::types::{InstallConfig, InstallationPaths};
+use crate::types::{available_examples, InstallConfig, InstallationPaths};
 use anyhow::Result;
 
 pub fn run(config: InstallConfig) -> Result<()> {
@@ -18,6 +18,12 @@ pub fn run(config: InstallConfig) -> Result<()> {
             crate::types::InstallProfile::Client => "Client",
         };
         println!("     • {}", profile_name);
+    }
+    if config.with_examples {
+        println!("   Examples:");
+        for example in available_examples() {
+            println!("     • {}", example.name);
+        }
     }
     println!();
 
@@ -224,6 +230,14 @@ fn install_components(
     let installation_manager = InstallationManager::new();
     installation_manager.create_directories(paths)?;
 
+    // Install examples first so missing example artifacts fail before core binaries are copied.
+    installation_manager.install_examples(
+        src_dir,
+        paths,
+        config.with_examples,
+        config.force_overwrite,
+    )?;
+
     // Install binaries
     installation_manager.install_binaries(
         artifacts,
@@ -322,6 +336,9 @@ fn print_summary(paths: &InstallationPaths, config: &InstallConfig) {
         .any(|p| p.includes_component("flamepy"));
     if has_flamepy {
         println!("  • Python libs: {}", paths.lib.display());
+    }
+    if config.with_examples {
+        println!("  • Examples: {}", paths.examples.display());
     }
     println!();
 

--- a/flmadm/src/main.rs
+++ b/flmadm/src/main.rs
@@ -64,6 +64,10 @@ enum Commands {
         #[arg(long)]
         all: bool,
 
+        /// Install all example binaries under FLAME_HOME/examples.
+        #[arg(long)]
+        with_examples: bool,
+
         /// Skip systemd service generation
         #[arg(long)]
         no_systemd: bool,
@@ -152,6 +156,7 @@ fn main() {
             cache,
             client,
             all,
+            with_examples,
             no_systemd,
             enable,
             skip_build,
@@ -222,6 +227,7 @@ fn main() {
                 profiles,
                 force_overwrite: force,
                 python_version,
+                with_examples,
             };
             commands::install::run(config)
         }

--- a/flmadm/src/managers/installation.rs
+++ b/flmadm/src/managers/installation.rs
@@ -1,4 +1,4 @@
-use crate::types::{BuildArtifacts, InstallProfile, InstallationPaths};
+use crate::types::{available_examples, BuildArtifacts, InstallProfile, InstallationPaths};
 use anyhow::{Context, Result};
 use std::fs;
 use std::io::{self, Write};
@@ -20,6 +20,7 @@ impl InstallationManager {
             ("bin", &paths.bin),
             ("sbin", &paths.sbin),
             // Note: sdk/python is created by install_python_sdk() to allow existence check
+            ("examples", &paths.examples),
             ("work", &paths.work),
             ("work/sessions", &paths.work.join("sessions")),
             ("work/executors", &paths.work.join("executors")),
@@ -44,6 +45,94 @@ impl InstallationManager {
             "✓ Created directory structure at: {}",
             paths.prefix.display()
         );
+        Ok(())
+    }
+
+    /// Install example binaries under FLAME_HOME/examples when requested.
+    pub fn install_examples(
+        &self,
+        src_dir: &Path,
+        paths: &InstallationPaths,
+        with_examples: bool,
+        force_overwrite: bool,
+    ) -> Result<()> {
+        if !with_examples {
+            println!("⊘ Skipped examples (--with-examples not specified)");
+            return Ok(());
+        }
+
+        println!("🧪 Installing examples...");
+        let target_dir = src_dir.join("target").join("release");
+
+        for example in available_examples() {
+            let dst_dir = paths.examples.join(example.relative_dir);
+            fs::create_dir_all(&dst_dir).context(format!(
+                "Failed to create example directory: {}",
+                dst_dir.display()
+            ))?;
+
+            println!("  • {}", example.name);
+            for binary in example.binaries {
+                let src = target_dir.join(binary);
+                if !src.exists() {
+                    anyhow::bail!(
+                        "Example binary not found: {}. Build package '{}' first or run without --skip-build.",
+                        src.display(),
+                        example.package
+                    );
+                }
+
+                let dst = dst_dir.join(binary);
+                if dst.exists() && !force_overwrite && !self.prompt_overwrite(binary)? {
+                    println!("    ⊘ Skipped {} (already exists)", binary);
+                    continue;
+                }
+
+                fs::copy(&src, &dst)
+                    .context(format!("Failed to copy example binary {}", binary))?;
+
+                let perms = fs::Permissions::from_mode(0o755);
+                fs::set_permissions(&dst, perms)
+                    .context(format!("Failed to set permissions on {}", binary))?;
+
+                println!(
+                    "    ✓ Installed {} to {}",
+                    binary,
+                    dst.strip_prefix(&paths.prefix).unwrap_or(&dst).display()
+                );
+            }
+
+            let src_example_dir = src_dir.join("examples").join(example.relative_dir);
+            for asset in example.assets {
+                let src = src_example_dir.join(asset);
+                if !src.exists() {
+                    anyhow::bail!(
+                        "Example asset not found: {} for example '{}'.",
+                        src.display(),
+                        example.name
+                    );
+                }
+
+                let dst = dst_dir.join(asset);
+                if dst.exists() && !force_overwrite && !self.prompt_overwrite(asset)? {
+                    println!("    ⊘ Skipped {} (already exists)", asset);
+                    continue;
+                }
+
+                fs::copy(&src, &dst).context(format!("Failed to copy example asset {}", asset))?;
+                let mode = if asset.ends_with(".sh") { 0o755 } else { 0o644 };
+                let perms = fs::Permissions::from_mode(mode);
+                fs::set_permissions(&dst, perms)
+                    .context(format!("Failed to set permissions on {}", asset))?;
+
+                println!(
+                    "    ✓ Installed {} to {}",
+                    asset,
+                    dst.strip_prefix(&paths.prefix).unwrap_or(&dst).display()
+                );
+            }
+        }
+
         Ok(())
     }
 
@@ -471,6 +560,11 @@ fi
             println!("  ✓ Removed Python libs");
         }
 
+        if paths.examples.exists() {
+            fs::remove_dir_all(&paths.examples).context("Failed to remove examples directory")?;
+            println!("  ✓ Removed examples");
+        }
+
         if paths.wheels.exists() {
             fs::remove_dir_all(&paths.wheels).context("Failed to remove wheels directory")?;
             println!("  ✓ Removed wheels");
@@ -626,6 +720,7 @@ mod tests {
             manager.create_directories(&paths).unwrap();
 
             assert!(paths.bin.exists());
+            assert!(paths.examples.exists());
             assert!(paths.work.exists());
             assert!(paths.work.join("sessions").exists());
             assert!(paths.work.join("executors").exists());
@@ -663,6 +758,103 @@ mod tests {
         }
     }
 
+    mod install_examples {
+        use super::*;
+
+        fn create_example_fixtures(src_dir: &Path) {
+            let target_dir = src_dir.join("target/release");
+            fs::create_dir_all(&target_dir).unwrap();
+            fs::write(target_dir.join("pi"), "client").unwrap();
+            fs::write(target_dir.join("pi-service"), "service").unwrap();
+            fs::write(target_dir.join("candle-based-example"), "client").unwrap();
+            fs::write(target_dir.join("candle-based-example-service"), "service").unwrap();
+
+            let pi_dir = src_dir.join("examples/pi/rust");
+            fs::create_dir_all(&pi_dir).unwrap();
+            fs::write(pi_dir.join("README.md"), "readme").unwrap();
+
+            let example_dir = src_dir.join("examples/candle/based");
+            fs::create_dir_all(&example_dir).unwrap();
+            fs::write(
+                example_dir.join("candle-based-example.yaml"),
+                "metadata: {}\n",
+            )
+            .unwrap();
+            fs::write(example_dir.join("README.md"), "readme").unwrap();
+        }
+
+        #[test]
+        fn copies_all_example_binaries_to_examples_dir() {
+            let temp = tempdir().unwrap();
+            let src_dir = temp.path().join("src");
+            create_example_fixtures(&src_dir);
+
+            let paths = InstallationPaths::new(temp.path().join("flame"));
+            let manager = InstallationManager::new();
+            manager.create_directories(&paths).unwrap();
+            manager
+                .install_examples(&src_dir, &paths, true, true)
+                .unwrap();
+
+            assert!(paths.examples.join("pi/rust/pi").exists());
+            assert!(paths.examples.join("pi/rust/pi-service").exists());
+            assert!(paths.examples.join("pi/rust/README.md").exists());
+            assert!(!paths.examples.join("pi/rust/deploy.sh").exists());
+
+            assert!(paths
+                .examples
+                .join("candle/based/candle-based-example")
+                .exists());
+            assert!(paths
+                .examples
+                .join("candle/based/candle-based-example-service")
+                .exists());
+            assert!(paths
+                .examples
+                .join("candle/based/candle-based-example.yaml")
+                .exists());
+            assert!(paths.examples.join("candle/based/README.md").exists());
+            assert!(!paths.bin.join("candle-based-example").exists());
+            assert!(!paths.bin.join("pi").exists());
+        }
+
+        #[test]
+        fn reports_missing_example_binary() {
+            let temp = tempdir().unwrap();
+            let src_dir = temp.path().join("src");
+            fs::create_dir_all(src_dir.join("target/release")).unwrap();
+            let paths = InstallationPaths::new(temp.path().join("flame"));
+            let manager = InstallationManager::new();
+            manager.create_directories(&paths).unwrap();
+
+            let error = manager
+                .install_examples(&src_dir, &paths, true, true)
+                .unwrap_err();
+
+            assert!(error.to_string().contains("Example binary not found"));
+        }
+
+        #[test]
+        fn skips_examples_when_flag_is_false() {
+            let temp = tempdir().unwrap();
+            let src_dir = temp.path().join("src");
+            create_example_fixtures(&src_dir);
+
+            let paths = InstallationPaths::new(temp.path().join("flame"));
+            let manager = InstallationManager::new();
+            manager.create_directories(&paths).unwrap();
+            manager
+                .install_examples(&src_dir, &paths, false, true)
+                .unwrap();
+
+            assert!(!paths.examples.join("pi/rust/pi").exists());
+            assert!(!paths
+                .examples
+                .join("candle/based/candle-based-example")
+                .exists());
+        }
+    }
+
     mod remove_installation {
         use super::*;
 
@@ -672,6 +864,8 @@ mod tests {
             let paths = InstallationPaths::new(temp.path().to_path_buf());
             fs::create_dir_all(&paths.bin).unwrap();
             fs::write(paths.bin.join("test"), "test").unwrap();
+            fs::create_dir_all(&paths.examples).unwrap();
+            fs::write(paths.examples.join("example"), "test").unwrap();
 
             let manager = InstallationManager::new();
             manager
@@ -679,6 +873,7 @@ mod tests {
                 .unwrap();
 
             assert!(!paths.bin.exists());
+            assert!(!paths.examples.exists());
         }
 
         #[test]

--- a/flmadm/src/types.rs
+++ b/flmadm/src/types.rs
@@ -46,6 +46,7 @@ pub struct InstallConfig {
     pub profiles: Vec<InstallProfile>,
     pub force_overwrite: bool,
     pub python_version: String,
+    pub with_examples: bool,
 }
 
 impl Default for InstallConfig {
@@ -66,8 +67,40 @@ impl Default for InstallConfig {
             ],
             force_overwrite: false,
             python_version: DEFAULT_PYTHON_VERSION.to_string(),
+            with_examples: false,
         }
     }
+}
+
+/// A buildable example whose release binaries can be installed by flmadm.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ExampleSpec {
+    pub name: &'static str,
+    pub package: &'static str,
+    pub relative_dir: &'static str,
+    pub binaries: &'static [&'static str],
+    pub assets: &'static [&'static str],
+}
+
+const EXAMPLES: &[ExampleSpec] = &[
+    ExampleSpec {
+        name: "pi/rust",
+        package: "pi",
+        relative_dir: "pi/rust",
+        binaries: &["pi", "pi-service"],
+        assets: &["README.md"],
+    },
+    ExampleSpec {
+        name: "candle/based",
+        package: "candle-based-example",
+        relative_dir: "candle/based",
+        binaries: &["candle-based-example", "candle-based-example-service"],
+        assets: &["candle-based-example.yaml", "README.md"],
+    },
+];
+
+pub fn available_examples() -> &'static [ExampleSpec] {
+    EXAMPLES
 }
 
 /// Configuration for the uninstall command
@@ -103,6 +136,7 @@ pub struct InstallationPaths {
     pub bin: PathBuf,
     pub sbin: PathBuf,
     pub lib: PathBuf,
+    pub examples: PathBuf,
     pub wheels: PathBuf,
     pub work: PathBuf,
     pub logs: PathBuf,
@@ -118,6 +152,7 @@ impl InstallationPaths {
             bin: prefix.join("bin"),
             sbin: prefix.join("sbin"),
             lib: prefix.join("lib"),
+            examples: prefix.join("examples"),
             wheels: prefix.join("wheels"),
             work: prefix.join("work"),
             logs: prefix.join("logs"),
@@ -281,6 +316,7 @@ mod tests {
             assert!(!config.verbose);
             assert!(!config.force_overwrite);
             assert!(config.src_dir.is_none());
+            assert!(!config.with_examples);
         }
 
         #[test]
@@ -326,6 +362,7 @@ mod tests {
             assert_eq!(paths.bin, prefix.join("bin"));
             assert_eq!(paths.sbin, prefix.join("sbin"));
             assert_eq!(paths.lib, prefix.join("lib"));
+            assert_eq!(paths.examples, prefix.join("examples"));
             assert_eq!(paths.wheels, prefix.join("wheels"));
             assert_eq!(paths.work, prefix.join("work"));
             assert_eq!(paths.logs, prefix.join("logs"));
@@ -393,6 +430,30 @@ mod tests {
         fn exit_codes() {
             assert_eq!(exit_codes::SUCCESS, 0);
             assert_eq!(exit_codes::INSTALL_FAILURE, 3);
+        }
+    }
+
+    mod examples {
+        use super::*;
+
+        #[test]
+        fn lists_supported_examples() {
+            let examples = available_examples();
+
+            let candle = examples
+                .iter()
+                .find(|example| example.name == "candle/based")
+                .expect("candle based example should be supported");
+            assert_eq!(
+                candle.binaries,
+                &["candle-based-example", "candle-based-example-service"]
+            );
+
+            let pi = examples
+                .iter()
+                .find(|example| example.name == "pi/rust")
+                .expect("pi rust example should be supported");
+            assert_eq!(pi.assets, &["README.md"]);
         }
     }
 }

--- a/flmctl/Cargo.toml
+++ b/flmctl/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+common = { path = "../common" }
 flame-rs = { path = "../sdk/rust" }
 stdng = { path = "../stdng" }
 
@@ -28,3 +29,8 @@ serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 serde_derive = { workspace = true }
 jsonschema = { workspace = true }
+flate2 = "1"
+tar = "0.4"
+sha2 = "0.10"
+tempfile = { workspace = true }
+toml = "0.9"

--- a/flmctl/src/deploy.rs
+++ b/flmctl/src/deploy.rs
@@ -1,0 +1,544 @@
+/*
+Copyright 2026 The Flame Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+mod artifact;
+mod detect;
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use chrono::Duration;
+use clap::Args;
+use flame_rs as flame;
+use flame_rs::apis::{FlameContext, FlameError, Shim};
+use flame_rs::client::{ApplicationAttributes, ApplicationSchema};
+use serde_derive::Serialize;
+use url::Url;
+
+use artifact::{prepare_application, PreparedApplication};
+use detect::{detect_application, DetectedApplication};
+
+#[derive(Debug, Clone, Args)]
+pub struct Options {
+    /// Application name.
+    #[arg(long)]
+    pub name: String,
+
+    /// Application path. Can be an executable file, .tar.gz/.tgz, or directory.
+    #[arg(long)]
+    pub application: PathBuf,
+
+    /// Render the deploy plan without uploading or registering the application.
+    #[arg(long)]
+    pub dry_run: bool,
+
+    /// Output format: summary, yaml, or json.
+    #[arg(short = 'o', long, default_value = "summary")]
+    pub output: String,
+
+    /// Application shim.
+    #[arg(long)]
+    pub shim: Option<String>,
+
+    /// Optional runtime image.
+    #[arg(long)]
+    pub image: Option<String>,
+
+    /// Application description.
+    #[arg(long)]
+    pub description: Option<String>,
+
+    /// Application label. Repeatable.
+    #[arg(long)]
+    pub label: Vec<String>,
+
+    /// Application command. Overrides detected command.
+    #[arg(long)]
+    pub command: Option<String>,
+
+    /// Add one command argument. Repeatable.
+    #[arg(long)]
+    pub argument: Vec<String>,
+
+    /// Add one environment variable in NAME=VALUE form. Repeatable.
+    #[arg(long)]
+    pub env: Vec<String>,
+
+    /// Runtime working directory.
+    #[arg(long)]
+    pub working_directory: Option<String>,
+
+    /// Application maximum instances.
+    #[arg(long)]
+    pub max_instances: Option<u32>,
+
+    /// Application delay-release value in seconds.
+    #[arg(long)]
+    pub delay_release: Option<i64>,
+
+    /// Installer type. Overrides detected installer.
+    #[arg(long)]
+    pub installer: Option<String>,
+
+    /// Optional input schema string.
+    #[arg(long)]
+    pub schema_input: Option<String>,
+
+    /// Optional output schema string.
+    #[arg(long)]
+    pub schema_output: Option<String>,
+
+    /// Optional common-data schema string.
+    #[arg(long)]
+    pub schema_common_data: Option<String>,
+}
+
+struct DeployPlan {
+    app_name: String,
+    cache_endpoint: String,
+    prepared: PreparedApplication,
+    attributes: ApplicationAttributes,
+    output: String,
+    dry_run: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct DeployResult {
+    name: String,
+    input_kind: String,
+    installer: String,
+    command: String,
+    arguments: Vec<String>,
+    object_key: String,
+    url: String,
+    sha256: String,
+    dry_run: bool,
+    application: RenderedApplication,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct RenderedApplication {
+    metadata: RenderedMetadata,
+    spec: RenderedSpec,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct RenderedMetadata {
+    name: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct RenderedSpec {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    shim: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    image: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    labels: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    command: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    arguments: Vec<String>,
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
+    environments: HashMap<String, String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    working_directory: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    max_instances: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    delay_release: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    schema: Option<RenderedSchema>,
+    url: String,
+    installer: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct RenderedSchema {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    input: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    output: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    common_data: Option<String>,
+}
+
+pub async fn run(ctx: &FlameContext, options: &Options) -> Result<(), FlameError> {
+    let plan = build_plan(ctx, options)?;
+    let object_key = plan.prepared.object_key(&plan.app_name);
+    let mut uploaded_key = object_key.clone();
+
+    if !plan.dry_run {
+        let object_ref = flame::object::upload_object_with_context(
+            ctx,
+            &object_key,
+            &plan.prepared.package_path,
+        )
+        .await?;
+        uploaded_key = object_ref.key;
+    }
+
+    let url = object_url(&plan.cache_endpoint, &uploaded_key);
+
+    let mut attributes = plan.attributes.clone();
+    attributes.url = Some(url.clone());
+
+    let result = DeployResult {
+        name: plan.app_name.clone(),
+        input_kind: plan.prepared.kind.to_string(),
+        installer: attributes.installer.clone().unwrap_or_default(),
+        command: attributes.command.clone().unwrap_or_default(),
+        arguments: attributes.arguments.clone(),
+        object_key: uploaded_key.clone(),
+        url: url.clone(),
+        sha256: plan.prepared.sha256.clone(),
+        dry_run: plan.dry_run,
+        application: render_application(&plan.app_name, &attributes),
+    };
+
+    if !plan.dry_run {
+        let current_ctx = ctx.get_current_context()?;
+        let conn = flame::client::connect_with_tls(
+            &current_ctx.cluster.endpoint,
+            current_ctx.cluster.tls.as_ref(),
+        )
+        .await?;
+        conn.register_application(plan.app_name.clone(), attributes)
+            .await?;
+    }
+
+    print_result(&plan.output, &result)?;
+    Ok(())
+}
+
+fn build_plan(ctx: &FlameContext, options: &Options) -> Result<DeployPlan, FlameError> {
+    validate_name(&options.name)?;
+    let current_ctx = ctx.get_current_context()?;
+    let cache_config = current_ctx
+        .cache
+        .as_ref()
+        .ok_or_else(|| FlameError::InvalidConfig("cache endpoint not configured".to_string()))?;
+    let cache_endpoint = cache_config
+        .endpoint
+        .as_deref()
+        .ok_or_else(|| FlameError::InvalidConfig("cache endpoint not configured".to_string()))
+        .and_then(normalize_cache_endpoint)?;
+
+    let prepared = prepare_application(&options.application)?;
+    let detected = detect_application(&options.name, prepared.kind, &prepared.detection_root)?;
+    let attributes = build_attributes(options, &detected)?;
+
+    Ok(DeployPlan {
+        app_name: options.name.clone(),
+        cache_endpoint,
+        prepared,
+        attributes,
+        output: options.output.clone(),
+        dry_run: options.dry_run,
+    })
+}
+
+fn build_attributes(
+    options: &Options,
+    detected: &DetectedApplication,
+) -> Result<ApplicationAttributes, FlameError> {
+    let shim = parse_shim(options.shim.as_deref())?;
+    let installer = options
+        .installer
+        .clone()
+        .or_else(|| detected.installer.clone())
+        .ok_or_else(|| {
+            FlameError::InvalidConfig(
+                "unable to detect installer; pass --installer binary or --installer python"
+                    .to_string(),
+            )
+        })?;
+    validate_installer(&installer)?;
+
+    let command = options.command.clone().or_else(|| detected.command.clone());
+    if command.is_none() {
+        return Err(FlameError::InvalidConfig(
+            "unable to detect command; pass --command".to_string(),
+        ));
+    }
+
+    let arguments = if !options.argument.is_empty() {
+        options.argument.clone()
+    } else {
+        detected.arguments.clone()
+    };
+
+    let schema = if options.schema_input.is_some()
+        || options.schema_output.is_some()
+        || options.schema_common_data.is_some()
+    {
+        Some(ApplicationSchema {
+            input: options.schema_input.clone(),
+            output: options.schema_output.clone(),
+            common_data: options.schema_common_data.clone(),
+        })
+    } else {
+        None
+    };
+
+    Ok(ApplicationAttributes {
+        shim,
+        image: options.image.clone(),
+        description: options.description.clone(),
+        labels: options.label.clone(),
+        command,
+        arguments,
+        environments: parse_envs(&options.env)?,
+        working_directory: options.working_directory.clone(),
+        max_instances: options.max_instances,
+        delay_release: options.delay_release.map(Duration::seconds),
+        schema,
+        url: None,
+        installer: Some(installer),
+    })
+}
+
+fn parse_shim(value: Option<&str>) -> Result<Option<Shim>, FlameError> {
+    match value {
+        None => Ok(Some(Shim::Host)),
+        Some("Host") | Some("host") => Ok(Some(Shim::Host)),
+        Some("Wasm") | Some("wasm") | Some("WASM") => Ok(Some(Shim::Wasm)),
+        Some(other) => Err(FlameError::InvalidConfig(format!(
+            "invalid shim value '{}'. Must be Host or Wasm",
+            other
+        ))),
+    }
+}
+
+fn validate_installer(installer: &str) -> Result<(), FlameError> {
+    match installer {
+        "binary" | "python" => Ok(()),
+        other => Err(FlameError::InvalidConfig(format!(
+            "unsupported installer '{}'. Supported installers: binary, python",
+            other
+        ))),
+    }
+}
+
+fn parse_envs(values: &[String]) -> Result<HashMap<String, String>, FlameError> {
+    let mut envs = HashMap::new();
+    for value in values {
+        let Some((key, val)) = value.split_once('=') else {
+            return Err(FlameError::InvalidConfig(format!(
+                "invalid environment '{}'; expected NAME=VALUE",
+                value
+            )));
+        };
+        if key.is_empty() {
+            return Err(FlameError::InvalidConfig(
+                "environment variable name cannot be empty".to_string(),
+            ));
+        }
+        envs.insert(key.to_string(), val.to_string());
+    }
+    Ok(envs)
+}
+
+fn validate_name(name: &str) -> Result<(), FlameError> {
+    common::apis::validate_application_name(name)
+        .map_err(|e| FlameError::InvalidConfig(e.to_string()))
+}
+
+fn normalize_cache_endpoint(raw: &str) -> Result<String, FlameError> {
+    let parsed = Url::parse(raw)
+        .map_err(|e| FlameError::InvalidConfig(format!("invalid cache endpoint: {}", e)))?;
+    let scheme = parsed.scheme();
+    if scheme != "grpc" && scheme != "grpcs" {
+        return Err(FlameError::InvalidConfig(format!(
+            "unsupported cache endpoint scheme <{}>; expected grpc or grpcs",
+            scheme
+        )));
+    }
+    let host = parsed
+        .host_str()
+        .ok_or_else(|| FlameError::InvalidConfig("cache endpoint missing host".to_string()))?;
+    let port = parsed.port().unwrap_or(9090);
+    Ok(format!("{}://{}:{}", scheme, host, port))
+}
+
+fn object_url(cache_endpoint: &str, key: &str) -> String {
+    format!("{}/{}", cache_endpoint.trim_end_matches('/'), key)
+}
+
+fn render_application(name: &str, attributes: &ApplicationAttributes) -> RenderedApplication {
+    RenderedApplication {
+        metadata: RenderedMetadata {
+            name: name.to_string(),
+        },
+        spec: RenderedSpec {
+            shim: attributes.shim.map(|shim| shim.to_string()),
+            image: attributes.image.clone(),
+            description: attributes.description.clone(),
+            labels: attributes.labels.clone(),
+            command: attributes.command.clone(),
+            arguments: attributes.arguments.clone(),
+            environments: attributes.environments.clone(),
+            working_directory: attributes.working_directory.clone(),
+            max_instances: attributes.max_instances,
+            delay_release: attributes.delay_release.map(|d| d.num_seconds()),
+            schema: attributes.schema.clone().map(|schema| RenderedSchema {
+                input: schema.input,
+                output: schema.output,
+                common_data: schema.common_data,
+            }),
+            url: attributes.url.clone().unwrap_or_default(),
+            installer: attributes.installer.clone().unwrap_or_default(),
+        },
+    }
+}
+
+fn print_result(output: &str, result: &DeployResult) -> Result<(), FlameError> {
+    match output {
+        "summary" => {
+            if result.dry_run {
+                println!("Application <{}> deploy plan.", result.name);
+            } else {
+                println!("Application <{}> deployed.", result.name);
+            }
+            println!("Input Kind: {}", result.input_kind);
+            println!("Installer: {}", result.installer);
+            println!("Command: {}", result.command);
+            if !result.arguments.is_empty() {
+                println!("Arguments: {}", result.arguments.join(" "));
+            }
+            println!("Object: {}", result.object_key);
+            println!("SHA256: {}", result.sha256);
+            println!("URL: {}", result.url);
+            if result.dry_run {
+                println!("Dry Run: true");
+            }
+            Ok(())
+        }
+        "yaml" => {
+            let rendered = serde_yaml::to_string(&result.application)
+                .map_err(|e| FlameError::Internal(format!("failed to render yaml: {}", e)))?;
+            print!("{rendered}");
+            Ok(())
+        }
+        "json" => {
+            let rendered = serde_json::to_string_pretty(result)
+                .map_err(|e| FlameError::Internal(format!("failed to render json: {}", e)))?;
+            println!("{rendered}");
+            Ok(())
+        }
+        other => Err(FlameError::InvalidConfig(format!(
+            "unsupported output format '{}'. Supported: summary, yaml, json",
+            other
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_envs_requires_name_value() {
+        assert!(parse_envs(&["A=B".to_string()]).is_ok());
+        assert!(parse_envs(&["A".to_string()]).is_err());
+    }
+
+    #[test]
+    fn normalizes_cache_endpoint_and_object_url() {
+        let endpoint = normalize_cache_endpoint("grpc://cache").unwrap();
+        assert_eq!(endpoint, "grpc://cache:9090");
+        assert_eq!(
+            object_url(&endpoint, "app/pkg/app.tar.gz"),
+            "grpc://cache:9090/app/pkg/app.tar.gz"
+        );
+    }
+
+    #[test]
+    fn rejects_non_cache_endpoint_scheme() {
+        assert!(normalize_cache_endpoint("http://cache:9090").is_err());
+    }
+
+    #[test]
+    fn validates_names_like_session_manager() {
+        assert!(validate_name("demo-app").is_ok());
+        assert!(validate_name("app@name").is_err());
+        assert!(validate_name("-demo").is_err());
+    }
+
+    #[test]
+    fn explicit_options_override_detection() {
+        let options = Options {
+            name: "demo".to_string(),
+            application: PathBuf::from("."),
+            dry_run: true,
+            output: "summary".to_string(),
+            shim: None,
+            image: None,
+            description: None,
+            label: vec![],
+            command: Some("python".to_string()),
+            argument: vec!["-m".to_string(), "demo".to_string()],
+            env: vec![],
+            working_directory: None,
+            max_instances: None,
+            delay_release: None,
+            installer: Some("python".to_string()),
+            schema_input: None,
+            schema_output: None,
+            schema_common_data: None,
+        };
+        let detected = DetectedApplication::executable("service".to_string());
+        let attributes = build_attributes(&options, &detected).unwrap();
+        assert_eq!(attributes.command.as_deref(), Some("python"));
+        assert_eq!(attributes.arguments, vec!["-m", "demo"]);
+        assert_eq!(attributes.installer.as_deref(), Some("python"));
+    }
+
+    #[test]
+    fn binary_package_url_uses_three_part_content_addressed_object_key() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let bin = temp.path().join("service");
+        std::fs::write(&bin, b"#!/bin/sh\n").unwrap();
+        make_executable(&bin);
+
+        let prepared = prepare_application(&bin).unwrap();
+        let object_key = prepared.object_key("demo");
+        assert_eq!(
+            object_key,
+            format!("demo/pkg/demo-{}.tar.gz", &prepared.sha256[..16])
+        );
+        assert_eq!(
+            object_url("grpc://cache:9090", &object_key),
+            format!(
+                "grpc://cache:9090/demo/pkg/demo-{}.tar.gz",
+                &prepared.sha256[..16]
+            )
+        );
+    }
+
+    fn make_executable(path: &std::path::Path) {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut permissions = std::fs::metadata(path).unwrap().permissions();
+            permissions.set_mode(0o755);
+            std::fs::set_permissions(path, permissions).unwrap();
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = path;
+        }
+    }
+}

--- a/flmctl/src/deploy/artifact.rs
+++ b/flmctl/src/deploy/artifact.rs
@@ -1,0 +1,541 @@
+/*
+Copyright 2026 The Flame Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::fs;
+use std::io::Read;
+use std::path::{Component, Path, PathBuf};
+
+use flame_rs::apis::FlameError;
+use flate2::read::GzDecoder;
+use flate2::write::GzEncoder;
+use flate2::{Compression, GzBuilder};
+use sha2::{Digest, Sha256};
+use tar::{Archive, Builder, EntryType, Header};
+use tempfile::TempDir;
+
+const PACKAGE_EXTENSIONS: [&str; 2] = [".tar.gz", ".tgz"];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ApplicationInputKind {
+    ExecutableFile,
+    TarGz,
+    Directory,
+}
+
+impl std::fmt::Display for ApplicationInputKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ExecutableFile => write!(f, "executable-file"),
+            Self::TarGz => write!(f, "tar.gz"),
+            Self::Directory => write!(f, "directory"),
+        }
+    }
+}
+
+pub struct PreparedApplication {
+    pub kind: ApplicationInputKind,
+    pub detection_root: PathBuf,
+    pub package_path: PathBuf,
+    pub sha256: String,
+    _temp_dir: TempDir,
+}
+
+impl PreparedApplication {
+    pub fn filename(&self, app_name: &str) -> String {
+        match self.kind {
+            ApplicationInputKind::ExecutableFile => format!("{}.tar.gz", app_name),
+            ApplicationInputKind::TarGz | ApplicationInputKind::Directory => {
+                format!("{}-{}.tar.gz", app_name, &self.sha256[..16])
+            }
+        }
+    }
+
+    pub fn object_key(&self, app_name: &str) -> String {
+        let object_name = match self.kind {
+            ApplicationInputKind::ExecutableFile => {
+                format!("{}-{}.tar.gz", app_name, &self.sha256[..16])
+            }
+            ApplicationInputKind::TarGz | ApplicationInputKind::Directory => {
+                self.filename(app_name)
+            }
+        };
+        format!("{}/pkg/{}", app_name, object_name)
+    }
+}
+
+pub fn prepare_application(path: &Path) -> Result<PreparedApplication, FlameError> {
+    let input_path = path.canonicalize().map_err(|e| {
+        FlameError::InvalidConfig(format!("failed to resolve {}: {}", path.display(), e))
+    })?;
+
+    let kind = classify_application(&input_path)?;
+    let temp_dir = TempDir::new()
+        .map_err(|e| FlameError::Internal(format!("failed to create temp dir: {}", e)))?;
+
+    let detection_root = match kind {
+        ApplicationInputKind::ExecutableFile => {
+            let root = temp_dir.path().join("binary");
+            let bin_dir = root.join("bin");
+            fs::create_dir_all(&bin_dir).map_err(|e| {
+                FlameError::Internal(format!("failed to create binary package dir: {}", e))
+            })?;
+            let filename = input_path.file_name().ok_or_else(|| {
+                FlameError::InvalidConfig(format!("invalid binary path: {}", input_path.display()))
+            })?;
+            fs::copy(&input_path, bin_dir.join(filename)).map_err(|e| {
+                FlameError::Internal(format!("failed to copy binary into package dir: {}", e))
+            })?;
+            root
+        }
+        ApplicationInputKind::TarGz => {
+            let root = temp_dir.path().join("extract");
+            fs::create_dir_all(&root).map_err(|e| {
+                FlameError::Internal(format!("failed to create extraction dir: {}", e))
+            })?;
+            unpack_tar_gz(&input_path, &root)?;
+            select_detection_root(&root)?
+        }
+        ApplicationInputKind::Directory => input_path,
+    };
+
+    let package_path = temp_dir.path().join("application.tar.gz");
+    package_directory(&detection_root, &package_path)?;
+    let sha256 = sha256_file(&package_path)?;
+
+    Ok(PreparedApplication {
+        kind,
+        detection_root,
+        package_path,
+        sha256,
+        _temp_dir: temp_dir,
+    })
+}
+
+pub fn classify_application(path: &Path) -> Result<ApplicationInputKind, FlameError> {
+    if path.is_dir() {
+        return Ok(ApplicationInputKind::Directory);
+    }
+
+    if path.is_file() && has_package_extension(path) {
+        return Ok(ApplicationInputKind::TarGz);
+    }
+
+    if path.is_file() && is_executable(path)? {
+        return Ok(ApplicationInputKind::ExecutableFile);
+    }
+
+    Err(FlameError::InvalidConfig(format!(
+        "{} must be a directory, .tar.gz/.tgz package, or executable file",
+        path.display()
+    )))
+}
+
+fn has_package_extension(path: &Path) -> bool {
+    let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+        return false;
+    };
+    PACKAGE_EXTENSIONS.iter().any(|ext| name.ends_with(ext))
+}
+
+pub fn is_executable(path: &Path) -> Result<bool, FlameError> {
+    let metadata = fs::metadata(path).map_err(|e| {
+        FlameError::InvalidConfig(format!("failed to stat {}: {}", path.display(), e))
+    })?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        Ok(metadata.permissions().mode() & 0o111 != 0)
+    }
+
+    #[cfg(not(unix))]
+    {
+        Ok(metadata.is_file())
+    }
+}
+
+fn package_directory(src_root: &Path, dest_path: &Path) -> Result<(), FlameError> {
+    let file = fs::File::create(dest_path).map_err(|e| {
+        FlameError::Internal(format!(
+            "failed to create package {}: {}",
+            dest_path.display(),
+            e
+        ))
+    })?;
+    let encoder = GzBuilder::new()
+        .mtime(0)
+        .write(file, Compression::default());
+    let mut builder = Builder::new(encoder);
+    let root = src_root.canonicalize().map_err(|e| {
+        FlameError::Internal(format!(
+            "failed to resolve package root {}: {}",
+            src_root.display(),
+            e
+        ))
+    })?;
+
+    let mut entries = Vec::new();
+    collect_entries(&root, Path::new(""), &root, &mut entries)?;
+    entries.sort();
+
+    for relative in entries {
+        let src = root.join(&relative);
+        append_file(&mut builder, &root, &src, &relative)?;
+    }
+
+    let encoder = builder
+        .into_inner()
+        .map_err(|e| FlameError::Internal(format!("failed to finish tar archive: {}", e)))?;
+    encoder
+        .finish()
+        .map_err(|e| FlameError::Internal(format!("failed to finish gzip archive: {}", e)))?;
+    Ok(())
+}
+
+fn collect_entries(
+    root: &Path,
+    relative: &Path,
+    canonical_root: &Path,
+    entries: &mut Vec<PathBuf>,
+) -> Result<(), FlameError> {
+    let dir = root.join(relative);
+    let mut children = Vec::new();
+    for entry in fs::read_dir(&dir).map_err(|e| {
+        FlameError::Internal(format!("failed to read directory {}: {}", dir.display(), e))
+    })? {
+        let entry = entry
+            .map_err(|e| FlameError::Internal(format!("failed to read directory entry: {}", e)))?;
+        children.push(entry.path());
+    }
+    children.sort();
+
+    for child in children {
+        let name = child.file_name().ok_or_else(|| {
+            FlameError::Internal(format!("invalid path in package: {}", child.display()))
+        })?;
+        let child_relative = relative.join(name);
+        let metadata = fs::symlink_metadata(&child).map_err(|e| {
+            FlameError::Internal(format!("failed to stat {}: {}", child.display(), e))
+        })?;
+
+        if metadata.file_type().is_symlink() {
+            let target = child.canonicalize().map_err(|e| {
+                FlameError::InvalidConfig(format!(
+                    "failed to resolve symlink {}: {}",
+                    child.display(),
+                    e
+                ))
+            })?;
+            if !target.starts_with(canonical_root) {
+                return Err(FlameError::InvalidConfig(format!(
+                    "symlink {} points outside application root",
+                    child.display()
+                )));
+            }
+            if target.is_dir() {
+                return Err(FlameError::InvalidConfig(format!(
+                    "symlinked directories are not supported: {}",
+                    child.display()
+                )));
+            }
+            entries.push(child_relative);
+        } else if metadata.is_dir() {
+            collect_entries(root, &child_relative, canonical_root, entries)?;
+        } else if metadata.is_file() {
+            entries.push(child_relative);
+        }
+    }
+
+    Ok(())
+}
+
+fn append_file(
+    builder: &mut Builder<GzEncoder<fs::File>>,
+    canonical_root: &Path,
+    src: &Path,
+    relative: &Path,
+) -> Result<(), FlameError> {
+    let actual_src = if fs::symlink_metadata(src)
+        .map_err(|e| FlameError::Internal(format!("failed to stat {}: {}", src.display(), e)))?
+        .file_type()
+        .is_symlink()
+    {
+        src.canonicalize().map_err(|e| {
+            FlameError::InvalidConfig(format!(
+                "failed to resolve symlink {}: {}",
+                src.display(),
+                e
+            ))
+        })?
+    } else {
+        src.to_path_buf()
+    };
+
+    if !actual_src
+        .canonicalize()
+        .unwrap_or(actual_src.clone())
+        .starts_with(canonical_root)
+    {
+        return Err(FlameError::InvalidConfig(format!(
+            "{} is outside application root",
+            src.display()
+        )));
+    }
+
+    let mut file = fs::File::open(&actual_src).map_err(|e| {
+        FlameError::Internal(format!("failed to open {}: {}", actual_src.display(), e))
+    })?;
+    let metadata = file.metadata().map_err(|e| {
+        FlameError::Internal(format!("failed to stat {}: {}", actual_src.display(), e))
+    })?;
+
+    let mut header = Header::new_gnu();
+    header.set_entry_type(EntryType::Regular);
+    header.set_size(metadata.len());
+    header.set_mtime(0);
+    header.set_uid(0);
+    header.set_gid(0);
+    header.set_mode(file_mode(&metadata));
+    header.set_cksum();
+
+    builder
+        .append_data(&mut header, relative, &mut file)
+        .map_err(|e| FlameError::Internal(format!("failed to append package file: {}", e)))?;
+    Ok(())
+}
+
+fn file_mode(metadata: &fs::Metadata) -> u32 {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        metadata.permissions().mode() & 0o777
+    }
+
+    #[cfg(not(unix))]
+    {
+        if metadata.permissions().readonly() {
+            0o444
+        } else {
+            0o644
+        }
+    }
+}
+
+fn unpack_tar_gz(package: &Path, dest: &Path) -> Result<(), FlameError> {
+    let file = fs::File::open(package).map_err(|e| {
+        FlameError::Internal(format!(
+            "failed to open package {}: {}",
+            package.display(),
+            e
+        ))
+    })?;
+    let decoder = GzDecoder::new(file);
+    let mut archive = Archive::new(decoder);
+
+    for entry in archive.entries().map_err(|e| {
+        FlameError::InvalidConfig(format!(
+            "failed to read tar archive {}: {}",
+            package.display(),
+            e
+        ))
+    })? {
+        let mut entry =
+            entry.map_err(|e| FlameError::InvalidConfig(format!("invalid tar entry: {}", e)))?;
+        let path = entry
+            .path()
+            .map_err(|e| FlameError::InvalidConfig(format!("invalid tar path: {}", e)))?;
+        let path = path.to_path_buf();
+        validate_relative_path(&path)?;
+
+        let entry_type = entry.header().entry_type();
+        if !(entry_type.is_dir() || entry_type.is_file()) {
+            return Err(FlameError::InvalidConfig(format!(
+                "unsupported tar entry type for {}",
+                path.display()
+            )));
+        }
+
+        entry.unpack_in(dest).map_err(|e| {
+            FlameError::InvalidConfig(format!("failed to unpack {}: {}", path.display(), e))
+        })?;
+    }
+
+    Ok(())
+}
+
+fn validate_relative_path(path: &Path) -> Result<(), FlameError> {
+    for component in path.components() {
+        match component {
+            Component::Normal(_) | Component::CurDir => {}
+            _ => {
+                return Err(FlameError::InvalidConfig(format!(
+                    "unsafe archive path: {}",
+                    path.display()
+                )))
+            }
+        }
+    }
+    Ok(())
+}
+
+fn select_detection_root(root: &Path) -> Result<PathBuf, FlameError> {
+    let entries: Vec<PathBuf> = fs::read_dir(root)
+        .map_err(|e| FlameError::Internal(format!("failed to read extraction root: {}", e)))?
+        .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+        .collect();
+
+    if entries.len() == 1 && entries[0].is_dir() {
+        Ok(entries[0].clone())
+    } else {
+        Ok(root.to_path_buf())
+    }
+}
+
+fn sha256_file(path: &Path) -> Result<String, FlameError> {
+    let mut file = fs::File::open(path).map_err(|e| {
+        FlameError::Internal(format!("failed to open package {}: {}", path.display(), e))
+    })?;
+    let mut hasher = Sha256::new();
+    let mut buffer = [0_u8; 1024 * 1024];
+
+    loop {
+        let read = file
+            .read(&mut buffer)
+            .map_err(|e| FlameError::Internal(format!("failed to read package: {}", e)))?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn classify_directory() {
+        let temp = TempDir::new().unwrap();
+        assert_eq!(
+            classify_application(temp.path()).unwrap(),
+            ApplicationInputKind::Directory
+        );
+    }
+
+    #[test]
+    fn prepare_executable_file_packages_under_bin() {
+        let temp = TempDir::new().unwrap();
+        let bin = temp.path().join("service");
+        fs::write(&bin, b"#!/bin/sh\n").unwrap();
+        make_executable(&bin);
+
+        let prepared = prepare_application(&bin).unwrap();
+        assert_eq!(prepared.kind, ApplicationInputKind::ExecutableFile);
+        assert!(prepared.detection_root.join("bin/service").exists());
+        assert_eq!(prepared.filename("demo"), "demo.tar.gz");
+        assert_eq!(
+            prepared.object_key("demo"),
+            format!("demo/pkg/demo-{}.tar.gz", &prepared.sha256[..16])
+        );
+        assert_eq!(prepared.sha256.len(), 64);
+    }
+
+    #[test]
+    fn tarball_path_traversal_is_rejected() {
+        let temp = TempDir::new().unwrap();
+        let package = temp.path().join("bad.tar.gz");
+        let file = fs::File::create(&package).unwrap();
+        let encoder = GzBuilder::new()
+            .mtime(0)
+            .write(file, Compression::default());
+        let mut encoder = encoder;
+        write_raw_tar_entry(&mut encoder, "../bad", b"bad");
+        encoder.write_all(&[0_u8; 1024]).unwrap();
+        encoder.finish().unwrap();
+
+        let dest = temp.path().join("dest");
+        fs::create_dir(&dest).unwrap();
+        assert!(unpack_tar_gz(&package, &dest).is_err());
+    }
+
+    #[test]
+    fn tarball_curdir_entries_are_allowed() {
+        assert!(validate_relative_path(Path::new("./app.py")).is_ok());
+        assert!(validate_relative_path(Path::new("./bin/service")).is_ok());
+    }
+
+    fn write_raw_tar_entry<W: Write>(writer: &mut W, name: &str, data: &[u8]) {
+        let mut header = [0_u8; 512];
+        header[..name.len()].copy_from_slice(name.as_bytes());
+        write_octal(&mut header[100..108], 0o644);
+        write_octal(&mut header[108..116], 0);
+        write_octal(&mut header[116..124], 0);
+        write_octal(&mut header[124..136], data.len() as u64);
+        write_octal(&mut header[136..148], 0);
+        header[148..156].fill(b' ');
+        header[156] = b'0';
+        header[257..263].copy_from_slice(b"ustar\0");
+        header[263..265].copy_from_slice(b"00");
+        let checksum: u32 = header.iter().map(|byte| *byte as u32).sum();
+        write_octal(&mut header[148..156], checksum as u64);
+
+        writer.write_all(&header).unwrap();
+        writer.write_all(data).unwrap();
+        let padding = (512 - (data.len() % 512)) % 512;
+        if padding > 0 {
+            writer.write_all(&vec![0_u8; padding]).unwrap();
+        }
+    }
+
+    fn write_octal(field: &mut [u8], value: u64) {
+        field.fill(0);
+        let digits = format!("{:0width$o}", value, width = field.len() - 1);
+        field[..digits.len()].copy_from_slice(digits.as_bytes());
+    }
+
+    fn make_executable(path: &Path) {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut permissions = fs::metadata(path).unwrap().permissions();
+            permissions.set_mode(0o755);
+            fs::set_permissions(path, permissions).unwrap();
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = path;
+        }
+    }
+
+    #[test]
+    fn directory_package_is_content_addressed() {
+        let temp = TempDir::new().unwrap();
+        let file = temp.path().join("app.py");
+        let mut f = fs::File::create(file).unwrap();
+        writeln!(f, "print('hello')").unwrap();
+
+        let prepared = prepare_application(temp.path()).unwrap();
+        assert!(prepared.package_path.exists());
+        assert_eq!(
+            prepared.filename("demo").len(),
+            "demo-".len() + 16 + ".tar.gz".len()
+        );
+        assert_eq!(
+            prepared.object_key("demo"),
+            format!("demo/pkg/{}", prepared.filename("demo"))
+        );
+    }
+}

--- a/flmctl/src/deploy/detect.rs
+++ b/flmctl/src/deploy/detect.rs
@@ -1,0 +1,258 @@
+/*
+Copyright 2026 The Flame Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use flame_rs::apis::FlameError;
+use toml::Value;
+
+use super::artifact::{is_executable, ApplicationInputKind};
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct DetectedApplication {
+    pub installer: Option<String>,
+    pub command: Option<String>,
+    pub arguments: Vec<String>,
+}
+
+impl DetectedApplication {
+    pub fn executable(command: String) -> Self {
+        Self {
+            installer: Some("binary".to_string()),
+            command: Some(command),
+            arguments: Vec::new(),
+        }
+    }
+}
+
+pub fn detect_application(
+    app_name: &str,
+    kind: ApplicationInputKind,
+    root: &Path,
+) -> Result<DetectedApplication, FlameError> {
+    match kind {
+        ApplicationInputKind::ExecutableFile => {
+            let command = root
+                .join("bin")
+                .read_dir()
+                .map_err(|e| {
+                    FlameError::Internal(format!("failed to read binary package dir: {}", e))
+                })?
+                .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+                .find(|path| path.is_file())
+                .and_then(|path| {
+                    path.file_name()
+                        .and_then(|n| n.to_str())
+                        .map(|name| name.to_string())
+                })
+                .ok_or_else(|| {
+                    FlameError::InvalidConfig("failed to detect binary command".to_string())
+                })?;
+            Ok(DetectedApplication::executable(command))
+        }
+        ApplicationInputKind::Directory | ApplicationInputKind::TarGz => {
+            detect_from_directory(app_name, root)
+        }
+    }
+}
+
+fn detect_from_directory(app_name: &str, root: &Path) -> Result<DetectedApplication, FlameError> {
+    if has_python_marker(root) {
+        let (command, arguments) = detect_python_command(app_name, root)?;
+        return Ok(DetectedApplication {
+            installer: Some("python".to_string()),
+            command,
+            arguments,
+        });
+    }
+
+    let command = detect_binary_command(app_name, root)?;
+    Ok(DetectedApplication {
+        installer: Some("binary".to_string()),
+        command,
+        arguments: Vec::new(),
+    })
+}
+
+fn has_python_marker(root: &Path) -> bool {
+    root.join("pyproject.toml").exists()
+        || root.join("setup.py").exists()
+        || root.join("setup.cfg").exists()
+}
+
+fn detect_python_command(
+    app_name: &str,
+    root: &Path,
+) -> Result<(Option<String>, Vec<String>), FlameError> {
+    if let Some(command) = detect_pyproject_script(app_name, root)? {
+        return Ok((Some(command), Vec::new()));
+    }
+
+    let module_name = app_name.replace('-', "_");
+    if root.join(&module_name).join("__main__.py").exists() {
+        return Ok((
+            Some("python".to_string()),
+            vec!["-m".to_string(), module_name],
+        ));
+    }
+
+    Ok((None, Vec::new()))
+}
+
+fn detect_pyproject_script(app_name: &str, root: &Path) -> Result<Option<String>, FlameError> {
+    let pyproject = root.join("pyproject.toml");
+    if !pyproject.exists() {
+        return Ok(None);
+    }
+
+    let contents = fs::read_to_string(&pyproject).map_err(|e| {
+        FlameError::Internal(format!("failed to read {}: {}", pyproject.display(), e))
+    })?;
+    let value: Value = toml::from_str(&contents).map_err(|e| {
+        FlameError::InvalidConfig(format!("failed to parse {}: {}", pyproject.display(), e))
+    })?;
+
+    let Some(scripts) = value
+        .get("project")
+        .and_then(|project| project.get("scripts"))
+        .and_then(Value::as_table)
+    else {
+        return Ok(None);
+    };
+
+    if let Some((name, _)) = scripts.iter().find(|(name, _)| name.as_str() == app_name) {
+        return Ok(Some(name.clone()));
+    }
+
+    if scripts.len() == 1 {
+        return Ok(scripts.keys().next().cloned());
+    }
+
+    Ok(None)
+}
+
+fn detect_binary_command(app_name: &str, root: &Path) -> Result<Option<String>, FlameError> {
+    let bin = root.join("bin").join(app_name);
+    if bin.is_file() && is_executable(&bin)? {
+        return Ok(Some(app_name.to_string()));
+    }
+
+    let bin_dir = root.join("bin");
+    if bin_dir.is_dir() {
+        let executables = executable_children(&bin_dir)?;
+        if executables.len() == 1 {
+            return Ok(file_name(&executables[0]));
+        }
+        if executables.len() > 1 {
+            return Ok(None);
+        }
+    }
+
+    let executables = executable_children(root)?;
+    if executables.len() == 1 {
+        return Ok(file_name(&executables[0]));
+    }
+
+    Ok(None)
+}
+
+fn executable_children(dir: &Path) -> Result<Vec<PathBuf>, FlameError> {
+    let mut executables = Vec::new();
+    for entry in fs::read_dir(dir).map_err(|e| {
+        FlameError::Internal(format!("failed to read directory {}: {}", dir.display(), e))
+    })? {
+        let entry =
+            entry.map_err(|e| FlameError::Internal(format!("failed to read entry: {}", e)))?;
+        let path = entry.path();
+        if path.is_file() && is_executable(&path)? {
+            executables.push(path);
+        }
+    }
+    executables.sort();
+    Ok(executables)
+}
+
+fn file_name(path: &Path) -> Option<String> {
+    path.file_name()
+        .and_then(|n| n.to_str())
+        .map(|name| name.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn detects_pyproject_script_matching_app_name() {
+        let temp = TempDir::new().unwrap();
+        fs::write(
+            temp.path().join("pyproject.toml"),
+            "[project.scripts]\nother = 'pkg:main'\ndemo = 'pkg:demo'\n",
+        )
+        .unwrap();
+
+        let detected =
+            detect_application("demo", ApplicationInputKind::Directory, temp.path()).unwrap();
+        assert_eq!(detected.installer.as_deref(), Some("python"));
+        assert_eq!(detected.command.as_deref(), Some("demo"));
+    }
+
+    #[test]
+    fn detects_python_module_main() {
+        let temp = TempDir::new().unwrap();
+        fs::write(
+            temp.path().join("pyproject.toml"),
+            "[project]\nname = 'demo'\n",
+        )
+        .unwrap();
+        fs::create_dir(temp.path().join("demo_app")).unwrap();
+        fs::write(temp.path().join("demo_app/__main__.py"), "").unwrap();
+
+        let detected =
+            detect_application("demo-app", ApplicationInputKind::Directory, temp.path()).unwrap();
+        assert_eq!(detected.installer.as_deref(), Some("python"));
+        assert_eq!(detected.command.as_deref(), Some("python"));
+        assert_eq!(detected.arguments, vec!["-m", "demo_app"]);
+    }
+
+    #[test]
+    fn detects_binary_in_bin_dir() {
+        let temp = TempDir::new().unwrap();
+        let bin_dir = temp.path().join("bin");
+        fs::create_dir(&bin_dir).unwrap();
+        let bin = bin_dir.join("demo");
+        fs::write(&bin, "").unwrap();
+        make_executable(&bin);
+
+        let detected =
+            detect_application("demo", ApplicationInputKind::Directory, temp.path()).unwrap();
+        assert_eq!(detected.installer.as_deref(), Some("binary"));
+        assert_eq!(detected.command.as_deref(), Some("demo"));
+    }
+
+    fn make_executable(path: &Path) {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut permissions = fs::metadata(path).unwrap().permissions();
+            permissions.set_mode(0o755);
+            fs::set_permissions(path, permissions).unwrap();
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = path;
+        }
+    }
+}

--- a/flmctl/src/main.rs
+++ b/flmctl/src/main.rs
@@ -21,6 +21,7 @@ use flame_rs::apis::FlameContext;
 mod apis;
 mod close;
 mod create;
+mod deploy;
 mod helper;
 mod list;
 mod migrate;
@@ -127,6 +128,8 @@ enum Commands {
         #[arg(short, long)]
         file: String,
     },
+    /// Deploy an application package to object cache and register it
+    Deploy(Box<deploy::Options>),
     /// Unregister the application from Flame
     Unregister {
         /// The name of the application
@@ -171,6 +174,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         }) => view::run(&ctx, output_format, application, session, task, node).await?,
         Some(Commands::Migrate { url, sql }) => migrate::run(&ctx, url, sql).await?,
         Some(Commands::Register { file }) => register::run(&ctx, file).await?,
+        Some(Commands::Deploy(options)) => deploy::run(&ctx, options).await?,
         Some(Commands::Unregister { application }) => unregister::run(&ctx, application).await?,
         Some(Commands::Update { application }) => update::run(&ctx, application).await?,
         Some(Commands::Completion { shell }) => {

--- a/flmctl/tests/deploy_cli.rs
+++ b/flmctl/tests/deploy_cli.rs
@@ -1,0 +1,189 @@
+/*
+Copyright 2026 The Flame Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+use serde_json::Value;
+use tempfile::TempDir;
+
+const CACHE_ENDPOINT: &str = "grpc://127.0.0.1:19090";
+
+#[test]
+fn deploy_dry_run_executable_file_through_cli() {
+    let temp = TempDir::new().unwrap();
+    let config = write_config(temp.path());
+    let binary = temp.path().join("service");
+    fs::write(&binary, b"#!/bin/sh\nexec echo service\n").unwrap();
+    make_executable(&binary);
+
+    let json = run_deploy_json(&config, &binary, "demo-app");
+
+    assert_eq!(json_string(&json, "/name"), "demo-app");
+    assert_eq!(json_string(&json, "/input_kind"), "executable-file");
+    assert_eq!(json_string(&json, "/installer"), "binary");
+    assert_eq!(json_string(&json, "/command"), "service");
+    assert_eq!(
+        json.pointer("/dry_run").and_then(Value::as_bool),
+        Some(true)
+    );
+
+    let object_key = json_string(&json, "/object_key");
+    assert_content_addressed_package_key(object_key, "demo-app");
+    assert_eq!(
+        json_string(&json, "/url"),
+        format!("{}/{}", CACHE_ENDPOINT, object_key)
+    );
+    assert!(!json_string(&json, "/url").contains("?sha"));
+
+    assert_eq!(json_string(&json, "/application/metadata/name"), "demo-app");
+    assert_eq!(json_string(&json, "/application/spec/installer"), "binary");
+    assert_eq!(json_string(&json, "/application/spec/command"), "service");
+    assert_eq!(
+        json_string(&json, "/application/spec/url"),
+        json_string(&json, "/url")
+    );
+}
+
+#[test]
+fn deploy_dry_run_python_directory_through_cli() {
+    let temp = TempDir::new().unwrap();
+    let config = write_config(temp.path());
+    let app_dir = temp.path().join("app");
+    fs::create_dir(&app_dir).unwrap();
+    fs::write(
+        app_dir.join("pyproject.toml"),
+        "[project]\nname = 'demo-app'\n[project.scripts]\ndemo-app = 'demo:main'\n",
+    )
+    .unwrap();
+
+    let json = run_deploy_json(&config, &app_dir, "demo-app");
+
+    assert_eq!(json_string(&json, "/input_kind"), "directory");
+    assert_eq!(json_string(&json, "/installer"), "python");
+    assert_eq!(json_string(&json, "/command"), "demo-app");
+    assert_content_addressed_package_key(json_string(&json, "/object_key"), "demo-app");
+    assert_eq!(
+        json_string(&json, "/application/spec/url"),
+        json_string(&json, "/url")
+    );
+}
+
+fn run_deploy_json(config: &Path, application: &Path, name: &str) -> Value {
+    let output = Command::new(env!("CARGO_BIN_EXE_flmctl"))
+        .arg("--config")
+        .arg(config)
+        .arg("deploy")
+        .arg("--name")
+        .arg(name)
+        .arg("--application")
+        .arg(application)
+        .arg("--dry-run")
+        .arg("-o")
+        .arg("json")
+        .env_remove("FLAME_ENDPOINT")
+        .env_remove("FLAME_CACHE_ENDPOINT")
+        .env_remove("FLAME_CA_FILE")
+        .output()
+        .unwrap();
+    assert_success(output)
+}
+
+fn assert_success(output: Output) -> Value {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "flmctl deploy failed\nstdout:\n{}\nstderr:\n{}",
+        stdout,
+        stderr
+    );
+
+    serde_json::from_slice(&output.stdout).unwrap_or_else(|e| {
+        panic!(
+            "failed to parse flmctl json output: {}\nstdout:\n{}\nstderr:\n{}",
+            e, stdout, stderr
+        )
+    })
+}
+
+fn write_config(root: &Path) -> PathBuf {
+    let config = root.join("flame.yaml");
+    fs::write(
+        &config,
+        format!(
+            r#"current-context: test
+contexts:
+  - name: test
+    cluster:
+      endpoint: http://127.0.0.1:18080
+    cache:
+      endpoint: {}
+"#,
+            CACHE_ENDPOINT
+        ),
+    )
+    .unwrap();
+    config
+}
+
+fn json_string<'a>(json: &'a Value, pointer: &str) -> &'a str {
+    json.pointer(pointer)
+        .and_then(Value::as_str)
+        .unwrap_or_else(|| panic!("missing string at {} in {}", pointer, json))
+}
+
+fn assert_content_addressed_package_key(key: &str, app_name: &str) {
+    let prefix = format!("{}/pkg/{}-", app_name, app_name);
+    assert!(
+        key.starts_with(&prefix),
+        "object key {} should start with {}",
+        key,
+        prefix
+    );
+    assert!(
+        key.ends_with(".tar.gz"),
+        "object key {} should end with .tar.gz",
+        key
+    );
+    assert_eq!(
+        key.split('/').count(),
+        3,
+        "object key {} should have <app>/<session>/<object> shape",
+        key
+    );
+
+    let digest = &key[prefix.len()..key.len() - ".tar.gz".len()];
+    assert_eq!(digest.len(), 16, "object key {} should use sha16", key);
+    assert!(
+        digest.chars().all(|c| matches!(c, '0'..='9' | 'a'..='f')),
+        "object key {} should use lowercase hex digest",
+        key
+    );
+}
+
+fn make_executable(path: &Path) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut permissions = fs::metadata(path).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(path, permissions).unwrap();
+    }
+
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+    }
+}

--- a/object_cache/Cargo.toml
+++ b/object_cache/Cargo.toml
@@ -36,5 +36,7 @@ bson = "2"
 rayon = { workspace = true }
 
 [dev-dependencies]
+flame-rs = { path = "../sdk/rust" }
 tempfile = "3"
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+tokio-stream = { workspace = true, features = ["net"] }

--- a/object_cache/src/cache.rs
+++ b/object_cache/src/cache.rs
@@ -876,9 +876,9 @@ fn object_to_batch(object: &Object) -> Result<RecordBatch, FlameError> {
 // Helper function to extract data from RecordBatch
 // Note: Returns Object with empty deltas; caller populates deltas separately
 fn batch_to_object(batch: &RecordBatch) -> Result<Object, FlameError> {
-    if batch.num_rows() != 1 {
+    if batch.num_rows() == 0 {
         return Err(FlameError::InvalidState(
-            "Expected exactly one row".to_string(),
+            "Expected at least one row".to_string(),
         ));
     }
 
@@ -894,7 +894,10 @@ fn batch_to_object(batch: &RecordBatch) -> Result<Object, FlameError> {
         .ok_or_else(|| FlameError::Internal("Invalid data column".to_string()))?;
 
     let version = version_col.value(0);
-    let data = data_col.value(0).to_vec();
+    let mut data = Vec::new();
+    for row in 0..batch.num_rows() {
+        data.extend_from_slice(data_col.value(row));
+    }
 
     Ok(Object::new(version, data))
 }
@@ -1621,6 +1624,22 @@ mod tests {
         }
 
         #[test]
+        fn batch_to_object_concatenates_chunk_rows() {
+            let schema = get_object_schema();
+            let version_array = UInt64Array::from(vec![0, 0, 0]);
+            let data_array = BinaryArray::from(vec![b"abc".as_slice(), b"def".as_slice(), b"ghi"]);
+            let batch = RecordBatch::try_new(
+                Arc::new(schema),
+                vec![Arc::new(version_array), Arc::new(data_array)],
+            )
+            .unwrap();
+
+            let recovered = batch_to_object(&batch).unwrap();
+            assert_eq!(recovered.version, 0);
+            assert_eq!(recovered.data, b"abcdefghi");
+        }
+
+        #[test]
         fn get_object_schema_returns_correct_schema() {
             let schema = get_object_schema();
             assert_eq!(schema.fields().len(), 2);
@@ -2117,6 +2136,226 @@ mod tests {
             let schema = get_object_schema();
             let encoded = encode_schema(&schema).unwrap();
             assert!(!encoded.is_empty());
+        }
+    }
+
+    mod flame_rs_object_helpers_integration {
+        use super::*;
+        use arrow_flight::flight_service_server::FlightServiceServer;
+        use flame_rs as flame;
+        use flame_rs::FlameMessage;
+        use serde_derive::{Deserialize, Serialize};
+        use tokio::net::TcpListener;
+        use tokio::task::JoinHandle;
+        use tokio_stream::wrappers::TcpListenerStream;
+
+        #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+        struct TestObject {
+            value: String,
+            count: u32,
+        }
+
+        impl FlameMessage for TestObject {
+            fn encode(&self) -> Result<Bytes, flame::apis::FlameError> {
+                serde_json::to_vec(self)
+                    .map(Bytes::from)
+                    .map_err(|e| flame::apis::FlameError::Internal(e.to_string()))
+            }
+
+            fn decode(bytes: &[u8]) -> Result<Self, flame::apis::FlameError> {
+                serde_json::from_slice(bytes)
+                    .map_err(|e| flame::apis::FlameError::InvalidConfig(e.to_string()))
+            }
+        }
+
+        #[derive(Debug, Clone, PartialEq)]
+        struct TestBytes(Vec<u8>);
+
+        impl FlameMessage for TestBytes {
+            fn encode(&self) -> Result<Bytes, flame::apis::FlameError> {
+                Ok(Bytes::from(self.0.clone()))
+            }
+
+            fn decode(bytes: &[u8]) -> Result<Self, flame::apis::FlameError> {
+                Ok(Self(bytes.to_vec()))
+            }
+        }
+
+        struct TestCacheServer {
+            endpoint: String,
+            handle: JoinHandle<()>,
+        }
+
+        impl Drop for TestCacheServer {
+            fn drop(&mut self) {
+                self.handle.abort();
+            }
+        }
+
+        async fn start_test_cache_server() -> TestCacheServer {
+            let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let addr = listener.local_addr().unwrap();
+            let endpoint = CacheEndpoint {
+                scheme: "grpc".to_string(),
+                host: "127.0.0.1".to_string(),
+                port: addr.port(),
+            };
+            let storage = Box::new(crate::storage::NoneStorage::new());
+            let cache = Arc::new(ObjectCache::new(endpoint, storage, None).unwrap());
+            let server = FlightCacheServer::new(cache);
+            let incoming = TcpListenerStream::new(listener);
+
+            let handle = tokio::spawn(async move {
+                tonic::transport::Server::builder()
+                    .add_service(
+                        FlightServiceServer::new(server)
+                            .max_decoding_message_size(usize::MAX)
+                            .max_encoding_message_size(usize::MAX),
+                    )
+                    .serve_with_incoming(incoming)
+                    .await
+                    .unwrap();
+            });
+
+            TestCacheServer {
+                endpoint: format!("grpc://127.0.0.1:{}", addr.port()),
+                handle,
+            }
+        }
+
+        fn flame_context(endpoint: &str) -> flame::apis::FlameContext {
+            flame::apis::FlameContext {
+                current_context: "test".to_string(),
+                contexts: vec![flame::apis::FlameContextEntry {
+                    name: "test".to_string(),
+                    cluster: flame::apis::FlameClusterConfig {
+                        endpoint: "http://127.0.0.1:0".to_string(),
+                        tls: None,
+                    },
+                    cache: Some(flame::apis::FlameClientCache {
+                        endpoint: Some(endpoint.to_string()),
+                        tls: None,
+                        storage: None,
+                    }),
+                    package: None,
+                    runner: None,
+                }],
+            }
+        }
+
+        #[tokio::test]
+        async fn flame_rs_put_get_update_patch_round_trips_over_flight() {
+            let server = start_test_cache_server().await;
+            let context = flame_context(&server.endpoint);
+
+            let initial = TestObject {
+                value: "initial".to_string(),
+                count: 1,
+            };
+            let reference =
+                flame::object::put_object_with_context(&context, "rust-sdk/session", &initial)
+                    .await
+                    .unwrap();
+            assert_eq!(reference.endpoint, server.endpoint);
+            assert!(reference.key.starts_with("rust-sdk/session/"));
+            assert_eq!(reference.version, 1);
+
+            let fetched: TestObject = flame::get_object(reference.clone()).await.unwrap();
+            assert_eq!(fetched, initial);
+
+            let updated = TestObject {
+                value: "updated".to_string(),
+                count: 2,
+            };
+            let updated_ref = flame::update_object(&reference, &updated).await.unwrap();
+            assert_eq!(updated_ref.key, reference.key);
+            assert_eq!(updated_ref.version, 2);
+            let fetched_updated: TestObject = flame::get_object(updated_ref.clone()).await.unwrap();
+            assert_eq!(fetched_updated, updated);
+
+            let delta = TestObject {
+                value: "delta".to_string(),
+                count: 3,
+            };
+            let patched_ref = flame::patch_object(&updated_ref, &delta).await.unwrap();
+            assert_eq!(patched_ref.key, reference.key);
+            assert_eq!(patched_ref.version, 3);
+
+            // Rust typed get_object returns the base object. Patch rows are reserved for
+            // callers that add a future merge/deserializer API.
+            let fetched_after_patch: TestObject =
+                flame::get_object(patched_ref.clone()).await.unwrap();
+            assert_eq!(fetched_after_patch, updated);
+        }
+
+        #[tokio::test]
+        async fn flame_rs_upload_download_object_round_trips_file_over_flight() {
+            let server = start_test_cache_server().await;
+            let context = flame_context(&server.endpoint);
+            let temp = tempfile::TempDir::new().unwrap();
+            let source_path = temp.path().join("package.tar.gz");
+            let downloaded_path = temp.path().join("downloaded.tar.gz");
+            let package_bytes: Vec<u8> = (0..(5 * 1024 * 1024 + 123))
+                .map(|idx| (idx % 251) as u8)
+                .collect();
+            tokio::fs::write(&source_path, &package_bytes)
+                .await
+                .unwrap();
+
+            let reference = flame::object::upload_object_with_context(
+                &context,
+                "rust-sdk/pkg/package.tar.gz",
+                &source_path,
+            )
+            .await
+            .unwrap();
+            assert_eq!(reference.endpoint, server.endpoint);
+            assert_eq!(reference.key, "rust-sdk/pkg/package.tar.gz");
+            assert_eq!(reference.version, 1);
+
+            flame::download_object(&reference, &downloaded_path)
+                .await
+                .unwrap();
+            let downloaded = tokio::fs::read(&downloaded_path).await.unwrap();
+            assert_eq!(downloaded, package_bytes);
+
+            let fetched: TestBytes = flame::get_object(reference.clone()).await.unwrap();
+            assert_eq!(fetched.0, package_bytes);
+        }
+
+        #[tokio::test]
+        async fn flame_rs_download_object_rejects_patched_file_ref() {
+            let server = start_test_cache_server().await;
+            let context = flame_context(&server.endpoint);
+            let temp = tempfile::TempDir::new().unwrap();
+            let source_path = temp.path().join("package.tar.gz");
+            let downloaded_path = temp.path().join("downloaded.tar.gz");
+            tokio::fs::write(&source_path, b"base-package")
+                .await
+                .unwrap();
+
+            let reference = flame::object::upload_object_with_context(
+                &context,
+                "rust-sdk/pkg/patched-package.tar.gz",
+                &source_path,
+            )
+            .await
+            .unwrap();
+            let patched_ref = flame::patch_object(
+                &reference,
+                &TestObject {
+                    value: "delta".to_string(),
+                    count: 4,
+                },
+            )
+            .await
+            .unwrap();
+
+            let err = flame::download_object(&patched_ref, &downloaded_path)
+                .await
+                .unwrap_err();
+            assert!(err.to_string().contains("contains patch rows"));
+            assert!(!downloaded_path.exists());
         }
     }
 }

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -25,6 +25,7 @@ tonic-prost = { workspace = true }
 serde_json = { workspace = true }
 bincode = { workspace = true }
 url = { workspace = true }
+uuid = { workspace = true }
 
 time = { workspace = true }
 tokio-stream = { workspace = true }
@@ -35,6 +36,9 @@ chrono = { workspace = true }
 serde = { workspace = true }
 serde_yaml = { workspace = true }
 serde_derive = { workspace = true }
+arrow = { workspace = true }
+arrow-flight = { workspace = true }
+bson = { workspace = true }
 
 [build-dependencies]
 tonic-build = { workspace = true }

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -14,10 +14,15 @@ limitations under the License.
 pub mod apis;
 pub mod client;
 pub mod message;
+pub mod object;
 pub mod service;
 
 pub use client::{Connection, Session, SessionOptions, TaskFuture, TaskHandle, TaskResult};
 pub use message::{FlameMessage, FromTaskOutput, IntoCommonData, IntoTaskInput};
+pub use object::{
+    delete_objects, download_object, get_object, patch_object, put_object, update_object,
+    upload_object, ObjectFuture, ObjectKey, ObjectRef,
+};
 
 #[cfg(feature = "macros")]
 pub use flame_rs_macros::{entrypoint, instance, FlameMessage};

--- a/sdk/rust/src/object.rs
+++ b/sdk/rust/src/object.rs
@@ -1,0 +1,921 @@
+/*
+Copyright 2026 The Flame Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::fmt::{Display, Formatter};
+use std::future::Future;
+use std::io::Cursor;
+use std::path::Path;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use std::time::Duration;
+
+use arrow::array::{Array, BinaryArray, StringArray, UInt64Array};
+use arrow::datatypes::{DataType, Field, Schema};
+use arrow::record_batch::RecordBatch;
+use arrow_flight::encode::FlightDataEncoderBuilder;
+use arrow_flight::error::FlightError;
+use arrow_flight::flight_service_client::FlightServiceClient;
+use arrow_flight::{Action, FlightClient, FlightDescriptor, Ticket};
+use bson::{doc, Bson, Document};
+use bytes::Bytes;
+use futures::{stream, TryStreamExt};
+use serde_derive::{Deserialize, Serialize as DeriveSerialize};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tonic::transport::Channel;
+use url::Url;
+
+use crate::apis::{FlameClientCache, FlameClientTls, FlameContext, FlameError};
+use crate::message::FlameMessage;
+
+const OBJECT_FIELD_VERSION: &str = "version";
+const OBJECT_FIELD_KIND: &str = "kind";
+const OBJECT_FIELD_DATA: &str = "data";
+const OBJECT_KIND_BASE: &str = "base";
+const OBJECT_KIND_PATCH: &str = "patch";
+const WILDCARD_SESSION: &str = "*";
+const DEFAULT_CACHE_PORT: u16 = 9090;
+const CONNECT_TIMEOUT_SECS: u64 = 30;
+const UPLOAD_CHUNK_SIZE: usize = 1024 * 1024;
+const FLIGHT_MAX_MESSAGE_SIZE: usize = usize::MAX;
+
+type ObjectFutureInner<T> = Pin<Box<dyn Future<Output = Result<T, FlameError>> + Send + 'static>>;
+
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+pub struct ObjectKey {
+    pub app_name: String,
+    pub session_id: String,
+    pub object_id: Option<String>,
+}
+
+impl ObjectKey {
+    pub fn prefix(
+        app_name: impl Into<String>,
+        session_id: impl Into<String>,
+    ) -> Result<Self, FlameError> {
+        Self::new(app_name.into(), session_id.into(), None)
+    }
+
+    pub fn key(
+        app_name: impl Into<String>,
+        session_id: impl Into<String>,
+        object_id: impl Into<String>,
+    ) -> Result<Self, FlameError> {
+        Self::new(app_name.into(), session_id.into(), Some(object_id.into()))
+    }
+
+    pub fn from_path(path: impl AsRef<str>) -> Result<Self, FlameError> {
+        let path = path.as_ref();
+        let parts: Vec<&str> = path.split('/').collect();
+        match parts.as_slice() {
+            [app_name, session_id] => Self::new((*app_name).to_string(), (*session_id).to_string(), None),
+            [app_name, session_id, object_id] => Self::new(
+                (*app_name).to_string(),
+                (*session_id).to_string(),
+                Some((*object_id).to_string()),
+            ),
+            _ => Err(FlameError::InvalidConfig(format!(
+                "invalid object key path '{}': expected '<app>/<session>' or '<app>/<session>/<object>'",
+                path
+            ))),
+        }
+    }
+
+    pub fn from_prefix(prefix: impl AsRef<str>) -> Result<Self, FlameError> {
+        let prefix = prefix.as_ref();
+        let key = Self::from_path(prefix)?;
+        if key.object_id.is_some() {
+            return Err(FlameError::InvalidConfig(format!(
+                "invalid object key prefix '{}': expected '<app>/<session>'",
+                prefix
+            )));
+        }
+        Ok(key)
+    }
+
+    pub fn from_key(key: impl AsRef<str>) -> Result<Self, FlameError> {
+        let key = key.as_ref();
+        let object_key = Self::from_path(key)?;
+        if object_key.object_id.is_none() {
+            return Err(FlameError::InvalidConfig(format!(
+                "invalid object key '{}': expected '<app>/<session>/<object>'",
+                key
+            )));
+        }
+        Ok(object_key)
+    }
+
+    pub fn for_shared(app_name: impl Into<String>) -> Result<Self, FlameError> {
+        Self::prefix(app_name, "shared")
+    }
+
+    pub fn for_all_sessions(app_name: impl Into<String>) -> Result<Self, FlameError> {
+        Self::prefix(app_name, WILDCARD_SESSION)
+    }
+
+    pub fn is_all_sessions(&self) -> bool {
+        self.session_id == WILDCARD_SESSION
+    }
+
+    pub fn with_generated_id(&self) -> Result<Self, FlameError> {
+        if self.is_all_sessions() {
+            return Err(FlameError::InvalidConfig(
+                "wildcard session cannot have object_id".to_string(),
+            ));
+        }
+        Self::new(
+            self.app_name.clone(),
+            self.session_id.clone(),
+            Some(uuid::Uuid::new_v4().to_string()),
+        )
+    }
+
+    pub fn to_prefix(&self) -> String {
+        format!("{}/{}", self.app_name, self.session_id)
+    }
+
+    pub fn to_key(&self) -> Option<String> {
+        self.object_id
+            .as_ref()
+            .map(|object_id| format!("{}/{}/{}", self.app_name, self.session_id, object_id))
+    }
+
+    pub fn matches_key(&self, key: impl AsRef<str>) -> bool {
+        let key = key.as_ref();
+        if self.is_all_sessions() {
+            let prefix = format!("{}/", self.app_name);
+            if !key.starts_with(&prefix) {
+                return false;
+            }
+            let suffix = &key[prefix.len()..];
+            let Some((session_id, object_id)) = suffix.split_once('/') else {
+                return false;
+            };
+            return !session_id.is_empty() && !object_id.is_empty() && !object_id.contains('/');
+        }
+
+        if let Some(full_key) = self.to_key() {
+            return key == full_key;
+        }
+
+        let prefix = format!("{}/{}/", self.app_name, self.session_id);
+        if !key.starts_with(&prefix) {
+            return false;
+        }
+        let object_id = &key[prefix.len()..];
+        !object_id.is_empty() && !object_id.contains('/')
+    }
+
+    fn new(
+        app_name: String,
+        session_id: String,
+        object_id: Option<String>,
+    ) -> Result<Self, FlameError> {
+        validate_component("app_name", &app_name, false)?;
+        if app_name == WILDCARD_SESSION {
+            return Err(FlameError::InvalidConfig(
+                "wildcard '*' not allowed for app_name".to_string(),
+            ));
+        }
+
+        if session_id == WILDCARD_SESSION {
+            if object_id.is_some() {
+                return Err(FlameError::InvalidConfig(
+                    "wildcard session '*' cannot have object_id".to_string(),
+                ));
+            }
+        } else {
+            validate_component("session_id", &session_id, false)?;
+        }
+
+        if let Some(object_id) = object_id.as_deref() {
+            validate_component("object_id", object_id, true)?;
+        }
+
+        Ok(Self {
+            app_name,
+            session_id,
+            object_id,
+        })
+    }
+}
+
+impl Display for ObjectKey {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self.to_key() {
+            Some(key) => write!(f, "{key}"),
+            None => write!(f, "{}", self.to_prefix()),
+        }
+    }
+}
+
+#[derive(Clone, Debug, DeriveSerialize, Deserialize, Eq, PartialEq)]
+pub struct ObjectRef {
+    pub endpoint: String,
+    pub key: String,
+    pub version: u64,
+}
+
+impl ObjectRef {
+    pub fn new(
+        endpoint: impl Into<String>,
+        key: impl Into<String>,
+        version: u64,
+    ) -> Result<Self, FlameError> {
+        let reference = Self {
+            endpoint: endpoint.into(),
+            key: key.into(),
+            version,
+        };
+        ObjectKey::from_key(&reference.key)?;
+        Ok(reference)
+    }
+
+    pub fn encode(&self) -> Result<Bytes, FlameError> {
+        let mut bytes = Vec::new();
+        let version = i64::try_from(self.version).map_err(|_| {
+            FlameError::InvalidConfig(format!("object version too large: {}", self.version))
+        })?;
+        let doc = doc! {
+            "endpoint": &self.endpoint,
+            "key": &self.key,
+            "version": version,
+        };
+        doc.to_writer(&mut bytes)
+            .map_err(|e| FlameError::Internal(format!("failed to encode ObjectRef: {}", e)))?;
+        Ok(Bytes::from(bytes))
+    }
+
+    pub fn decode(data: impl AsRef<[u8]>) -> Result<Self, FlameError> {
+        let doc = Document::from_reader(Cursor::new(data.as_ref()))
+            .map_err(|e| FlameError::InvalidConfig(format!("failed to decode ObjectRef: {}", e)))?;
+        object_ref_from_doc(doc)
+    }
+
+    pub fn get<T>(&self) -> ObjectFuture<T>
+    where
+        T: FlameMessage + Send + 'static,
+    {
+        get_object(self.clone())
+    }
+}
+
+pub struct ObjectFuture<T> {
+    inner: ObjectFutureInner<T>,
+}
+
+impl<T> ObjectFuture<T> {
+    fn new(inner: impl Future<Output = Result<T, FlameError>> + Send + 'static) -> Self {
+        Self {
+            inner: Box::pin(inner),
+        }
+    }
+}
+
+impl<T> Future for ObjectFuture<T> {
+    type Output = Result<T, FlameError>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.inner.as_mut().poll(cx)
+    }
+}
+
+pub async fn put_object<T>(key_prefix: impl AsRef<str>, object: &T) -> Result<ObjectRef, FlameError>
+where
+    T: FlameMessage,
+{
+    let context = FlameContext::from_file_with_env(None)?;
+    put_object_with_context(&context, key_prefix, object).await
+}
+
+pub async fn put_object_with_context<T>(
+    context: &FlameContext,
+    key_prefix: impl AsRef<str>,
+    object: &T,
+) -> Result<ObjectRef, FlameError>
+where
+    T: FlameMessage,
+{
+    let bytes = object.encode()?;
+    put_encoded_object_with_context(context, key_prefix, bytes).await
+}
+
+async fn put_encoded_object_with_context(
+    context: &FlameContext,
+    key_prefix: impl AsRef<str>,
+    bytes: impl Into<Vec<u8>>,
+) -> Result<ObjectRef, FlameError> {
+    let object_key = ObjectKey::from_prefix(key_prefix.as_ref())?;
+    let cache = cache_from_context(context)?;
+    let descriptor = FlightDescriptor::new_path(vec![object_key.to_prefix()]);
+    do_put_bytes(
+        &cache.endpoint,
+        cache.tls.as_ref(),
+        descriptor,
+        bytes.into(),
+    )
+    .await
+}
+
+pub fn get_object<T>(reference: ObjectRef) -> ObjectFuture<T>
+where
+    T: FlameMessage + Send + 'static,
+{
+    ObjectFuture::new(async move {
+        let bytes = fetch_object_bytes(&reference).await?;
+        T::decode(&bytes)
+    })
+}
+
+pub async fn update_object<T>(reference: &ObjectRef, object: &T) -> Result<ObjectRef, FlameError>
+where
+    T: FlameMessage,
+{
+    let bytes = object.encode()?;
+    update_object_bytes(reference, bytes).await
+}
+
+async fn update_object_bytes(
+    reference: &ObjectRef,
+    bytes: impl Into<Vec<u8>>,
+) -> Result<ObjectRef, FlameError> {
+    ObjectKey::from_key(&reference.key)?;
+    let endpoint = CacheEndpoint::parse(&reference.endpoint)?;
+    let tls = current_cache_tls()?;
+    let descriptor = FlightDescriptor::new_path(vec![reference.key.clone()]);
+    do_put_bytes(&endpoint, tls.as_ref(), descriptor, bytes.into()).await
+}
+
+pub async fn patch_object<T>(reference: &ObjectRef, delta: &T) -> Result<ObjectRef, FlameError>
+where
+    T: FlameMessage,
+{
+    let bytes = delta.encode()?;
+    patch_object_bytes(reference, bytes).await
+}
+
+async fn patch_object_bytes(
+    reference: &ObjectRef,
+    bytes: impl Into<Vec<u8>>,
+) -> Result<ObjectRef, FlameError> {
+    ObjectKey::from_key(&reference.key)?;
+    let endpoint = CacheEndpoint::parse(&reference.endpoint)?;
+    let tls = current_cache_tls()?;
+    let descriptor = FlightDescriptor::new_cmd(format!("PATCH:{}", reference.key));
+    do_put_bytes(&endpoint, tls.as_ref(), descriptor, bytes.into()).await
+}
+
+pub async fn delete_objects(key_prefix: impl AsRef<str>) -> Result<(), FlameError> {
+    let object_key = ObjectKey::from_path(key_prefix.as_ref())?;
+    let context = FlameContext::from_file_with_env(None)?;
+    let cache = cache_from_context(&context)?;
+    let mut client = flight_client(connect_cache(&cache.endpoint, cache.tls.as_ref()).await?);
+    let results: Vec<_> = client
+        .do_action(Action::new("DELETE", object_key.to_string().into_bytes()))
+        .await
+        .map_err(|e| FlameError::Internal(format!("cache delete failed: {}", e)))?
+        .try_collect()
+        .await
+        .map_err(|e| FlameError::Internal(format!("cache delete failed: {}", e)))?;
+
+    if results.is_empty() {
+        return Err(FlameError::Internal(
+            "cache delete returned no result".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+pub async fn upload_object(
+    key_or_prefix: impl AsRef<str>,
+    file_path: impl AsRef<Path>,
+) -> Result<ObjectRef, FlameError> {
+    let context = FlameContext::from_file_with_env(None)?;
+    upload_object_with_context(&context, key_or_prefix, file_path).await
+}
+
+pub async fn upload_object_with_context(
+    context: &FlameContext,
+    key_or_prefix: impl AsRef<str>,
+    file_path: impl AsRef<Path>,
+) -> Result<ObjectRef, FlameError> {
+    let object_key = ObjectKey::from_path(key_or_prefix.as_ref())?;
+    if object_key.is_all_sessions() {
+        return Err(FlameError::InvalidConfig(format!(
+            "invalid object key path '{}'",
+            key_or_prefix.as_ref()
+        )));
+    }
+    let cache = cache_from_context(context)?;
+    let descriptor = FlightDescriptor::new_path(vec![object_key.to_string()]);
+    do_put_file(
+        &cache.endpoint,
+        cache.tls.as_ref(),
+        descriptor,
+        file_path.as_ref(),
+    )
+    .await
+}
+
+pub async fn download_object(
+    reference: &ObjectRef,
+    dest_path: impl AsRef<Path>,
+) -> Result<(), FlameError> {
+    ObjectKey::from_key(&reference.key)?;
+    let endpoint = CacheEndpoint::parse(&reference.endpoint)?;
+    let tls = current_cache_tls()?;
+    let mut client = flight_client(connect_cache(&endpoint, tls.as_ref()).await?);
+    let mut stream = client
+        .do_get(Ticket::new(format!("{}:0", reference.key)))
+        .await
+        .map_err(|e| FlameError::Internal(format!("cache download failed: {}", e)))?;
+
+    if let Some(parent) = dest_path.as_ref().parent() {
+        tokio::fs::create_dir_all(parent).await.map_err(|e| {
+            FlameError::Internal(format!(
+                "failed to create download directory {}: {}",
+                parent.display(),
+                e
+            ))
+        })?;
+    }
+
+    let temp_path = dest_path.as_ref().with_extension("tmp");
+    let mut file = tokio::fs::File::create(&temp_path).await.map_err(|e| {
+        FlameError::Internal(format!("failed to create {}: {}", temp_path.display(), e))
+    })?;
+    let mut total_size = 0usize;
+
+    while let Some(batch) = stream
+        .try_next()
+        .await
+        .map_err(|e| FlameError::Internal(format!("cache download failed: {}", e)))?
+    {
+        let data = data_column(&batch)?;
+        if let Some(kind) = kind_column(&batch)? {
+            for row in 0..batch.num_rows() {
+                match kind.value(row) {
+                    OBJECT_KIND_BASE => {
+                        let chunk = data.value(row);
+                        file.write_all(chunk).await.map_err(|e| {
+                            FlameError::Internal(format!("failed to write download chunk: {}", e))
+                        })?;
+                        total_size += chunk.len();
+                    }
+                    OBJECT_KIND_PATCH => {
+                        drop(file);
+                        tokio::fs::remove_file(&temp_path).await.ok();
+                        return Err(FlameError::InvalidConfig(format!(
+                            "object {} contains patch rows and cannot be downloaded as a file",
+                            reference.key
+                        )));
+                    }
+                    other => {
+                        drop(file);
+                        tokio::fs::remove_file(&temp_path).await.ok();
+                        return Err(FlameError::InvalidConfig(format!(
+                            "invalid object response kind '{}'",
+                            other
+                        )));
+                    }
+                }
+            }
+        } else {
+            for row in 0..batch.num_rows() {
+                let chunk = data.value(row);
+                file.write_all(chunk).await.map_err(|e| {
+                    FlameError::Internal(format!("failed to write download chunk: {}", e))
+                })?;
+                total_size += chunk.len();
+            }
+        }
+    }
+
+    if total_size == 0 {
+        tokio::fs::remove_file(&temp_path).await.ok();
+        return Err(FlameError::NotFound(reference.key.clone()));
+    }
+
+    file.sync_all()
+        .await
+        .map_err(|e| FlameError::Internal(format!("failed to sync download: {}", e)))?;
+    drop(file);
+    tokio::fs::rename(&temp_path, dest_path.as_ref())
+        .await
+        .map_err(|e| FlameError::Internal(format!("failed to finish download: {}", e)))?;
+    Ok(())
+}
+
+#[derive(Debug, Clone)]
+struct CacheConfig {
+    endpoint: CacheEndpoint,
+    tls: Option<FlameClientTls>,
+}
+
+#[derive(Debug, Clone)]
+struct CacheEndpoint {
+    scheme: String,
+    host: String,
+    port: u16,
+}
+
+impl CacheEndpoint {
+    fn parse(raw: &str) -> Result<Self, FlameError> {
+        let parsed = Url::parse(raw)
+            .map_err(|e| FlameError::InvalidConfig(format!("invalid cache endpoint: {}", e)))?;
+        let scheme = match parsed.scheme() {
+            "grpc" => "grpc",
+            "grpcs" | "grpc+tls" => "grpcs",
+            scheme => {
+                return Err(FlameError::InvalidConfig(format!(
+                    "unsupported cache endpoint scheme <{}>; expected grpc, grpcs, or grpc+tls",
+                    scheme
+                )));
+            }
+        }
+        .to_string();
+        let host = parsed
+            .host_str()
+            .ok_or_else(|| FlameError::InvalidConfig("cache endpoint missing host".to_string()))?
+            .to_string();
+        let port = parsed.port().unwrap_or(DEFAULT_CACHE_PORT);
+        Ok(Self { scheme, host, port })
+    }
+}
+
+fn validate_component(name: &str, value: &str, reject_wildcard: bool) -> Result<(), FlameError> {
+    if value.is_empty() {
+        return Err(FlameError::InvalidConfig(format!("{name} cannot be empty")));
+    }
+    if value.contains("..") || value.contains('\\') || value.contains('/') {
+        return Err(FlameError::InvalidConfig(format!(
+            "{name} contains invalid characters: '{}'",
+            value
+        )));
+    }
+    if reject_wildcard && value == WILDCARD_SESSION {
+        return Err(FlameError::InvalidConfig(format!(
+            "wildcard '*' not allowed for {name}"
+        )));
+    }
+    Ok(())
+}
+
+fn cache_from_context(context: &FlameContext) -> Result<CacheConfig, FlameError> {
+    let current = context.get_current_context()?;
+    let cache = current
+        .cache
+        .as_ref()
+        .ok_or_else(|| FlameError::InvalidConfig("cache configuration not found".to_string()))?;
+    let endpoint = cache_endpoint(cache)?;
+    Ok(CacheConfig {
+        endpoint,
+        tls: cache.tls.clone(),
+    })
+}
+
+fn cache_endpoint(cache: &FlameClientCache) -> Result<CacheEndpoint, FlameError> {
+    let endpoint = cache
+        .endpoint
+        .as_deref()
+        .ok_or_else(|| FlameError::InvalidConfig("cache endpoint not configured".to_string()))?;
+    CacheEndpoint::parse(endpoint)
+}
+
+fn current_cache_tls() -> Result<Option<FlameClientTls>, FlameError> {
+    let Ok(context) = FlameContext::from_file_with_env(None) else {
+        return Ok(None);
+    };
+    Ok(context
+        .get_current_context()
+        .ok()
+        .and_then(|current| current.cache.as_ref())
+        .and_then(|cache| cache.tls.clone()))
+}
+
+async fn connect_cache(
+    endpoint: &CacheEndpoint,
+    tls: Option<&FlameClientTls>,
+) -> Result<Channel, FlameError> {
+    let transport_endpoint = if endpoint.scheme == "grpcs" {
+        format!("https://{}:{}", endpoint.host, endpoint.port)
+    } else {
+        format!("http://{}:{}", endpoint.host, endpoint.port)
+    };
+
+    let mut builder = Channel::from_shared(transport_endpoint)
+        .map_err(|e| FlameError::Internal(format!("invalid cache endpoint: {}", e)))?
+        .connect_timeout(Duration::from_secs(CONNECT_TIMEOUT_SECS));
+
+    if endpoint.scheme == "grpcs" {
+        if let Some(tls) = tls {
+            builder = builder
+                .tls_config(tls.client_tls_config(&endpoint.host)?)
+                .map_err(|e| FlameError::Internal(format!("cache TLS config error: {}", e)))?;
+        }
+    }
+
+    builder
+        .connect()
+        .await
+        .map_err(|e| FlameError::Internal(format!("failed to connect to object cache: {}", e)))
+}
+
+fn flight_client(channel: Channel) -> FlightClient {
+    let inner = FlightServiceClient::new(channel)
+        .max_decoding_message_size(FLIGHT_MAX_MESSAGE_SIZE)
+        .max_encoding_message_size(FLIGHT_MAX_MESSAGE_SIZE);
+    FlightClient::new_from_inner(inner)
+}
+
+async fn do_put_bytes(
+    endpoint: &CacheEndpoint,
+    tls: Option<&FlameClientTls>,
+    descriptor: FlightDescriptor,
+    bytes: Vec<u8>,
+) -> Result<ObjectRef, FlameError> {
+    let schema = object_schema();
+    let batch = object_record_batch(schema.clone(), bytes)
+        .map_err(|e| FlameError::Internal(format!("failed to create object batch: {}", e)))?;
+    let stream = stream::iter(vec![Ok::<RecordBatch, FlightError>(batch)]);
+    do_put_batches(endpoint, tls, descriptor, schema, stream).await
+}
+
+async fn do_put_file(
+    endpoint: &CacheEndpoint,
+    tls: Option<&FlameClientTls>,
+    descriptor: FlightDescriptor,
+    path: &Path,
+) -> Result<ObjectRef, FlameError> {
+    let file = tokio::fs::File::open(path).await.map_err(|e| {
+        FlameError::InvalidConfig(format!("failed to open {}: {}", path.display(), e))
+    })?;
+    let schema = object_schema();
+    let schema_for_stream = schema.clone();
+    let stream = stream::try_unfold((file, schema_for_stream), |(mut file, schema)| async move {
+        let mut chunk = vec![0_u8; UPLOAD_CHUNK_SIZE];
+        let read = file.read(&mut chunk).await.map_err(|e| {
+            FlightError::from_external_error(Box::new(std::io::Error::new(
+                e.kind(),
+                format!("failed to read object chunk: {}", e),
+            )))
+        })?;
+        if read == 0 {
+            return Ok(None);
+        }
+        chunk.truncate(read);
+        let batch = object_record_batch(schema.clone(), chunk)?;
+        Ok(Some((batch, (file, schema))))
+    });
+    do_put_batches(endpoint, tls, descriptor, schema, stream).await
+}
+
+async fn do_put_batches<S>(
+    endpoint: &CacheEndpoint,
+    tls: Option<&FlameClientTls>,
+    descriptor: FlightDescriptor,
+    schema: Arc<Schema>,
+    batches: S,
+) -> Result<ObjectRef, FlameError>
+where
+    S: futures::Stream<Item = Result<RecordBatch, FlightError>> + Send + 'static,
+{
+    let channel = connect_cache(endpoint, tls).await?;
+    let mut client = flight_client(channel);
+    let flight_data = FlightDataEncoderBuilder::new()
+        .with_schema(schema)
+        .with_flight_descriptor(Some(descriptor))
+        .build(batches);
+
+    let results: Vec<_> = client
+        .do_put(flight_data)
+        .await
+        .map_err(|e| FlameError::Internal(format!("cache upload failed: {}", e)))?
+        .try_collect()
+        .await
+        .map_err(|e| FlameError::Internal(format!("cache upload failed: {}", e)))?;
+    let result = results
+        .into_iter()
+        .next()
+        .ok_or_else(|| FlameError::Internal("cache upload returned no result".to_string()))?;
+    ObjectRef::decode(result.app_metadata)
+}
+
+async fn fetch_object_bytes(reference: &ObjectRef) -> Result<Vec<u8>, FlameError> {
+    ObjectKey::from_key(&reference.key)?;
+    let endpoint = CacheEndpoint::parse(&reference.endpoint)?;
+    let tls = current_cache_tls()?;
+    let mut client = flight_client(connect_cache(&endpoint, tls.as_ref()).await?);
+    let mut stream = client
+        .do_get(Ticket::new(format!("{}:0", reference.key)))
+        .await
+        .map_err(|e| FlameError::Internal(format!("cache get failed: {}", e)))?;
+
+    let mut base = Vec::new();
+    let mut found_base = false;
+    while let Some(batch) = stream
+        .try_next()
+        .await
+        .map_err(|e| FlameError::Internal(format!("cache get failed: {}", e)))?
+    {
+        if batch.num_rows() == 0 {
+            continue;
+        }
+        let data = data_column(&batch)?;
+        if let Some(kind) = kind_column(&batch)? {
+            for row in 0..batch.num_rows() {
+                match kind.value(row) {
+                    OBJECT_KIND_BASE => {
+                        base.extend_from_slice(data.value(row));
+                        found_base = true;
+                    }
+                    OBJECT_KIND_PATCH => {}
+                    other => {
+                        return Err(FlameError::InvalidConfig(format!(
+                            "invalid object response kind '{}'",
+                            other
+                        )))
+                    }
+                }
+            }
+        } else {
+            for row in 0..batch.num_rows() {
+                base.extend_from_slice(data.value(row));
+                found_base = true;
+            }
+        }
+    }
+
+    if found_base {
+        Ok(base)
+    } else {
+        Err(FlameError::NotFound(reference.key.clone()))
+    }
+}
+
+fn object_schema() -> Arc<Schema> {
+    Arc::new(Schema::new(vec![
+        Field::new(OBJECT_FIELD_VERSION, DataType::UInt64, false),
+        Field::new(OBJECT_FIELD_DATA, DataType::Binary, false),
+    ]))
+}
+
+fn object_record_batch(
+    schema: Arc<Schema>,
+    bytes: Vec<u8>,
+) -> arrow_flight::error::Result<RecordBatch> {
+    let version_array = UInt64Array::from(vec![0_u64]);
+    let data_array = BinaryArray::from(vec![bytes.as_slice()]);
+    RecordBatch::try_new(schema, vec![Arc::new(version_array), Arc::new(data_array)])
+        .map_err(FlightError::from)
+}
+
+fn data_column(batch: &RecordBatch) -> Result<&BinaryArray, FlameError> {
+    let array = batch.column_by_name(OBJECT_FIELD_DATA).ok_or_else(|| {
+        FlameError::InvalidConfig("object response missing data column".to_string())
+    })?;
+    array
+        .as_any()
+        .downcast_ref::<BinaryArray>()
+        .ok_or_else(|| FlameError::InvalidConfig("invalid object data column".to_string()))
+}
+
+fn kind_column(batch: &RecordBatch) -> Result<Option<&StringArray>, FlameError> {
+    let Some(array) = batch.column_by_name(OBJECT_FIELD_KIND) else {
+        return Ok(None);
+    };
+    Ok(Some(
+        array
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .ok_or_else(|| FlameError::InvalidConfig("invalid object kind column".to_string()))?,
+    ))
+}
+
+fn object_ref_from_doc(doc: Document) -> Result<ObjectRef, FlameError> {
+    let endpoint = doc
+        .get_str("endpoint")
+        .map_err(|e| FlameError::InvalidConfig(format!("ObjectRef missing endpoint: {}", e)))?
+        .to_string();
+    let key = doc
+        .get_str("key")
+        .map_err(|e| FlameError::InvalidConfig(format!("ObjectRef missing key: {}", e)))?
+        .to_string();
+    let version = match doc.get("version") {
+        Some(Bson::Int64(value)) if *value >= 0 => *value as u64,
+        Some(Bson::Int32(value)) if *value >= 0 => *value as u64,
+        Some(other) => {
+            return Err(FlameError::InvalidConfig(format!(
+                "invalid ObjectRef version: {}",
+                other
+            )))
+        }
+        None => 0,
+    };
+    ObjectRef::new(endpoint, key, version)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug, DeriveSerialize, Deserialize, PartialEq)]
+    struct SampleObject {
+        name: String,
+        count: u32,
+    }
+
+    impl FlameMessage for SampleObject {
+        fn encode(&self) -> Result<Bytes, FlameError> {
+            serde_json::to_vec(self)
+                .map(Bytes::from)
+                .map_err(|e| FlameError::Internal(e.to_string()))
+        }
+
+        fn decode(bytes: &[u8]) -> Result<Self, FlameError> {
+            serde_json::from_slice(bytes).map_err(|e| FlameError::InvalidConfig(e.to_string()))
+        }
+    }
+
+    #[test]
+    fn object_key_parses_prefix_and_full_key() {
+        let prefix = ObjectKey::from_prefix("app/session").unwrap();
+        assert_eq!(prefix.app_name, "app");
+        assert_eq!(prefix.session_id, "session");
+        assert_eq!(prefix.object_id, None);
+        assert_eq!(prefix.to_string(), "app/session");
+        assert!(prefix.matches_key("app/session/object"));
+        assert!(!prefix.matches_key("app/other/object"));
+
+        let full = ObjectKey::from_key("app/session/object").unwrap();
+        assert_eq!(full.object_id.as_deref(), Some("object"));
+        assert_eq!(full.to_string(), "app/session/object");
+        assert!(full.matches_key("app/session/object"));
+        assert!(!full.matches_key("app/session/other"));
+    }
+
+    #[test]
+    fn object_key_rejects_unsafe_components() {
+        assert!(ObjectKey::from_path("../session").is_err());
+        assert!(ObjectKey::from_path("app/session/").is_err());
+        assert!(ObjectKey::from_path("app/*/object").is_err());
+        assert!(ObjectKey::from_path("*/session").is_err());
+    }
+
+    #[test]
+    fn object_key_supports_shared_and_wildcard_helpers() {
+        let shared = ObjectKey::for_shared("app").unwrap();
+        assert_eq!(shared.to_string(), "app/shared");
+
+        let wildcard = ObjectKey::for_all_sessions("app").unwrap();
+        assert!(wildcard.is_all_sessions());
+        assert!(wildcard.matches_key("app/session/object"));
+        assert!(!wildcard.matches_key("other/session/object"));
+        assert!(wildcard.with_generated_id().is_err());
+    }
+
+    #[test]
+    fn object_ref_encodes_bson() {
+        let reference = ObjectRef::new("grpc://cache:9090", "app/session/object", 7).unwrap();
+        let encoded = reference.encode().unwrap();
+        let decoded = ObjectRef::decode(encoded).unwrap();
+        assert_eq!(decoded, reference);
+    }
+
+    #[test]
+    fn cache_endpoint_accepts_grpc_tls_alias() {
+        let endpoint = CacheEndpoint::parse("grpc+tls://cache.example.com:9443").unwrap();
+        assert_eq!(endpoint.scheme, "grpcs");
+        assert_eq!(endpoint.host, "cache.example.com");
+        assert_eq!(endpoint.port, 9443);
+    }
+
+    #[test]
+    fn typed_object_uses_flame_message_codec() {
+        let object = SampleObject {
+            name: "demo".to_string(),
+            count: 42,
+        };
+        let bytes = object.encode().unwrap();
+        let decoded = SampleObject::decode(&bytes).unwrap();
+        assert_eq!(decoded, object);
+    }
+
+    #[tokio::test]
+    async fn object_future_polls_inner_future() {
+        let value = ObjectFuture::new(async { Ok::<_, FlameError>(42_u32) })
+            .await
+            .unwrap();
+        assert_eq!(value, 42);
+    }
+}


### PR DESCRIPTION
## Summary

- add RFE458 design and `flmctl deploy` for packaging directory, tarball, or executable-file applications
- add Rust SDK object helpers and object-cache wire integration coverage
- add binary installer support and URL-aware application release installs
- add the Candle Based Rust example under `examples/candle/based`

## Notes

Executable-file deploys create `<app>.tar.gz` locally with `bin/<binary>` inside, then upload it under a three-component object key like `<app>/pkg/<app>-<sha16>.tar.gz` to match FlamePy/object-cache rules.

Host-built example binaries were intentionally not committed.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p flmctl deploy`
- `cargo test -p flame-rs object --lib`
- `cargo test -p flame-executor-manager binary`
- `cargo test -p flame-object-cache flame_rs_` with local-port permission
- `cargo check -p flmctl`
- `cargo check -p flame-rs`
- `cargo check -p flame-executor-manager`
- `git diff --check`
