### PR TITLE
[codex] add flmexec runtime parameter

### DIFF
--- a/e2e/tests/test_flmexec.py
+++ b/e2e/tests/test_flmexec.py
@@ -40,10 +40,10 @@ def check_flmexec_runner_environment():
         pytest.skip(f"Flame cluster is not available: {exc}")
 
 
-def _invoke_flmexec_python(script: str) -> str:
+def _invoke_flmexec_python(script: str, runtime: str | None = None) -> str:
     session = flamepy.create_session("flmexec")
     try:
-        request = {"language": "python", "code": script, "input": None}
+        request = {"language": "python", "runtime": runtime, "code": script, "input": None}
         raw_response = session.invoke(json.dumps(request).encode("utf-8"))
     finally:
         session.close()

--- a/examples/agents/scripts/main.py
+++ b/examples/agents/scripts/main.py
@@ -19,6 +19,10 @@ tools = [
                         "type": "string",
                         "description": "The code of the script to run, e.g. print('Hello, world!')",
                     },
+                    "runtime": {
+                        "type": "string",
+                        "description": "The runtime for the selected language, e.g. Python version or shell type",
+                    },
                 },
                 "required": ["language", "code"],
             },

--- a/examples/agents/sra/apis.py
+++ b/examples/agents/sra/apis.py
@@ -20,3 +20,4 @@ class WebPage:
 class Script:
     language: str
     code: str
+    runtime: str | None = None

--- a/flmexec/src/api/mod.rs
+++ b/flmexec/src/api/mod.rs
@@ -17,6 +17,8 @@ use serde_derive::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize, FlameMessage)]
 pub struct Script {
     pub language: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runtime: Option<String>,
     pub code: String,
     pub input: Option<Vec<u8>>,
 }
@@ -24,4 +26,37 @@ pub struct Script {
 #[derive(Debug, Clone, Serialize, Deserialize, FlameMessage)]
 pub struct ScriptOutput {
     pub data: Vec<u8>,
+}
+
+#[cfg(test)]
+mod tests {
+    use flame_rs::FlameMessage;
+
+    use super::*;
+
+    #[test]
+    fn decodes_request_without_runtime() {
+        let script =
+            Script::decode(br#"{"language":"python","code":"print(1)","input":null}"#).unwrap();
+
+        assert_eq!(script.language, "python");
+        assert_eq!(script.runtime, None);
+        assert_eq!(script.code, "print(1)");
+        assert_eq!(script.input, None);
+    }
+
+    #[test]
+    fn encodes_request_runtime_when_present() {
+        let script = Script {
+            language: "shell".to_string(),
+            runtime: Some("zsh".to_string()),
+            code: "echo ok".to_string(),
+            input: None,
+        };
+
+        let encoded = script.encode().unwrap();
+        let encoded = String::from_utf8(encoded.to_vec()).unwrap();
+
+        assert!(encoded.contains(r#""runtime":"zsh""#));
+    }
 }

--- a/flmexec/src/client.rs
+++ b/flmexec/src/client.rs
@@ -38,6 +38,9 @@ struct Cli {
     /// The language of the code
     #[arg(short, long, default_value = "shell", value_parser = parse_language)]
     language: String,
+    /// The runtime for the selected language, e.g. Python version or shell type
+    #[arg(short, long)]
+    runtime: Option<String>,
     /// The input to the code slice
     #[arg(short, long)]
     input: Option<Vec<u8>>,
@@ -71,6 +74,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let script = Script {
         language: cli.language.clone(),
+        runtime: cli.runtime.clone(),
         code: cli.code.clone(),
         input: cli.input.clone(),
     };

--- a/flmexec/src/script/lang/python.rs
+++ b/flmexec/src/script/lang/python.rs
@@ -70,12 +70,12 @@ fn get_uv_cmd() -> String {
     }
 }
 
-fn configure_python_env(envs: &mut HashMap<String, String>) -> String {
+fn configure_python_env(envs: &mut HashMap<String, String>, runtime: Option<&str>) -> String {
     let flame_home = flame_home(envs);
     envs.entry(FLAME_HOME_ENV.to_string())
         .or_insert_with(|| flame_home.to_string_lossy().to_string());
 
-    let python_version = python_version(envs, &flame_home);
+    let python_version = python_version(runtime);
     envs.insert(FLAME_PYTHON_VERSION_ENV.to_string(), python_version.clone());
 
     let site_packages = site_packages_path(&flame_home, &python_version);
@@ -98,47 +98,17 @@ fn flame_home(envs: &HashMap<String, String>) -> PathBuf {
         .unwrap_or_else(|| PathBuf::from(DEFAULT_FLAME_HOME))
 }
 
-fn python_version(envs: &HashMap<String, String>, flame_home: &Path) -> String {
-    envs.get(FLAME_PYTHON_VERSION_ENV)
-        .map(|version| version_number(version))
+fn python_version(runtime: Option<&str>) -> String {
+    runtime
+        .map(str::trim)
         .filter(|version| !version.is_empty())
+        .map(version_number)
         .map(ToOwned::to_owned)
-        .or_else(|| latest_installed_python_version(flame_home))
         .unwrap_or_else(|| DEFAULT_PYTHON_VERSION.to_string())
 }
 
 fn version_number(version: &str) -> &str {
     version.strip_prefix("python").unwrap_or(version)
-}
-
-fn latest_installed_python_version(flame_home: &Path) -> Option<String> {
-    let lib_path = flame_home.join("lib");
-    let mut versions = fs::read_dir(lib_path)
-        .ok()?
-        .flatten()
-        .filter_map(|entry| {
-            let path = entry.path();
-            if !path.is_dir() || !path.join("site-packages").is_dir() {
-                return None;
-            }
-
-            let name = entry.file_name();
-            let name = name.to_string_lossy();
-            name.strip_prefix("python")
-                .filter(|version| !version.is_empty())
-                .map(|version| version.to_string())
-        })
-        .collect::<Vec<_>>();
-
-    versions.sort_by_key(|version| minor_version(version));
-    versions.pop()
-}
-
-fn minor_version(version: &str) -> Vec<u32> {
-    version
-        .split('.')
-        .map(|part| part.parse::<u32>().unwrap_or(0))
-        .collect()
 }
 
 fn site_packages_path(flame_home: &Path, version: &str) -> PathBuf {
@@ -199,7 +169,7 @@ impl PythonScript {
                 env.insert((*key).to_string(), value);
             }
         }
-        configure_python_env(&mut env);
+        configure_python_env(&mut env, script.runtime.as_deref());
 
         let runtime = ScriptRuntime {
             entrypoint: full_path.to_string_lossy().to_string(),
@@ -300,9 +270,11 @@ mod tests {
     }
 
     #[test]
-    fn configures_python_env_from_installed_flame_site_packages() {
+    fn configures_default_python_version() {
         let temp = tempfile::tempdir().unwrap();
-        let site_packages = temp.path().join("lib/python3.12/site-packages");
+        let site_packages = temp
+            .path()
+            .join(format!("lib/python{DEFAULT_PYTHON_VERSION}/site-packages"));
         fs::create_dir_all(&site_packages).unwrap();
 
         let existing_path = temp.path().join("existing-pythonpath");
@@ -315,21 +287,49 @@ mod tests {
                 PYTHONPATH_ENV.to_string(),
                 existing_path.to_string_lossy().to_string(),
             ),
+            (
+                FLAME_PYTHON_VERSION_ENV.to_string(),
+                "python3.11".to_string(),
+            ),
         ]);
 
-        let python_version = configure_python_env(&mut envs);
+        let python_version = configure_python_env(&mut envs, None);
 
-        assert_eq!(python_version, "3.12");
-        assert_eq!(envs.get(FLAME_PYTHON_VERSION_ENV).unwrap(), "3.12");
+        assert_eq!(python_version, DEFAULT_PYTHON_VERSION);
+        assert_eq!(
+            envs.get(FLAME_PYTHON_VERSION_ENV).unwrap(),
+            DEFAULT_PYTHON_VERSION
+        );
 
         let python_paths = env::split_paths(envs.get(PYTHONPATH_ENV).unwrap()).collect::<Vec<_>>();
         assert_eq!(python_paths, vec![site_packages, existing_path]);
     }
 
     #[test]
-    fn configures_requested_python_version() {
+    fn normalizes_script_runtime_python_version() {
         let temp = tempfile::tempdir().unwrap();
         let site_packages = temp.path().join("lib/python3.11/site-packages");
+        fs::create_dir_all(&site_packages).unwrap();
+
+        let mut envs = HashMap::from([(
+            FLAME_HOME_ENV.to_string(),
+            temp.path().to_string_lossy().to_string(),
+        )]);
+
+        let python_version = configure_python_env(&mut envs, Some("python3.11"));
+
+        assert_eq!(python_version, "3.11");
+        assert_eq!(envs.get(FLAME_PYTHON_VERSION_ENV).unwrap(), "3.11");
+        assert_eq!(
+            env::split_paths(envs.get(PYTHONPATH_ENV).unwrap()).collect::<Vec<_>>(),
+            vec![site_packages]
+        );
+    }
+
+    #[test]
+    fn configures_script_runtime_python_version() {
+        let temp = tempfile::tempdir().unwrap();
+        let site_packages = temp.path().join("lib/python3.10/site-packages");
         fs::create_dir_all(&site_packages).unwrap();
 
         let mut envs = HashMap::from([
@@ -339,14 +339,14 @@ mod tests {
             ),
             (
                 FLAME_PYTHON_VERSION_ENV.to_string(),
-                "python3.11".to_string(),
+                "python3.12".to_string(),
             ),
         ]);
 
-        let python_version = configure_python_env(&mut envs);
+        let python_version = configure_python_env(&mut envs, Some("python3.10"));
 
-        assert_eq!(python_version, "3.11");
-        assert_eq!(envs.get(FLAME_PYTHON_VERSION_ENV).unwrap(), "3.11");
+        assert_eq!(python_version, "3.10");
+        assert_eq!(envs.get(FLAME_PYTHON_VERSION_ENV).unwrap(), "3.10");
         assert_eq!(
             env::split_paths(envs.get(PYTHONPATH_ENV).unwrap()).collect::<Vec<_>>(),
             vec![site_packages]

--- a/flmexec/src/script/lang/python.rs
+++ b/flmexec/src/script/lang/python.rs
@@ -75,7 +75,7 @@ fn configure_python_env(envs: &mut HashMap<String, String>, runtime: Option<&str
     envs.entry(FLAME_HOME_ENV.to_string())
         .or_insert_with(|| flame_home.to_string_lossy().to_string());
 
-    let python_version = python_version(runtime);
+    let python_version = python_version(envs, &flame_home, runtime);
     envs.insert(FLAME_PYTHON_VERSION_ENV.to_string(), python_version.clone());
 
     let site_packages = site_packages_path(&flame_home, &python_version);
@@ -98,17 +98,58 @@ fn flame_home(envs: &HashMap<String, String>) -> PathBuf {
         .unwrap_or_else(|| PathBuf::from(DEFAULT_FLAME_HOME))
 }
 
-fn python_version(runtime: Option<&str>) -> String {
+fn python_version(
+    envs: &HashMap<String, String>,
+    flame_home: &Path,
+    runtime: Option<&str>,
+) -> String {
     runtime
         .map(str::trim)
         .filter(|version| !version.is_empty())
         .map(version_number)
         .map(ToOwned::to_owned)
+        .or_else(|| {
+            envs.get(FLAME_PYTHON_VERSION_ENV)
+                .map(|version| version_number(version))
+                .filter(|version| !version.is_empty())
+                .map(ToOwned::to_owned)
+        })
+        .or_else(|| latest_installed_python_version(flame_home))
         .unwrap_or_else(|| DEFAULT_PYTHON_VERSION.to_string())
 }
 
 fn version_number(version: &str) -> &str {
     version.strip_prefix("python").unwrap_or(version)
+}
+
+fn latest_installed_python_version(flame_home: &Path) -> Option<String> {
+    let lib_path = flame_home.join("lib");
+    let mut versions = fs::read_dir(lib_path)
+        .ok()?
+        .flatten()
+        .filter_map(|entry| {
+            let path = entry.path();
+            if !path.is_dir() || !path.join("site-packages").is_dir() {
+                return None;
+            }
+
+            let name = entry.file_name();
+            let name = name.to_string_lossy();
+            name.strip_prefix("python")
+                .filter(|version| !version.is_empty())
+                .map(|version| version.to_string())
+        })
+        .collect::<Vec<_>>();
+
+    versions.sort_by_key(|version| minor_version(version));
+    versions.pop()
+}
+
+fn minor_version(version: &str) -> Vec<u32> {
+    version
+        .split('.')
+        .map(|part| part.parse::<u32>().unwrap_or(0))
+        .collect()
 }
 
 fn site_packages_path(flame_home: &Path, version: &str) -> PathBuf {
@@ -287,10 +328,6 @@ mod tests {
                 PYTHONPATH_ENV.to_string(),
                 existing_path.to_string_lossy().to_string(),
             ),
-            (
-                FLAME_PYTHON_VERSION_ENV.to_string(),
-                "python3.11".to_string(),
-            ),
         ]);
 
         let python_version = configure_python_env(&mut envs, None);
@@ -323,6 +360,56 @@ mod tests {
         assert_eq!(
             env::split_paths(envs.get(PYTHONPATH_ENV).unwrap()).collect::<Vec<_>>(),
             vec![site_packages]
+        );
+    }
+
+    #[test]
+    fn configures_env_python_version() {
+        let temp = tempfile::tempdir().unwrap();
+        let site_packages = temp.path().join("lib/python3.11/site-packages");
+        fs::create_dir_all(&site_packages).unwrap();
+
+        let mut envs = HashMap::from([
+            (
+                FLAME_HOME_ENV.to_string(),
+                temp.path().to_string_lossy().to_string(),
+            ),
+            (
+                FLAME_PYTHON_VERSION_ENV.to_string(),
+                "python3.11".to_string(),
+            ),
+        ]);
+
+        let python_version = configure_python_env(&mut envs, None);
+
+        assert_eq!(python_version, "3.11");
+        assert_eq!(envs.get(FLAME_PYTHON_VERSION_ENV).unwrap(), "3.11");
+        assert_eq!(
+            env::split_paths(envs.get(PYTHONPATH_ENV).unwrap()).collect::<Vec<_>>(),
+            vec![site_packages]
+        );
+    }
+
+    #[test]
+    fn configures_latest_installed_python_version() {
+        let temp = tempfile::tempdir().unwrap();
+        let old_site_packages = temp.path().join("lib/python3.10/site-packages");
+        let new_site_packages = temp.path().join("lib/python3.11/site-packages");
+        fs::create_dir_all(&old_site_packages).unwrap();
+        fs::create_dir_all(&new_site_packages).unwrap();
+
+        let mut envs = HashMap::from([(
+            FLAME_HOME_ENV.to_string(),
+            temp.path().to_string_lossy().to_string(),
+        )]);
+
+        let python_version = configure_python_env(&mut envs, None);
+
+        assert_eq!(python_version, "3.11");
+        assert_eq!(envs.get(FLAME_PYTHON_VERSION_ENV).unwrap(), "3.11");
+        assert_eq!(
+            env::split_paths(envs.get(PYTHONPATH_ENV).unwrap()).collect::<Vec<_>>(),
+            vec![new_site_packages]
         );
     }
 

--- a/flmexec/src/script/lang/shell.rs
+++ b/flmexec/src/script/lang/shell.rs
@@ -29,15 +29,19 @@ use crate::api::Script;
 use crate::script::{ScriptEngine, ScriptRuntime};
 
 const DEFAULT_ENTRYPOINT: &str = "main.sh";
-const SHELL_CMD: &str = "/bin/bash";
+const DEFAULT_SHELL_CMD: &str = "bash";
+const SUPPORTED_SHELLS: &[&str] = &["sh", "bash", "zsh", "csh", "tcsh", "ksh", "fish"];
 
 pub struct ShellScript {
     runtime: ScriptRuntime,
+    shell_cmd: String,
 }
 
 impl ShellScript {
     pub fn new(script: &Script) -> Result<Self, FlameError> {
         trace_fn!("ShellScript::new");
+
+        let shell_cmd = shell_cmd(script.runtime.as_deref())?;
 
         let mut rng = rand::rng();
         let work_dir_path = format!("/tmp/flame/script/shell-{}", rng.random::<u32>());
@@ -61,9 +65,30 @@ impl ShellScript {
             input: script.input.clone(),
             env: HashMap::new(),
         };
-
-        Ok(Self { runtime })
+        Ok(Self { runtime, shell_cmd })
     }
+}
+
+fn shell_cmd(runtime: Option<&str>) -> Result<String, FlameError> {
+    let Some(runtime) = runtime.map(str::trim).filter(|value| !value.is_empty()) else {
+        return Ok(DEFAULT_SHELL_CMD.to_string());
+    };
+
+    let shell_name = Path::new(runtime)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or(runtime);
+    let supported_name = SUPPORTED_SHELLS.contains(&shell_name);
+    let supported_path = SUPPORTED_SHELLS
+        .iter()
+        .any(|shell| runtime == format!("/bin/{shell}") || runtime == format!("/usr/bin/{shell}"));
+    if !supported_name || (runtime.contains('/') && !supported_path) {
+        return Err(FlameError::InvalidConfig(format!(
+            "Unsupported shell runtime: {runtime}"
+        )));
+    }
+
+    Ok(runtime.to_string())
 }
 
 impl ScriptEngine for ShellScript {
@@ -72,8 +97,9 @@ impl ScriptEngine for ShellScript {
 
         tracing::debug!("Running script: {}", self.runtime.entrypoint);
         tracing::debug!("Work directory: {}", self.runtime.work_dir);
+        tracing::debug!("Using shell runtime: {}", self.shell_cmd);
 
-        let mut child = Command::new(SHELL_CMD)
+        let mut child = Command::new(&self.shell_cmd)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .current_dir(&self.runtime.work_dir)
@@ -127,5 +153,29 @@ impl Drop for ShellScript {
         trace_fn!("ShellScript::drop");
 
         fs::remove_dir_all(Path::new(&self.runtime.work_dir)).unwrap();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn uses_default_shell_when_runtime_is_not_requested() {
+        assert_eq!(shell_cmd(None).unwrap(), DEFAULT_SHELL_CMD);
+        assert_eq!(shell_cmd(Some("")).unwrap(), DEFAULT_SHELL_CMD);
+    }
+
+    #[test]
+    fn accepts_supported_shell_runtime() {
+        assert_eq!(shell_cmd(Some("zsh")).unwrap(), "zsh");
+        assert_eq!(shell_cmd(Some("/bin/csh")).unwrap(), "/bin/csh");
+    }
+
+    #[test]
+    fn rejects_unsupported_shell_runtime() {
+        assert!(shell_cmd(Some("python")).is_err());
+        assert!(shell_cmd(Some("/tmp/bash")).is_err());
+        assert!(shell_cmd(Some("/tmp/custom-shell")).is_err());
     }
 }

--- a/flmexec/src/script/lang/shell.rs
+++ b/flmexec/src/script/lang/shell.rs
@@ -79,9 +79,12 @@ fn shell_cmd(runtime: Option<&str>) -> Result<String, FlameError> {
         .and_then(|name| name.to_str())
         .unwrap_or(runtime);
     let supported_name = SUPPORTED_SHELLS.contains(&shell_name);
-    let supported_path = SUPPORTED_SHELLS
-        .iter()
-        .any(|shell| runtime == format!("/bin/{shell}") || runtime == format!("/usr/bin/{shell}"));
+    let supported_path = SUPPORTED_SHELLS.iter().any(|&shell| {
+        runtime.strip_prefix("/bin/").is_some_and(|s| s == shell)
+            || runtime
+                .strip_prefix("/usr/bin/")
+                .is_some_and(|s| s == shell)
+    });
     if !supported_name || (runtime.contains('/') && !supported_path) {
         return Err(FlameError::InvalidConfig(format!(
             "Unsupported shell runtime: {runtime}"


### PR DESCRIPTION
## Summary
- add an optional runtime field to flmexec Script requests and the flmexec CLI
- use runtime as the Python version for python scripts, defaulting to 3.12
- use runtime as the shell type for shell scripts, defaulting to bash
- update flmexec examples and the e2e helper to carry the optional runtime field

## Verification
- cargo fmt --check -p flmexec
- cargo test -p flmexec
- cargo check -p flmexec
- uv run --extra dev ruff check tests/test_flmexec.py (from e2e/)
- python3 -m py_compile e2e/tests/test_flmexec.py examples/agents/sra/apis.py examples/agents/scripts/main.py