### PR TITLE
[codex] align system test workflow with CI

### DIFF
--- a/.github/workflows/e2e-system.yaml
+++ b/.github/workflows/e2e-system.yaml
@@ -1,40 +1,18 @@
-name: Flame System Test
-
-"on":
-  schedule:
-    - cron: "0 18 * * *"
-  workflow_dispatch:
-    inputs:
-      profile:
-        description: System test profile to run
-        required: true
-        default: all
-        type: choice
-        options:
-          - all
-          - stress
-          - longevity
-          - runner
-
-permissions:
-  contents: read
-
-concurrency:
-  group: flame-system-test-${{ github.ref }}
-  cancel-in-progress: false
-
+name: Flame CI
+on: [push, pull_request]
 env:
   CLICOLOR_FORCE: 1
-  E2E_SYSTEM_PROFILE: ${{ github.event.inputs.profile || 'all' }}
-
 jobs:
-  system-test:
+  ci:
     name: Python System Test
-    runs-on: ubuntu-latest
-    timeout-minutes: 120
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v2
 
       - name: Set up Docker Compose
         uses: docker/setup-compose-action@v1
@@ -53,24 +31,29 @@ jobs:
 
       - name: Wait for services to be ready
         run: |
+          echo "Waiting for services to be ready..."
           sleep 10
           docker compose ps
 
       - name: Run Python system tests
-        run: make e2e-py-system-docker E2E_SYSTEM_PROFILE="${E2E_SYSTEM_PROFILE}"
+        timeout-minutes: 120
+        run: |
+          make e2e-py-system-docker
 
       - name: Print session-manager logs
-        if: failure() || cancelled()
-        run: docker compose logs flame-session-manager --tail=500
+        if: always()
+        run: |
+          echo "=== Session Manager Logs ==="
+          docker compose logs flame-session-manager --tail=500
 
       - name: Print executor-manager logs
-        if: failure() || cancelled()
-        run: docker compose logs flame-executor-manager --tail=500
+        if: always()
+        run: |
+          echo "=== Executor Manager Logs ==="
+          docker compose logs flame-executor-manager --tail=500
 
       - name: Print object-cache logs
-        if: failure() || cancelled()
-        run: docker compose logs flame-object-cache --tail=500
-
-      - name: Stop Flame
         if: always()
-        run: docker compose down --volumes --remove-orphans
+        run: |
+          echo "=== Object Cache Logs ==="
+          docker compose logs flame-object-cache --tail=500


### PR DESCRIPTION
## Summary
- align the system test workflow with the existing Flame CI workflow format
- run it on push and pull_request instead of a daily schedule
- remove the custom dispatch/concurrency shape so it behaves like the other CI jobs

## Verification
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/e2e-system.yaml"); puts "ok"'
- git diff --check -- .github/workflows/e2e-system.yaml