### PR TITLE
[codex] Move flmexec Python default local

### DIFF
--- a/flmexec/src/script/lang/python.rs
+++ b/flmexec/src/script/lang/python.rs
@@ -23,12 +23,13 @@ use std::{
 
 use rand::Rng;
 
-use flame_rs::{apis::FlameError, DEFAULT_PYTHON_VERSION, FLAME_PYTHON_VERSION_ENV};
+use flame_rs::{apis::FlameError, FLAME_PYTHON_VERSION_ENV};
 use stdng::trace_fn;
 
 use crate::api::Script;
 use crate::script::{ScriptEngine, ScriptRuntime};
 
+const DEFAULT_PYTHON_VERSION: &str = "3.12";
 const DEFAULT_ENTRYPOINT: &str = "main.py";
 const DEFAULT_FLAME_HOME: &str = "/usr/local/flame";
 const PYTHONPATH_ENV: &str = "PYTHONPATH";

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -18,7 +18,6 @@ pub mod object;
 pub mod service;
 
 pub const FLAME_PYTHON_VERSION_ENV: &str = "FLAME_PYTHON_VERSION";
-pub const DEFAULT_PYTHON_VERSION: &str = "3.12";
 
 pub use client::{Connection, Session, SessionOptions, TaskFuture, TaskHandle, TaskResult};
 pub use message::{FlameMessage, FromTaskOutput, IntoCommonData, IntoTaskInput};


### PR DESCRIPTION
## Summary

Move the `flmexec` Python fallback version into `flmexec` itself and stop exporting that runtime policy from the Rust SDK.

## Why

`DEFAULT_PYTHON_VERSION` is a `flmexec` fallback decision, not a public Rust SDK contract. Keeping it local preserves the SDK boundary while leaving `FLAME_PYTHON_VERSION_ENV` exported as the shared environment contract.

## Validation

- `cargo check -p flame-rs`
- `cargo test -p flmexec`
