### PR TITLE
[codex] polish delay release output

### DIFF
--- a/flmctl/src/deploy.rs
+++ b/flmctl/src/deploy.rs
@@ -29,6 +29,8 @@ use url::Url;
 use artifact::{prepare_application, PreparedApplication};
 use detect::{detect_application, DetectedApplication};
 
+use crate::utils::format_duration;
+
 #[derive(Debug, Clone, Args)]
 pub struct Options {
     /// Application name.
@@ -416,6 +418,12 @@ fn print_result(output: &str, result: &DeployResult) -> Result<(), FlameError> {
             println!("Input Kind: {}", result.input_kind);
             println!("Installer: {}", result.installer);
             println!("Command: {}", result.command);
+            if let Some(delay_release) = result.application.spec.delay_release {
+                println!(
+                    "Delay Release: {}",
+                    format_duration(Duration::seconds(delay_release))
+                );
+            }
             if !result.arguments.is_empty() {
                 println!("Arguments: {}", result.arguments.join(" "));
             }

--- a/flmctl/src/utils.rs
+++ b/flmctl/src/utils.rs
@@ -49,13 +49,9 @@ pub fn format_resreq(r: &Option<ResourceRequirement>) -> String {
 
 /// Formats a duration as compact CLI output such as `45s` or `1h 5m`.
 pub fn format_duration(duration: Duration) -> String {
-    let mut seconds = duration.num_seconds();
-    let sign = if seconds < 0 {
-        seconds = seconds.saturating_abs();
-        "-"
-    } else {
-        ""
-    };
+    let seconds_raw = duration.num_seconds();
+    let sign = if seconds_raw < 0 { "-" } else { "" };
+    let mut seconds = seconds_raw.unsigned_abs();
 
     let days = seconds / 86_400;
     seconds %= 86_400;
@@ -79,6 +75,14 @@ pub fn format_duration(duration: Duration) -> String {
     }
 
     format!("{sign}{}", parts.join(" "))
+}
+
+/// Formats an optional duration, using `-` for unset values.
+pub fn format_optional_duration(duration: &Option<Duration>) -> String {
+    match duration {
+        Some(duration) => format_duration(*duration),
+        None => "-".to_string(),
+    }
 }
 
 #[cfg(test)]
@@ -131,5 +135,15 @@ mod tests {
     #[test]
     fn format_duration_negative() {
         assert_eq!(format_duration(Duration::seconds(-65)), "-1m 5s");
+    }
+
+    #[test]
+    fn format_optional_duration_some() {
+        assert_eq!(format_optional_duration(&Some(Duration::seconds(60))), "1m");
+    }
+
+    #[test]
+    fn format_optional_duration_none_renders_dash() {
+        assert_eq!(format_optional_duration(&None), "-");
     }
 }

--- a/flmctl/src/utils.rs
+++ b/flmctl/src/utils.rs
@@ -11,6 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use chrono::Duration;
 use flame_rs::client::ResourceRequirement;
 
 /// Formats a byte count into a human-readable string with appropriate unit suffix.
@@ -46,6 +47,40 @@ pub fn format_resreq(r: &Option<ResourceRequirement>) -> String {
     }
 }
 
+/// Formats a duration as compact CLI output such as `45s` or `1h 5m`.
+pub fn format_duration(duration: Duration) -> String {
+    let mut seconds = duration.num_seconds();
+    let sign = if seconds < 0 {
+        seconds = seconds.saturating_abs();
+        "-"
+    } else {
+        ""
+    };
+
+    let days = seconds / 86_400;
+    seconds %= 86_400;
+    let hours = seconds / 3_600;
+    seconds %= 3_600;
+    let minutes = seconds / 60;
+    seconds %= 60;
+
+    let mut parts = Vec::new();
+    if days > 0 {
+        parts.push(format!("{days}d"));
+    }
+    if hours > 0 {
+        parts.push(format!("{hours}h"));
+    }
+    if minutes > 0 {
+        parts.push(format!("{minutes}m"));
+    }
+    if seconds > 0 || parts.is_empty() {
+        parts.push(format!("{seconds}s"));
+    }
+
+    format!("{sign}{}", parts.join(" "))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -73,5 +108,28 @@ mod tests {
             gpu: 0,
         };
         assert_eq!(format_resreq(&Some(rr)), "cpu=0,mem=0B,gpu=0");
+    }
+
+    #[test]
+    fn format_duration_seconds() {
+        assert_eq!(format_duration(Duration::seconds(60)), "1m");
+    }
+
+    #[test]
+    fn format_duration_compound_values() {
+        assert_eq!(
+            format_duration(Duration::seconds(86_400 + 3_600 + 120 + 3)),
+            "1d 1h 2m 3s"
+        );
+    }
+
+    #[test]
+    fn format_duration_zero() {
+        assert_eq!(format_duration(Duration::zero()), "0s");
+    }
+
+    #[test]
+    fn format_duration_negative() {
+        assert_eq!(format_duration(Duration::seconds(-65)), "-1m 5s");
     }
 }

--- a/flmctl/src/view.rs
+++ b/flmctl/src/view.rs
@@ -20,7 +20,7 @@ use serde_json::Value;
 use flame_rs::apis::{FlameContext, FlameError, TaskState};
 use flame_rs::client::{self, NodeState};
 
-use crate::utils::{format_duration, format_memory, format_resreq};
+use crate::utils::{format_memory, format_optional_duration, format_resreq};
 
 pub async fn run(
     ctx: &FlameContext,
@@ -195,7 +195,7 @@ async fn view_application(
     println!(
         "{:<15}{}",
         "Delay Release:",
-        format_duration(application.attributes.delay_release.unwrap_or_default())
+        format_optional_duration(&application.attributes.delay_release)
     );
 
     println!("{:<15}", "Schema:");

--- a/flmctl/src/view.rs
+++ b/flmctl/src/view.rs
@@ -20,7 +20,7 @@ use serde_json::Value;
 use flame_rs::apis::{FlameContext, FlameError, TaskState};
 use flame_rs::client::{self, NodeState};
 
-use crate::utils::{format_memory, format_resreq};
+use crate::utils::{format_duration, format_memory, format_resreq};
 
 pub async fn run(
     ctx: &FlameContext,
@@ -195,7 +195,7 @@ async fn view_application(
     println!(
         "{:<15}{}",
         "Delay Release:",
-        application.attributes.delay_release.unwrap_or_default()
+        format_duration(application.attributes.delay_release.unwrap_or_default())
     );
 
     println!("{:<15}", "Schema:");

--- a/flmctl/tests/deploy_cli.rs
+++ b/flmctl/tests/deploy_cli.rs
@@ -80,6 +80,39 @@ fn deploy_dry_run_python_directory_through_cli() {
     );
 }
 
+#[test]
+fn deploy_dry_run_summary_formats_delay_release() {
+    let temp = TempDir::new().unwrap();
+    let config = write_config(temp.path());
+    let binary = temp.path().join("service");
+    fs::write(&binary, b"#!/bin/sh\nexec echo service\n").unwrap();
+    make_executable(&binary);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_flmctl"))
+        .arg("--config")
+        .arg(config)
+        .arg("deploy")
+        .arg("--name")
+        .arg("demo-app")
+        .arg("--application")
+        .arg(binary)
+        .arg("--delay-release")
+        .arg("60")
+        .arg("--dry-run")
+        .env_remove("FLAME_ENDPOINT")
+        .env_remove("FLAME_CACHE_ENDPOINT")
+        .env_remove("FLAME_CA_FILE")
+        .output()
+        .unwrap();
+
+    let stdout = assert_success_stdout(output);
+    assert!(
+        stdout.contains("Delay Release: 1m"),
+        "summary should format delay release for humans\nstdout:\n{}",
+        stdout
+    );
+}
+
 fn run_deploy_json(config: &Path, application: &Path, name: &str) -> Value {
     let output = Command::new(env!("CARGO_BIN_EXE_flmctl"))
         .arg("--config")
@@ -98,6 +131,18 @@ fn run_deploy_json(config: &Path, application: &Path, name: &str) -> Value {
         .output()
         .unwrap();
     assert_success(output)
+}
+
+fn assert_success_stdout(output: Output) -> String {
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "flmctl deploy failed\nstdout:\n{}\nstderr:\n{}",
+        stdout,
+        stderr
+    );
+    stdout
 }
 
 fn assert_success(output: Output) -> Value {


### PR DESCRIPTION
## Summary

- Add a shared `flmctl` duration formatter for compact human-readable CLI output.
- Use it for `flmctl view -a <app>` so delay release prints as values like `1m` instead of `PT60S`.
- Include formatted delay release in `flmctl deploy --dry-run` summary output while preserving seconds in JSON/YAML output.

## Root Cause

`flmctl view` was printing `chrono::Duration` directly, which renders in an ISO-8601-like form such as `PT60S`. That is correct structurally but awkward for CLI output.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p flmctl format_duration`
- `cargo test -p flmctl deploy_dry_run_summary_formats_delay_release`
- `cargo test -p flmctl`
- `cargo clippy -p flmctl --all-targets -- -D warnings`
- `git diff --check`
