### PR TITLE
Fix Runner packaging for ad hoc scripts

### DIFF
--- a/e2e/tests/test_flmexec.py
+++ b/e2e/tests/test_flmexec.py
@@ -17,7 +17,8 @@ import textwrap
 import flamepy
 import pytest
 
-RESULT_PREFIX = "FLMEXEC_RUNNER_NUMPY_RESULT="
+NODEPS_RESULT_PREFIX = "FLMEXEC_RUNNER_NODEPS_RESULT="
+NUMPY_RESULT_PREFIX = "FLMEXEC_RUNNER_NUMPY_RESULT="
 
 
 @pytest.fixture(scope="module")
@@ -37,6 +38,55 @@ def check_flmexec_runner_environment():
             pytest.skip("flmrun application is not registered")
     except Exception as exc:
         pytest.skip(f"Flame cluster is not available: {exc}")
+
+
+def _invoke_flmexec_python(script: str) -> str:
+    session = flamepy.create_session("flmexec")
+    try:
+        request = {"language": "python", "code": script, "input": None}
+        raw_response = session.invoke(json.dumps(request).encode("utf-8"))
+    finally:
+        session.close()
+
+    response = json.loads(raw_response.decode("utf-8"))
+    return bytes(response["data"]).decode("utf-8")
+
+
+@pytest.mark.timeout(600)
+def test_flmexec_python_script_starts_runner_without_project_metadata(check_flmexec_runner_environment):
+    script = textwrap.dedent(
+        f"""
+        import json
+        import sys
+        import traceback
+        import uuid
+
+        try:
+            from flamepy.runner import Runner
+
+            def test_fn(x):
+                return x * x
+
+            app_name = f"test-flmexec-runner-nodeps-{{uuid.uuid4().hex[:8]}}"
+
+            with Runner(app_name) as rr:
+                service = rr.service(test_fn)
+                result = rr.get([service(10), service(20)])
+
+            print("{NODEPS_RESULT_PREFIX}" + json.dumps(result))
+        except BaseException:
+            traceback.print_exc(file=sys.stdout)
+            sys.stdout.flush()
+            raise
+        """
+    )
+
+    output = _invoke_flmexec_python(script)
+    result_line = next((line for line in output.splitlines() if line.startswith(NODEPS_RESULT_PREFIX)), None)
+    assert result_line is not None, f"missing result line in flmexec output:\n{output}"
+
+    result = json.loads(result_line.removeprefix(NODEPS_RESULT_PREFIX))
+    assert result == [100, 400]
 
 
 @pytest.mark.timeout(600)
@@ -67,7 +117,7 @@ def test_flmexec_python_script_starts_runner_with_numpy_dependency(check_flmexec
                 service = rr.service(numpy_summary)
                 result = service(5).get()
 
-            print("{RESULT_PREFIX}" + json.dumps(result, sort_keys=True))
+            print("{NUMPY_RESULT_PREFIX}" + json.dumps(result, sort_keys=True))
         except BaseException:
             traceback.print_exc(file=sys.stdout)
             sys.stdout.flush()
@@ -75,17 +125,9 @@ def test_flmexec_python_script_starts_runner_with_numpy_dependency(check_flmexec
         """
     )
 
-    session = flamepy.create_session("flmexec")
-    try:
-        request = {"language": "python", "code": script, "input": None}
-        raw_response = session.invoke(json.dumps(request).encode("utf-8"))
-    finally:
-        session.close()
-
-    response = json.loads(raw_response.decode("utf-8"))
-    output = bytes(response["data"]).decode("utf-8")
-    result_line = next((line for line in output.splitlines() if line.startswith(RESULT_PREFIX)), None)
+    output = _invoke_flmexec_python(script)
+    result_line = next((line for line in output.splitlines() if line.startswith(NUMPY_RESULT_PREFIX)), None)
     assert result_line is not None, f"missing result line in flmexec output:\n{output}"
 
-    result = json.loads(result_line.removeprefix(RESULT_PREFIX))
+    result = json.loads(result_line.removeprefix(NUMPY_RESULT_PREFIX))
     assert result == {"dtype": "int64", "shape": [5], "sum": 15}

--- a/sdk/python/src/flamepy/runner/runner.py
+++ b/sdk/python/src/flamepy/runner/runner.py
@@ -741,6 +741,7 @@ class Runner:
                     data = generated_pyproject.encode("utf-8")
                     tarinfo = tarfile.TarInfo("pyproject.toml")
                     tarinfo.size = len(data)
+                    tarinfo.mode = 0o644
                     tar.addfile(tarinfo, io.BytesIO(data))
 
             logger.debug(f"Created package: {package_path}")
@@ -764,8 +765,15 @@ class Runner:
             return None
 
         has_legacy_metadata = os.path.exists(os.path.join(cwd, "setup.py")) or os.path.exists(os.path.join(cwd, "setup.cfg"))
-        if has_legacy_metadata and not self._dependencies:
-            logger.debug("Python package metadata already exists, skipping generated metadata")
+        if has_legacy_metadata:
+            if self._dependencies:
+                logger.warning(
+                    "Python package metadata (setup.py/setup.cfg) already exists. "
+                    "Skipping pyproject.toml generation to avoid conflicting with existing metadata. "
+                    "Please specify dependencies in your setup.py or setup.cfg."
+                )
+            else:
+                logger.debug("Python package metadata already exists, skipping generated metadata")
             return None
 
         deps = sorted(self._dependencies or [])

--- a/sdk/python/src/flamepy/runner/runner.py
+++ b/sdk/python/src/flamepy/runner/runner.py
@@ -12,6 +12,7 @@ limitations under the License.
 """
 
 import inspect
+import io
 import logging
 import os
 import tarfile
@@ -694,7 +695,7 @@ class Runner:
         # Create dist directory if it doesn't exist
         os.makedirs(dist_dir, exist_ok=True)
 
-        self._generate_pyproject_toml()
+        generated_pyproject = self._generated_pyproject_toml(cwd)
 
         package_filename = f"{self._name}.tar.gz"
         package_path = os.path.join(dist_dir, package_filename)
@@ -736,6 +737,12 @@ class Runner:
                     item_path = os.path.join(cwd, item)
                     tar.add(item_path, arcname=item, recursive=True, filter=lambda tarinfo: None if self._should_exclude(tarinfo.name, excludes) else tarinfo)
 
+                if generated_pyproject is not None:
+                    data = generated_pyproject.encode("utf-8")
+                    tarinfo = tarfile.TarInfo("pyproject.toml")
+                    tarinfo.size = len(data)
+                    tar.addfile(tarinfo, io.BytesIO(data))
+
             logger.debug(f"Created package: {package_path}")
             return package_path
 
@@ -750,36 +757,39 @@ class Runner:
                 return True
         return False
 
-    def _generate_pyproject_toml(self) -> None:
-        """Generate pyproject.toml if dependencies are specified and no pyproject.toml exists."""
-        cwd = os.getcwd()
-        pyproject_path = os.path.join(cwd, "pyproject.toml")
+    def _generated_pyproject_toml(self, cwd: str) -> Optional[str]:
+        """Return generated package metadata when the source tree needs it."""
+        if os.path.exists(os.path.join(cwd, "pyproject.toml")):
+            logger.debug("pyproject.toml already exists, skipping generated metadata")
+            return None
 
-        if os.path.exists(pyproject_path):
-            logger.debug("pyproject.toml already exists, skipping generation")
-            return
+        has_legacy_metadata = os.path.exists(os.path.join(cwd, "setup.py")) or os.path.exists(os.path.join(cwd, "setup.cfg"))
+        if has_legacy_metadata and not self._dependencies:
+            logger.debug("Python package metadata already exists, skipping generated metadata")
+            return None
 
-        if not self._dependencies:
-            logger.debug("No dependencies specified and no pyproject.toml found")
-            return
+        deps = sorted(self._dependencies or [])
+        if deps:
+            deps_block = "dependencies = [\n    " + ",\n    ".join(f'"{dep}"' for dep in deps) + ",\n]"
+        else:
+            deps_block = "dependencies = []"
 
-        deps_str = ",\n    ".join(f'"{dep}"' for dep in sorted(self._dependencies))
+        content = f'''[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
 
-        content = f'''[project]
+[project]
 name = "{self._name}"
 version = "0.1.0"
 requires-python = ">=3.9"
-dependencies = [
-    {deps_str},
-]
+{deps_block}
+
+[tool.setuptools]
+py-modules = []
 '''
 
-        try:
-            with open(pyproject_path, "w") as f:
-                f.write(content)
-            logger.info(f"Generated pyproject.toml with dependencies: {list(self._dependencies)}")
-        except Exception as e:
-            logger.error(f"Failed to generate pyproject.toml: {e}")
+        logger.info(f"Generated package pyproject.toml with dependencies: {deps}")
+        return content
 
     def _upload_package(self) -> str:
         """Upload the package to the storage location.

--- a/sdk/python/tests/test_runner.py
+++ b/sdk/python/tests/test_runner.py
@@ -1,6 +1,9 @@
 """Tests for flamepy runner APIs."""
 
+import sys
+import tarfile
 from concurrent.futures import Future
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -9,6 +12,15 @@ from flamepy.runner.storage import CacheStorage, FileStorage, create_storage_bac
 from flamepy.runner.types import RunnerContext, RunnerRequest, SessionContext
 
 # Runner Storage Tests
+
+
+def _parse_toml(content: str):
+    if sys.version_info < (3, 11):
+        return None
+
+    import tomllib
+
+    return tomllib.loads(content)
 
 
 def test_file_storage_basic(tmp_path):
@@ -223,6 +235,62 @@ def test_runner_should_exclude_handles_nested_paths():
 
     assert runner._should_exclude("src/__pycache__/module.pyc", ["*.pyc"])
     assert runner._should_exclude("tests/data/file.tmp", ["*.tmp"])
+
+
+def test_runner_package_generates_metadata_without_dependencies(tmp_path, monkeypatch):
+    """Runner packages ad hoc script directories as installable Python projects."""
+    from flamepy.runner.runner import Runner
+
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "script.py").write_text("def test_fn(x):\n    return x * x\n")
+
+    runner = object.__new__(Runner)
+    runner._name = "test-run"
+    runner._dependencies = None
+    runner._context = SimpleNamespace(package=None)
+
+    package_path = runner._create_package()
+
+    assert not (tmp_path / "pyproject.toml").exists()
+    with tarfile.open(package_path, "r:gz") as package:
+        pyproject = package.extractfile("pyproject.toml")
+        assert pyproject is not None
+        content = pyproject.read().decode("utf-8")
+
+    assert 'name = "test-run"' in content
+    assert "dependencies = []" in content
+    assert "py-modules = []" in content
+    parsed = _parse_toml(content)
+    if parsed is not None:
+        assert parsed["project"]["dependencies"] == []
+
+
+def test_runner_package_generates_dependency_metadata_in_archive(tmp_path, monkeypatch):
+    """Generated dependency metadata is packaged without mutating the caller cwd."""
+    from flamepy.runner.runner import Runner
+
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "script.py").write_text("def test_fn(x):\n    return x * x\n")
+
+    runner = object.__new__(Runner)
+    runner._name = "test-run"
+    runner._dependencies = ["pandas>=2", "numpy"]
+    runner._context = SimpleNamespace(package=None)
+
+    package_path = runner._create_package()
+
+    assert not (tmp_path / "pyproject.toml").exists()
+    with tarfile.open(package_path, "r:gz") as package:
+        pyproject = package.extractfile("pyproject.toml")
+        assert pyproject is not None
+        content = pyproject.read().decode("utf-8")
+
+    assert '"numpy"' in content
+    assert '"pandas>=2"' in content
+    assert "py-modules = []" in content
+    parsed = _parse_toml(content)
+    if parsed is not None:
+        assert parsed["project"]["dependencies"] == ["numpy", "pandas>=2"]
 
 
 def test_runnerservice_generates_method_wrappers():

--- a/sdk/python/tests/test_runner.py
+++ b/sdk/python/tests/test_runner.py
@@ -253,6 +253,7 @@ def test_runner_package_generates_metadata_without_dependencies(tmp_path, monkey
 
     assert not (tmp_path / "pyproject.toml").exists()
     with tarfile.open(package_path, "r:gz") as package:
+        assert package.getmember("pyproject.toml").mode == 0o644
         pyproject = package.extractfile("pyproject.toml")
         assert pyproject is not None
         content = pyproject.read().decode("utf-8")
@@ -281,6 +282,7 @@ def test_runner_package_generates_dependency_metadata_in_archive(tmp_path, monke
 
     assert not (tmp_path / "pyproject.toml").exists()
     with tarfile.open(package_path, "r:gz") as package:
+        assert package.getmember("pyproject.toml").mode == 0o644
         pyproject = package.extractfile("pyproject.toml")
         assert pyproject is not None
         content = pyproject.read().decode("utf-8")
@@ -291,6 +293,33 @@ def test_runner_package_generates_dependency_metadata_in_archive(tmp_path, monke
     parsed = _parse_toml(content)
     if parsed is not None:
         assert parsed["project"]["dependencies"] == ["numpy", "pandas>=2"]
+
+
+@pytest.mark.parametrize("metadata_file", ["setup.py", "setup.cfg"])
+def test_runner_package_skips_generated_metadata_for_legacy_projects(tmp_path, monkeypatch, caplog, metadata_file):
+    """Runner does not add pyproject.toml over legacy package metadata."""
+    from flamepy.runner.runner import Runner
+
+    monkeypatch.chdir(tmp_path)
+    if metadata_file == "setup.py":
+        (tmp_path / metadata_file).write_text("from setuptools import setup\nsetup(name='legacy-runner')\n")
+    else:
+        (tmp_path / metadata_file).write_text("[metadata]\nname = legacy-runner\n")
+
+    runner = object.__new__(Runner)
+    runner._name = "test-run"
+    runner._dependencies = ["numpy"]
+    runner._context = SimpleNamespace(package=None)
+
+    caplog.set_level("WARNING", logger="flamepy.runner.runner")
+    package_path = runner._create_package()
+
+    with tarfile.open(package_path, "r:gz") as package:
+        names = package.getnames()
+
+    assert metadata_file in names
+    assert "pyproject.toml" not in names
+    assert "Skipping pyproject.toml generation" in caplog.text
 
 
 def test_runnerservice_generates_method_wrappers():


### PR DESCRIPTION
## Summary
- generate Runner package metadata inside the archive when the working directory has no Python project metadata
- avoid mutating the caller working directory while still allowing executor-side `uv pip install .`
- add SDK coverage for generated metadata and an e2e regression for `flmexec` running `Runner(...)` without dependencies

## Verification
- python3 -m py_compile sdk/python/src/flamepy/runner/runner.py sdk/python/tests/test_runner.py e2e/tests/test_flmexec.py
- cd sdk/python && uv run --extra dev pytest tests/test_runner.py -q
- cd sdk/python && uv run --extra dev ruff check src/flamepy/runner/runner.py tests/test_runner.py
- cd e2e && uv run --extra dev ruff check tests/test_flmexec.py
- simulated executor install: generated Runner tarball extracted to src, then `uv pip install --target deps .`
- podman flmexec check printed `Flame Runner works perfectly! Results: [100, 400]`
- podman e2e: `python3 -m pytest -vv -s --durations=0 tests/test_flmexec.py`