### PR TITLE
[codex] Prepare flamepy metadata for 0.6

### DIFF
--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -18,7 +18,6 @@ classifiers = [
   "Intended Audience :: Developers",
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
@@ -58,7 +57,7 @@ Issues = "https://github.com/xflops/flame/issues"
 
 [tool.ruff]
 line-length = 320
-target-version = "py38"
+target-version = "py39"
 exclude = [
     ".eggs",
     ".git",
@@ -83,7 +82,7 @@ ignore = []
 known-first-party = ["flamepy"]
 
 [tool.mypy]
-python_version = "3.8"
+python_version = "3.9"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
   "grpcio>=1.80",

--- a/sdk/python/src/flamepy/__init__.py
+++ b/sdk/python/src/flamepy/__init__.py
@@ -76,7 +76,7 @@ from .core import (  # Type aliases; Constants; Enums; Exception classes; Data c
     update_object,
 )
 
-__version__ = "0.5.0"
+__version__ = "0.6.0"
 
 __all__ = [
     # Type aliases


### PR DESCRIPTION
## Summary

Prepare the Python SDK metadata for the Flame 0.6 release.

Changes:

- Sync `flamepy.__version__` to `0.6.0`.
- Remove stale Python 3.8 metadata/configuration now that `requires-python` is `>=3.9`.
- Add the Python 3.12 package classifier.

## Validation

- `python3 -c "import tomllib; tomllib.load(open('sdk/python/pyproject.toml','rb')); print('pyproject ok')"`
- Checked that `sdk/python/pyproject.toml` lists Python 3.9 through 3.12 and no Python 3.8 classifier.
