### PR TITLE
[codex] Backport Helm install to release-0.6

### DIFF
--- a/.github/workflows/e2e-k8s.yaml
+++ b/.github/workflows/e2e-k8s.yaml
@@ -1,0 +1,101 @@
+name: Flame Kubernetes E2E
+
+"on":
+  pull_request:
+    paths:
+      - ".github/workflows/e2e-k8s.yaml"
+      - "charts/flame/**"
+      - "ci/k8s/**"
+      - "ci/kind.yaml"
+      - "common/**"
+      - "docker/**"
+      - "executor_manager/**"
+      - "flmctl/**"
+      - "flmexec/**"
+      - "flmping/**"
+      - "object_cache/**"
+      - "rpc/**"
+      - "sdk/**"
+      - "session_manager/**"
+      - "Cargo.lock"
+      - "Cargo.toml"
+  push:
+    branches:
+      - main
+      - release-*
+    paths:
+      - ".github/workflows/e2e-k8s.yaml"
+      - "charts/flame/**"
+      - "ci/k8s/**"
+      - "ci/kind.yaml"
+      - "common/**"
+      - "docker/**"
+      - "executor_manager/**"
+      - "flmctl/**"
+      - "flmexec/**"
+      - "flmping/**"
+      - "object_cache/**"
+      - "rpc/**"
+      - "sdk/**"
+      - "session_manager/**"
+      - "Cargo.lock"
+      - "Cargo.toml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: flame-k8s-e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CLICOLOR_FORCE: 1
+  DOCKER_BUILDKIT: 1
+  IMAGE_REGISTRY: xflops
+  IMAGE_TAG: ci
+
+jobs:
+  k8s-e2e:
+    name: Helm chart on Kind
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - name: Create Kind cluster
+        uses: helm/kind-action@v1
+        with:
+          cluster_name: flame
+          config: ci/kind.yaml
+          wait: 120s
+
+      - name: Build Flame images
+        run: |
+          docker build -t ${IMAGE_REGISTRY}/flame-session-manager:${IMAGE_TAG} -f docker/Dockerfile.fsm .
+          docker build -t ${IMAGE_REGISTRY}/flame-object-cache:${IMAGE_TAG} -f docker/Dockerfile.foc .
+          docker build -t ${IMAGE_REGISTRY}/flame-executor-manager:${IMAGE_TAG} -f docker/Dockerfile.fem .
+          docker build -t ${IMAGE_REGISTRY}/flame-console:${IMAGE_TAG} -f docker/Dockerfile.console .
+
+      - name: Load images into Kind
+        run: |
+          kind load docker-image ${IMAGE_REGISTRY}/flame-session-manager:${IMAGE_TAG} --name flame
+          kind load docker-image ${IMAGE_REGISTRY}/flame-object-cache:${IMAGE_TAG} --name flame
+          kind load docker-image ${IMAGE_REGISTRY}/flame-executor-manager:${IMAGE_TAG} --name flame
+          kind load docker-image ${IMAGE_REGISTRY}/flame-console:${IMAGE_TAG} --name flame
+
+      - name: Run Kubernetes e2e
+        run: ci/k8s/e2e.sh
+
+      - name: Print Kubernetes diagnostics
+        if: failure() || cancelled()
+        run: |
+          kubectl -n flame-k8s-e2e get all,pvc || true
+          kubectl -n flame-k8s-e2e get events --sort-by=.lastTimestamp || true
+          kubectl -n flame-k8s-e2e logs -l app.kubernetes.io/component=session-manager --all-containers --tail=500 || true
+          kubectl -n flame-k8s-e2e logs -l app.kubernetes.io/component=object-cache --all-containers --tail=500 || true
+          kubectl -n flame-k8s-e2e logs -l app.kubernetes.io/component=executor-manager --all-containers --tail=500 || true

--- a/.github/workflows/e2e-k8s.yaml
+++ b/.github/workflows/e2e-k8s.yaml
@@ -1,4 +1,4 @@
-name: Flame Kubernetes E2E
+name: Flame CI
 
 on: [push, pull_request, workflow_dispatch]
 
@@ -16,8 +16,8 @@ env:
   IMAGE_TAG: ci
 
 jobs:
-  k8s-e2e:
-    name: Helm chart on Kind
+  ci:
+    name: Kubernetes E2E Test
     runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:

--- a/.github/workflows/e2e-k8s.yaml
+++ b/.github/workflows/e2e-k8s.yaml
@@ -1,46 +1,6 @@
 name: Flame Kubernetes E2E
 
-"on":
-  pull_request:
-    paths:
-      - ".github/workflows/e2e-k8s.yaml"
-      - "charts/flame/**"
-      - "ci/k8s/**"
-      - "ci/kind.yaml"
-      - "common/**"
-      - "docker/**"
-      - "executor_manager/**"
-      - "flmctl/**"
-      - "flmexec/**"
-      - "flmping/**"
-      - "object_cache/**"
-      - "rpc/**"
-      - "sdk/**"
-      - "session_manager/**"
-      - "Cargo.lock"
-      - "Cargo.toml"
-  push:
-    branches:
-      - main
-      - release-*
-    paths:
-      - ".github/workflows/e2e-k8s.yaml"
-      - "charts/flame/**"
-      - "ci/k8s/**"
-      - "ci/kind.yaml"
-      - "common/**"
-      - "docker/**"
-      - "executor_manager/**"
-      - "flmctl/**"
-      - "flmexec/**"
-      - "flmping/**"
-      - "object_cache/**"
-      - "rpc/**"
-      - "sdk/**"
-      - "session_manager/**"
-      - "Cargo.lock"
-      - "Cargo.toml"
-  workflow_dispatch:
+on: [push, pull_request, workflow_dispatch]
 
 permissions:
   contents: read

--- a/charts/flame/.helmignore
+++ b/charts/flame/.helmignore
@@ -1,0 +1,7 @@
+.git/
+.github/
+target/
+*.swp
+*.tmp
+*.bak
+.DS_Store

--- a/charts/flame/Chart.yaml
+++ b/charts/flame/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+name: flame
+description: Static Kubernetes deployment for Flame
+type: application
+version: 0.1.0
+appVersion: "0.6.0"
+home: https://github.com/xflops/flame
+sources:
+  - https://github.com/xflops/flame
+keywords:
+  - flame
+  - distributed
+  - ai
+  - scheduler
+maintainers:
+  - name: Flame Authors
+    email: support@xflops.io

--- a/charts/flame/README.md
+++ b/charts/flame/README.md
@@ -1,0 +1,52 @@
+# Flame Helm Chart
+
+This chart installs a static Flame cluster on Kubernetes:
+
+- one `flame-session-manager`
+- one `flame-object-cache`
+- a configurable number of `flame-executor-manager` replicas
+
+It does not implement the future Kubernetes provider or application pod
+autoscaling. Executor capacity is static and follows
+`executorManager.replicas`.
+
+## Install
+
+```bash
+helm install flame ./charts/flame --namespace flame --create-namespace
+```
+
+For local Kind testing without persistent volumes:
+
+```bash
+helm install flame ./charts/flame \
+  --namespace flame \
+  --create-namespace \
+  --set sessionManager.persistence.enabled=false \
+  --set objectCache.persistence.enabled=false
+```
+
+## Verify
+
+```bash
+helm test flame --namespace flame
+kubectl -n flame get pods,svc
+```
+
+Port-forward for local inspection:
+
+```bash
+kubectl -n flame port-forward svc/flame-session-manager 8080:8080
+kubectl -n flame port-forward svc/flame-object-cache 9090:9090
+```
+
+Then configure local clients:
+
+```bash
+export FLAME_ENDPOINT=http://127.0.0.1:8080
+export FLAME_CACHE_ENDPOINT=grpc://127.0.0.1:9090
+```
+
+Port-forwarded cache endpoints are suitable for local inspection. Package
+deployment flows should use a cache endpoint that is reachable by both the
+client and executor-manager pods.

--- a/charts/flame/README.md
+++ b/charts/flame/README.md
@@ -3,12 +3,14 @@
 This chart installs a static Flame cluster on Kubernetes:
 
 - one `flame-session-manager`
-- one `flame-object-cache`
+- a configurable number of `flame-object-cache` replicas
 - a configurable number of `flame-executor-manager` replicas
 
 It does not implement the future Kubernetes provider or application pod
 autoscaling. Executor capacity is static and follows
-`executorManager.replicas`.
+`executorManager.replicas`. Object-cache capacity follows
+`objectCache.replicas`; each StatefulSet replica owns its own cache volume when
+persistence is enabled.
 
 ## Install
 
@@ -24,6 +26,15 @@ helm install flame ./charts/flame \
   --create-namespace \
   --set sessionManager.persistence.enabled=false \
   --set objectCache.persistence.enabled=false
+```
+
+To install multiple object-cache replicas:
+
+```bash
+helm install flame ./charts/flame \
+  --namespace flame \
+  --create-namespace \
+  --set objectCache.replicas=3
 ```
 
 ## Verify

--- a/charts/flame/templates/NOTES.txt
+++ b/charts/flame/templates/NOTES.txt
@@ -1,0 +1,19 @@
+Flame has been installed.
+
+In-cluster endpoints:
+  Session manager: {{ include "flame.clusterEndpoint" . }}
+  Object cache:    {{ include "flame.cacheEndpoint" . }}
+
+Check pods:
+  kubectl -n {{ .Release.Namespace }} get pods,svc
+
+Run Helm chart test:
+  helm test {{ .Release.Name }} -n {{ .Release.Namespace }}
+
+Port-forward for local inspection:
+  kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "flame.sessionManager.name" . }} 8080:{{ .Values.sessionManager.service.frontendPort }}
+  kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "flame.objectCache.name" . }} 9090:{{ .Values.objectCache.service.port }}
+
+Local client environment:
+  export FLAME_ENDPOINT=http://127.0.0.1:8080
+  export FLAME_CACHE_ENDPOINT=grpc://127.0.0.1:9090

--- a/charts/flame/templates/_helpers.tpl
+++ b/charts/flame/templates/_helpers.tpl
@@ -109,6 +109,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- if ne (int .Values.sessionManager.replicas) 1 -}}
 {{- fail "sessionManager.replicas must be 1 for the static chart" -}}
 {{- end -}}
+{{- if and .Values.objectCache.enabled (lt (int .Values.objectCache.replicas) 1) -}}
+{{- fail "objectCache.replicas must be at least 1 when objectCache.enabled=true" -}}
+{{- end -}}
 {{- $expectedBackendPort := add (int .Values.sessionManager.service.frontendPort) 1 -}}
 {{- if ne (int .Values.sessionManager.service.backendPort) (int $expectedBackendPort) -}}
 {{- fail (printf "sessionManager.service.backendPort must equal frontendPort + 1 (%d)" (int $expectedBackendPort)) -}}

--- a/charts/flame/templates/_helpers.tpl
+++ b/charts/flame/templates/_helpers.tpl
@@ -1,0 +1,129 @@
+{{/*
+Expand the chart name.
+*/}}
+{{- define "flame.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "flame.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "flame.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "flame.labels" -}}
+helm.sh/chart: {{ include "flame.chart" . }}
+app.kubernetes.io/name: {{ include "flame.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "flame.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "flame.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "flame.sessionManager.name" -}}
+{{- printf "%s-session-manager" (include "flame.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "flame.objectCache.name" -}}
+{{- printf "%s-object-cache" (include "flame.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "flame.executorManager.name" -}}
+{{- printf "%s-executor-manager" (include "flame.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "flame.configMapName" -}}
+{{- printf "%s-config" (include "flame.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "flame.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "flame.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "flame.image" -}}
+{{- $root := index . "root" -}}
+{{- $image := index . "image" -}}
+{{- $tag := default $root.Values.global.imageTag $image.tag -}}
+{{- if $root.Values.global.imageRegistry -}}
+{{- printf "%s/%s:%s" $root.Values.global.imageRegistry $image.repository $tag -}}
+{{- else -}}
+{{- printf "%s:%s" $image.repository $tag -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "flame.clusterScheme" -}}
+{{- if .Values.tls.enabled -}}https{{- else -}}http{{- end -}}
+{{- end -}}
+
+{{- define "flame.cacheScheme" -}}
+{{- if .Values.tls.enabled -}}grpcs{{- else -}}grpc{{- end -}}
+{{- end -}}
+
+{{- define "flame.clusterEndpoint" -}}
+{{- printf "%s://%s:%d" (include "flame.clusterScheme" .) (include "flame.sessionManager.name" .) (int .Values.sessionManager.service.frontendPort) -}}
+{{- end -}}
+
+{{- define "flame.cacheEndpoint" -}}
+{{- printf "%s://%s:%d" (include "flame.cacheScheme" .) (include "flame.objectCache.name" .) (int .Values.objectCache.service.port) -}}
+{{- end -}}
+
+{{- define "flame.tlsClusterPath" -}}
+{{- printf "%s/cluster" .Values.tls.mountPath -}}
+{{- end -}}
+
+{{- define "flame.tlsCachePath" -}}
+{{- printf "%s/cache" .Values.tls.mountPath -}}
+{{- end -}}
+
+{{- define "flame.validate" -}}
+{{- if .Values.tls.enabled -}}
+{{- if not .Values.tls.cluster.secretName -}}
+{{- fail "tls.cluster.secretName is required when tls.enabled=true" -}}
+{{- end -}}
+{{- if not .Values.tls.cache.secretName -}}
+{{- fail "tls.cache.secretName is required when tls.enabled=true" -}}
+{{- end -}}
+{{- end -}}
+{{- if ne (int .Values.sessionManager.replicas) 1 -}}
+{{- fail "sessionManager.replicas must be 1 for the static chart" -}}
+{{- end -}}
+{{- $expectedBackendPort := add (int .Values.sessionManager.service.frontendPort) 1 -}}
+{{- if ne (int .Values.sessionManager.service.backendPort) (int $expectedBackendPort) -}}
+{{- fail (printf "sessionManager.service.backendPort must equal frontendPort + 1 (%d)" (int $expectedBackendPort)) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "flame.runtimeEmptyDir" -}}
+{{- if or .medium .sizeLimit -}}
+{{- with .medium }}
+medium: {{ . | quote }}
+{{- end }}
+{{- with .sizeLimit }}
+sizeLimit: {{ . | quote }}
+{{- end }}
+{{- else -}}
+{}
+{{- end -}}
+{{- end -}}

--- a/charts/flame/templates/configmap.yaml
+++ b/charts/flame/templates/configmap.yaml
@@ -1,0 +1,74 @@
+{{- include "flame.validate" . -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "flame.configMapName" . }}
+  labels:
+    {{- include "flame.labels" . | nindent 4 }}
+data:
+  flame-cluster.yaml: |
+    ---
+    cluster:
+      name: {{ .Values.cluster.name | quote }}
+      endpoint: {{ include "flame.clusterEndpoint" . | quote }}
+      resreq: {{ .Values.cluster.resreq | quote }}
+      policies:
+        {{- range .Values.cluster.policies }}
+        - {{ . | quote }}
+        {{- end }}
+      storage: {{ .Values.cluster.storage | quote }}
+      schedule_interval: {{ .Values.cluster.scheduleInterval }}
+      executors:
+        shim: {{ .Values.cluster.executors.shim | quote }}
+      limits:
+        max_sessions: {{ .Values.cluster.limits.maxSessions }}
+        max_executors: {{ .Values.cluster.limits.maxExecutors }}
+      recovery:
+        session:
+          retry_limits: {{ .Values.cluster.recovery.session.retryLimits }}
+      {{- if .Values.tls.enabled }}
+      tls:
+        cert_file: {{ printf "%s/%s" (include "flame.tlsClusterPath" .) .Values.tls.cluster.certKey | quote }}
+        key_file: {{ printf "%s/%s" (include "flame.tlsClusterPath" .) .Values.tls.cluster.privateKeyKey | quote }}
+        ca_file: {{ printf "%s/%s" (include "flame.tlsClusterPath" .) .Values.tls.cluster.caKey | quote }}
+      {{- end }}
+    cache:
+      endpoint: {{ include "flame.cacheEndpoint" . | quote }}
+      network_interface: {{ .Values.objectCache.networkInterface | quote }}
+      storage: {{ .Values.objectCache.storage | quote }}
+      eviction:
+        policy: {{ .Values.objectCache.eviction.policy | quote }}
+        max_memory: {{ .Values.objectCache.eviction.maxMemory | quote }}
+        {{- if .Values.objectCache.eviction.maxObjects }}
+        max_objects: {{ .Values.objectCache.eviction.maxObjects }}
+        {{- end }}
+      {{- if .Values.tls.enabled }}
+      tls:
+        cert_file: {{ printf "%s/%s" (include "flame.tlsCachePath" .) .Values.tls.cache.certKey | quote }}
+        key_file: {{ printf "%s/%s" (include "flame.tlsCachePath" .) .Values.tls.cache.privateKeyKey | quote }}
+        ca_file: {{ printf "%s/%s" (include "flame.tlsCachePath" .) .Values.tls.cache.caKey | quote }}
+      {{- end }}
+  {{- if .Values.clientConfig.enabled }}
+  flame.yaml: |
+    ---
+    current-context: {{ .Values.cluster.name | quote }}
+    contexts:
+      - name: {{ .Values.cluster.name | quote }}
+        cluster:
+          endpoint: {{ include "flame.clusterEndpoint" . | quote }}
+          {{- if .Values.tls.enabled }}
+          tls:
+            ca_file: {{ printf "%s/%s" (include "flame.tlsClusterPath" .) .Values.tls.cluster.caKey | quote }}
+          {{- end }}
+        cache:
+          endpoint: {{ include "flame.cacheEndpoint" . | quote }}
+          {{- if .Values.tls.enabled }}
+          tls:
+            ca_file: {{ printf "%s/%s" (include "flame.tlsCachePath" .) .Values.tls.cache.caKey | quote }}
+          {{- end }}
+        package:
+          excludes:
+            {{- range .Values.clientConfig.package.excludes }}
+            - {{ . | quote }}
+            {{- end }}
+  {{- end }}

--- a/charts/flame/templates/executor-manager-deployment.yaml
+++ b/charts/flame/templates/executor-manager-deployment.yaml
@@ -1,0 +1,131 @@
+{{- if .Values.executorManager.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "flame.executorManager.name" . }}
+  labels:
+    {{- include "flame.labels" . | nindent 4 }}
+    app.kubernetes.io/component: executor-manager
+spec:
+  replicas: {{ .Values.executorManager.replicas }}
+  selector:
+    matchLabels:
+      {{- include "flame.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: executor-manager
+  template:
+    metadata:
+      labels:
+        {{- include "flame.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: executor-manager
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+    spec:
+      serviceAccountName: {{ include "flame.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountToken }}
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: executor-manager
+          image: {{ include "flame.image" (dict "root" . "image" .Values.executorManager.image) | quote }}
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          workingDir: /usr/local/flame/work
+          command:
+            - /usr/local/flame/bin/flame-executor-manager
+          args:
+            - --config
+            - /usr/local/flame/conf/flame-cluster.yaml
+          env:
+            - name: RUST_LOG
+              value: info
+            - name: FLAME_HOME
+              value: /usr/local/flame
+            {{- with .Values.executorManager.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          volumeMounts:
+            - name: config
+              mountPath: /usr/local/flame/conf/flame-cluster.yaml
+              subPath: flame-cluster.yaml
+              readOnly: true
+            - name: work
+              mountPath: /usr/local/flame/work
+            - name: apps
+              mountPath: /usr/local/flame/data/apps
+            - name: data-cache
+              mountPath: /usr/local/flame/data/cache
+            - name: logs
+              mountPath: /usr/local/flame/logs
+            - name: tmp-flame
+              mountPath: /tmp/flame
+            - name: var-flame
+              mountPath: /var/flame
+            {{- if .Values.tls.enabled }}
+            - name: cluster-tls
+              mountPath: {{ include "flame.tlsClusterPath" . }}
+              readOnly: true
+            - name: cache-tls
+              mountPath: {{ include "flame.tlsCachePath" . }}
+              readOnly: true
+            {{- end }}
+            {{- with .Values.executorManager.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.executorManager.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "flame.configMapName" . }}
+        - name: work
+          emptyDir:
+            {{- include "flame.runtimeEmptyDir" .Values.executorManager.runtimeStorage | nindent 12 }}
+        - name: apps
+          emptyDir:
+            {{- include "flame.runtimeEmptyDir" .Values.executorManager.runtimeStorage | nindent 12 }}
+        - name: data-cache
+          emptyDir:
+            {{- include "flame.runtimeEmptyDir" .Values.executorManager.runtimeStorage | nindent 12 }}
+        - name: logs
+          emptyDir: {}
+        - name: tmp-flame
+          emptyDir:
+            {{- include "flame.runtimeEmptyDir" .Values.executorManager.runtimeStorage | nindent 12 }}
+        - name: var-flame
+          emptyDir:
+            {{- include "flame.runtimeEmptyDir" .Values.executorManager.runtimeStorage | nindent 12 }}
+        {{- if .Values.tls.enabled }}
+        - name: cluster-tls
+          secret:
+            secretName: {{ .Values.tls.cluster.secretName }}
+        - name: cache-tls
+          secret:
+            secretName: {{ .Values.tls.cache.secretName }}
+        {{- end }}
+        {{- with .Values.executorManager.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.executorManager.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.executorManager.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.executorManager.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/flame/templates/object-cache-service.yaml
+++ b/charts/flame/templates/object-cache-service.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.objectCache.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "flame.objectCache.name" . }}
+  labels:
+    {{- include "flame.labels" . | nindent 4 }}
+    app.kubernetes.io/component: object-cache
+spec:
+  type: {{ .Values.objectCache.service.type }}
+  ports:
+    - name: flight
+      port: {{ .Values.objectCache.service.port }}
+      targetPort: flight
+      protocol: TCP
+  selector:
+    {{- include "flame.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: object-cache
+{{- end }}

--- a/charts/flame/templates/object-cache-statefulset.yaml
+++ b/charts/flame/templates/object-cache-statefulset.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/component: object-cache
 spec:
   serviceName: {{ include "flame.objectCache.name" . }}
-  replicas: 1
+  replicas: {{ .Values.objectCache.replicas }}
   selector:
     matchLabels:
       {{- include "flame.selectorLabels" . | nindent 6 }}

--- a/charts/flame/templates/object-cache-statefulset.yaml
+++ b/charts/flame/templates/object-cache-statefulset.yaml
@@ -62,6 +62,10 @@ spec:
             tcpSocket:
               port: flight
             periodSeconds: 5
+          livenessProbe:
+            tcpSocket:
+              port: flight
+            periodSeconds: 10
           volumeMounts:
             - name: config
               mountPath: /usr/local/flame/conf/flame-cluster.yaml

--- a/charts/flame/templates/object-cache-statefulset.yaml
+++ b/charts/flame/templates/object-cache-statefulset.yaml
@@ -1,0 +1,137 @@
+{{- if .Values.objectCache.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "flame.objectCache.name" . }}
+  labels:
+    {{- include "flame.labels" . | nindent 4 }}
+    app.kubernetes.io/component: object-cache
+spec:
+  serviceName: {{ include "flame.objectCache.name" . }}
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "flame.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: object-cache
+  template:
+    metadata:
+      labels:
+        {{- include "flame.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: object-cache
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+    spec:
+      serviceAccountName: {{ include "flame.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountToken }}
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: object-cache
+          image: {{ include "flame.image" (dict "root" . "image" .Values.objectCache.image) | quote }}
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          workingDir: /usr/local/flame
+          command:
+            - /usr/local/flame/bin/flame-object-cache
+          args:
+            - --config
+            - /usr/local/flame/conf/flame-cluster.yaml
+          env:
+            - name: RUST_LOG
+              value: info
+            - name: FLAME_HOME
+              value: /usr/local/flame
+            {{- with .Values.objectCache.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          ports:
+            - name: flight
+              containerPort: {{ .Values.objectCache.service.port }}
+              protocol: TCP
+          startupProbe:
+            tcpSocket:
+              port: flight
+            failureThreshold: 30
+            periodSeconds: 2
+          readinessProbe:
+            tcpSocket:
+              port: flight
+            periodSeconds: 5
+          volumeMounts:
+            - name: config
+              mountPath: /usr/local/flame/conf/flame-cluster.yaml
+              subPath: flame-cluster.yaml
+              readOnly: true
+            - name: cache-data
+              mountPath: /var/lib/flame/cache
+            - name: logs
+              mountPath: /usr/local/flame/logs
+            {{- if .Values.tls.enabled }}
+            - name: cache-tls
+              mountPath: {{ include "flame.tlsCachePath" . }}
+              readOnly: true
+            {{- end }}
+            {{- with .Values.objectCache.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.objectCache.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "flame.configMapName" . }}
+        - name: logs
+          emptyDir: {}
+        {{- if not .Values.objectCache.persistence.enabled }}
+        - name: cache-data
+          emptyDir: {}
+        {{- end }}
+        {{- if .Values.tls.enabled }}
+        - name: cache-tls
+          secret:
+            secretName: {{ .Values.tls.cache.secretName }}
+        {{- end }}
+        {{- with .Values.objectCache.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.objectCache.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.objectCache.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.objectCache.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  {{- if .Values.objectCache.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: cache-data
+        labels:
+          {{- include "flame.labels" . | nindent 10 }}
+          app.kubernetes.io/component: object-cache
+      spec:
+        accessModes:
+          {{- toYaml .Values.objectCache.persistence.accessModes | nindent 10 }}
+        resources:
+          requests:
+            storage: {{ .Values.objectCache.persistence.size }}
+        {{- if .Values.objectCache.persistence.storageClassName }}
+        storageClassName: {{ .Values.objectCache.persistence.storageClassName | quote }}
+        {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/flame/templates/serviceaccount.yaml
+++ b/charts/flame/templates/serviceaccount.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "flame.serviceAccountName" . }}
+  labels:
+    {{- include "flame.labels" . | nindent 4 }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountToken }}
+{{- end }}

--- a/charts/flame/templates/session-manager-deployment.yaml
+++ b/charts/flame/templates/session-manager-deployment.yaml
@@ -64,6 +64,10 @@ spec:
             tcpSocket:
               port: frontend
             periodSeconds: 5
+          livenessProbe:
+            tcpSocket:
+              port: frontend
+            periodSeconds: 10
           volumeMounts:
             - name: config
               mountPath: /usr/local/flame/conf/flame-cluster.yaml
@@ -71,8 +75,10 @@ spec:
               readOnly: true
             - name: session-data
               mountPath: /var/lib/flame/session
+              subPath: session
             - name: session-data
               mountPath: /usr/local/flame/events
+              subPath: events
             - name: logs
               mountPath: /usr/local/flame/logs
             {{- if .Values.tls.enabled }}

--- a/charts/flame/templates/session-manager-deployment.yaml
+++ b/charts/flame/templates/session-manager-deployment.yaml
@@ -1,0 +1,127 @@
+{{- if .Values.sessionManager.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "flame.sessionManager.name" . }}
+  labels:
+    {{- include "flame.labels" . | nindent 4 }}
+    app.kubernetes.io/component: session-manager
+spec:
+  replicas: {{ .Values.sessionManager.replicas }}
+  selector:
+    matchLabels:
+      {{- include "flame.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: session-manager
+  template:
+    metadata:
+      labels:
+        {{- include "flame.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: session-manager
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+    spec:
+      serviceAccountName: {{ include "flame.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountToken }}
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: session-manager
+          image: {{ include "flame.image" (dict "root" . "image" .Values.sessionManager.image) | quote }}
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          workingDir: /usr/local/flame
+          command:
+            - /usr/local/flame/bin/flame-session-manager
+          args:
+            - --config
+            - /usr/local/flame/conf/flame-cluster.yaml
+          env:
+            - name: RUST_LOG
+              value: info
+            - name: FLAME_HOME
+              value: /usr/local/flame
+            {{- with .Values.sessionManager.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          ports:
+            - name: frontend
+              containerPort: {{ .Values.sessionManager.service.frontendPort }}
+              protocol: TCP
+            - name: backend
+              containerPort: {{ .Values.sessionManager.service.backendPort }}
+              protocol: TCP
+          startupProbe:
+            tcpSocket:
+              port: frontend
+            failureThreshold: 30
+            periodSeconds: 2
+          readinessProbe:
+            tcpSocket:
+              port: frontend
+            periodSeconds: 5
+          volumeMounts:
+            - name: config
+              mountPath: /usr/local/flame/conf/flame-cluster.yaml
+              subPath: flame-cluster.yaml
+              readOnly: true
+            - name: session-data
+              mountPath: /var/lib/flame/session
+            - name: session-data
+              mountPath: /usr/local/flame/events
+            - name: logs
+              mountPath: /usr/local/flame/logs
+            {{- if .Values.tls.enabled }}
+            - name: cluster-tls
+              mountPath: {{ include "flame.tlsClusterPath" . }}
+              readOnly: true
+            {{- end }}
+            {{- with .Values.sessionManager.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.sessionManager.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "flame.configMapName" . }}
+        - name: session-data
+          {{- if .Values.sessionManager.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "flame.sessionManager.name" . }}-data
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        - name: logs
+          emptyDir: {}
+        {{- if .Values.tls.enabled }}
+        - name: cluster-tls
+          secret:
+            secretName: {{ .Values.tls.cluster.secretName }}
+        {{- end }}
+        {{- with .Values.sessionManager.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.sessionManager.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.sessionManager.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.sessionManager.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/flame/templates/session-manager-pvc.yaml
+++ b/charts/flame/templates/session-manager-pvc.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.sessionManager.enabled .Values.sessionManager.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "flame.sessionManager.name" . }}-data
+  labels:
+    {{- include "flame.labels" . | nindent 4 }}
+    app.kubernetes.io/component: session-manager
+spec:
+  accessModes:
+    {{- toYaml .Values.sessionManager.persistence.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.sessionManager.persistence.size }}
+  {{- if .Values.sessionManager.persistence.storageClassName }}
+  storageClassName: {{ .Values.sessionManager.persistence.storageClassName | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/flame/templates/session-manager-service.yaml
+++ b/charts/flame/templates/session-manager-service.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.sessionManager.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "flame.sessionManager.name" . }}
+  labels:
+    {{- include "flame.labels" . | nindent 4 }}
+    app.kubernetes.io/component: session-manager
+spec:
+  type: {{ .Values.sessionManager.service.type }}
+  ports:
+    - name: frontend
+      port: {{ .Values.sessionManager.service.frontendPort }}
+      targetPort: frontend
+      protocol: TCP
+    - name: backend
+      port: {{ .Values.sessionManager.service.backendPort }}
+      targetPort: backend
+      protocol: TCP
+  selector:
+    {{- include "flame.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: session-manager
+{{- end }}

--- a/charts/flame/templates/tests/test-connection.yaml
+++ b/charts/flame/templates/tests/test-connection.yaml
@@ -1,0 +1,42 @@
+{{- if and .Values.tests.enabled .Values.clientConfig.enabled }}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ include "flame.fullname" . }}-test-connection
+  labels:
+    {{- include "flame.labels" . | nindent 4 }}
+    app.kubernetes.io/component: test
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  {{- with .Values.global.imagePullSecrets }}
+  imagePullSecrets:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  containers:
+    - name: test
+      image: {{ include "flame.image" (dict "root" . "image" .Values.tests.image) | quote }}
+      imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+      command:
+        - /bin/bash
+        - -ec
+      args:
+        - |
+          source /usr/local/flame/sbin/flmenv.sh
+          flmctl --config /etc/flame/flame.yaml list -a
+      volumeMounts:
+        - name: client-config
+          mountPath: /etc/flame/flame.yaml
+          subPath: flame.yaml
+          readOnly: true
+      {{- with .Values.tests.resources }}
+      resources:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  volumes:
+    - name: client-config
+      configMap:
+        name: {{ include "flame.configMapName" . }}
+{{- end }}

--- a/charts/flame/values.schema.json
+++ b/charts/flame/values.schema.json
@@ -27,6 +27,7 @@
     "objectCache": {
       "type": "object",
       "properties": {
+        "replicas": { "type": "integer", "minimum": 1 },
         "service": {
           "type": "object",
           "properties": {

--- a/charts/flame/values.schema.json
+++ b/charts/flame/values.schema.json
@@ -1,0 +1,105 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "global": {
+      "type": "object",
+      "properties": {
+        "imageRegistry": { "type": "string" },
+        "imageTag": { "type": "string" },
+        "imagePullPolicy": { "type": "string" },
+        "imagePullSecrets": { "type": "array" }
+      }
+    },
+    "sessionManager": {
+      "type": "object",
+      "properties": {
+        "replicas": { "type": "integer", "enum": [1] },
+        "service": {
+          "type": "object",
+          "properties": {
+            "frontendPort": { "type": "integer", "minimum": 1, "maximum": 65535 },
+            "backendPort": { "type": "integer", "minimum": 1, "maximum": 65535 }
+          }
+        }
+      }
+    },
+    "objectCache": {
+      "type": "object",
+      "properties": {
+        "service": {
+          "type": "object",
+          "properties": {
+            "port": { "type": "integer", "minimum": 1, "maximum": 65535 }
+          }
+        }
+      }
+    },
+    "executorManager": {
+      "type": "object",
+      "properties": {
+        "replicas": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "tls": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "mountPath": { "type": "string", "minLength": 1 },
+        "cluster": {
+          "type": "object",
+          "properties": {
+            "secretName": { "type": "string" },
+            "certKey": { "type": "string", "minLength": 1 },
+            "privateKeyKey": { "type": "string", "minLength": 1 },
+            "caKey": { "type": "string", "minLength": 1 }
+          }
+        },
+        "cache": {
+          "type": "object",
+          "properties": {
+            "secretName": { "type": "string" },
+            "certKey": { "type": "string", "minLength": 1 },
+            "privateKeyKey": { "type": "string", "minLength": 1 },
+            "caKey": { "type": "string", "minLength": 1 }
+          }
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "tls": {
+            "properties": {
+              "enabled": { "const": true }
+            },
+            "required": ["enabled"]
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "tls": {
+            "properties": {
+              "cluster": {
+                "properties": {
+                  "secretName": { "type": "string", "minLength": 1 }
+                },
+                "required": ["secretName"]
+              },
+              "cache": {
+                "properties": {
+                  "secretName": { "type": "string", "minLength": 1 }
+                },
+                "required": ["secretName"]
+              }
+            },
+            "required": ["cluster", "cache"]
+          }
+        }
+      }
+    }
+  ]
+}

--- a/charts/flame/values.yaml
+++ b/charts/flame/values.yaml
@@ -1,0 +1,132 @@
+global:
+  imageRegistry: xflops
+  imageTag: latest
+  imagePullPolicy: IfNotPresent
+  imagePullSecrets: []
+
+nameOverride: ""
+fullnameOverride: ""
+
+cluster:
+  name: flame
+  resreq: "cpu=1,mem=2g"
+  policies:
+    - priority
+    - drf
+    - gang
+  scheduleInterval: 100
+  storage: "sqlite:///var/lib/flame/session/flame.db"
+  executors:
+    shim: host
+  limits:
+    maxSessions: 1000
+    maxExecutors: 128
+  recovery:
+    session:
+      retryLimits: 5
+
+sessionManager:
+  enabled: true
+  image:
+    repository: flame-session-manager
+    tag: ""
+  replicas: 1
+  service:
+    type: ClusterIP
+    frontendPort: 8080
+    backendPort: 8081
+  persistence:
+    enabled: true
+    storageClassName: ""
+    size: 10Gi
+    accessModes:
+      - ReadWriteOnce
+  resources: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  extraEnv: []
+  extraVolumes: []
+  extraVolumeMounts: []
+
+objectCache:
+  enabled: true
+  image:
+    repository: flame-object-cache
+    tag: ""
+  service:
+    type: ClusterIP
+    port: 9090
+  networkInterface: eth0
+  storage: "/var/lib/flame/cache"
+  persistence:
+    enabled: true
+    storageClassName: ""
+    size: 100Gi
+    accessModes:
+      - ReadWriteOnce
+  eviction:
+    policy: lru
+    maxMemory: 1G
+    maxObjects: null
+  resources: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  extraEnv: []
+  extraVolumes: []
+  extraVolumeMounts: []
+
+executorManager:
+  enabled: true
+  image:
+    repository: flame-executor-manager
+    tag: ""
+  replicas: 3
+  runtimeStorage:
+    medium: ""
+    sizeLimit: ""
+  resources: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  extraEnv: []
+  extraVolumes: []
+  extraVolumeMounts: []
+
+tls:
+  enabled: false
+  mountPath: /etc/flame/certs
+  cluster:
+    secretName: ""
+    certKey: tls.crt
+    privateKeyKey: tls.key
+    caKey: ca.crt
+  cache:
+    secretName: ""
+    certKey: tls.crt
+    privateKeyKey: tls.key
+    caKey: ca.crt
+
+serviceAccount:
+  create: true
+  name: ""
+  automountToken: false
+
+podSecurityContext: {}
+securityContext: {}
+
+clientConfig:
+  enabled: true
+  package:
+    excludes:
+      - "*.log"
+      - "*.pkl"
+      - "*.tmp"
+
+tests:
+  enabled: true
+  image:
+    repository: flame-console
+    tag: ""
+  resources: {}

--- a/charts/flame/values.yaml
+++ b/charts/flame/values.yaml
@@ -54,6 +54,7 @@ objectCache:
   image:
     repository: flame-object-cache
     tag: ""
+  replicas: 1
   service:
     type: ClusterIP
     port: 9090

--- a/ci/k8s/e2e.sh
+++ b/ci/k8s/e2e.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+RELEASE="${RELEASE:-flame}"
+NAMESPACE="${NAMESPACE:-flame-k8s-e2e}"
+CHART_DIR="${CHART_DIR:-${ROOT_DIR}/charts/flame}"
+IMAGE_REGISTRY="${IMAGE_REGISTRY:-xflops}"
+IMAGE_TAG="${IMAGE_TAG:-ci}"
+IMAGE_PULL_POLICY="${IMAGE_PULL_POLICY:-IfNotPresent}"
+TIMEOUT="${TIMEOUT:-10m}"
+FLMPING_TASKS="${FLMPING_TASKS:-3}"
+E2E_POD="${E2E_POD:-${RELEASE}-console-e2e}"
+
+log() {
+    printf '[k8s-e2e] %s\n' "$*"
+}
+
+dump_debug() {
+    log "Kubernetes resources"
+    kubectl -n "$NAMESPACE" get all,pvc 2>/dev/null || true
+
+    log "Recent events"
+    kubectl -n "$NAMESPACE" get events --sort-by=.lastTimestamp 2>/dev/null || true
+
+    for component in session-manager object-cache executor-manager test; do
+        log "Logs for component=${component}"
+        kubectl -n "$NAMESPACE" logs -l "app.kubernetes.io/component=${component}" --all-containers --tail=500 2>/dev/null || true
+    done
+
+    log "Console e2e pod"
+    kubectl -n "$NAMESPACE" describe pod "$E2E_POD" 2>/dev/null || true
+    kubectl -n "$NAMESPACE" logs "$E2E_POD" --all-containers --tail=500 2>/dev/null || true
+}
+
+wait_rollout() {
+    local kind="$1"
+    local component="$2"
+
+    log "Waiting for ${kind}/${component}"
+    kubectl -n "$NAMESPACE" rollout status "$kind" \
+        -l "app.kubernetes.io/instance=${RELEASE},app.kubernetes.io/component=${component}" \
+        --timeout="$TIMEOUT"
+}
+
+trap 'rc=$?; if [ "$rc" -ne 0 ]; then dump_debug; fi' EXIT
+
+log "Linting chart"
+helm lint "$CHART_DIR"
+
+log "Rendering chart"
+helm template "$RELEASE" "$CHART_DIR" \
+    --namespace "$NAMESPACE" \
+    --set "global.imageRegistry=${IMAGE_REGISTRY}" \
+    --set "global.imageTag=${IMAGE_TAG}" \
+    --set "global.imagePullPolicy=${IMAGE_PULL_POLICY}" \
+    --set sessionManager.persistence.enabled=false \
+    --set objectCache.persistence.enabled=false \
+    --set executorManager.replicas=1 \
+    "$@" >/tmp/flame-k8s-e2e-rendered.yaml
+
+log "Installing chart into namespace ${NAMESPACE}"
+helm upgrade --install "$RELEASE" "$CHART_DIR" \
+    --namespace "$NAMESPACE" \
+    --create-namespace \
+    --wait \
+    --timeout "$TIMEOUT" \
+    --set "global.imageRegistry=${IMAGE_REGISTRY}" \
+    --set "global.imageTag=${IMAGE_TAG}" \
+    --set "global.imagePullPolicy=${IMAGE_PULL_POLICY}" \
+    --set sessionManager.persistence.enabled=false \
+    --set objectCache.persistence.enabled=false \
+    --set executorManager.replicas=1 \
+    "$@"
+
+wait_rollout deployment session-manager
+wait_rollout statefulset object-cache
+wait_rollout deployment executor-manager
+
+log "Running Helm chart test"
+helm test "$RELEASE" --namespace "$NAMESPACE" --timeout "$TIMEOUT" --logs
+
+CONFIG_MAP="$(kubectl -n "$NAMESPACE" get configmap \
+    -l "app.kubernetes.io/instance=${RELEASE},app.kubernetes.io/name=flame" \
+    -o jsonpath='{.items[0].metadata.name}')"
+SESSION_SERVICE="$(kubectl -n "$NAMESPACE" get service \
+    -l "app.kubernetes.io/instance=${RELEASE},app.kubernetes.io/component=session-manager" \
+    -o jsonpath='{.items[0].metadata.name}')"
+CACHE_SERVICE="$(kubectl -n "$NAMESPACE" get service \
+    -l "app.kubernetes.io/instance=${RELEASE},app.kubernetes.io/component=object-cache" \
+    -o jsonpath='{.items[0].metadata.name}')"
+
+log "Running in-cluster console e2e pod"
+kubectl -n "$NAMESPACE" delete pod "$E2E_POD" --ignore-not-found=true >/dev/null
+cat <<EOF | kubectl -n "$NAMESPACE" apply -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ${E2E_POD}
+  labels:
+    app.kubernetes.io/name: flame
+    app.kubernetes.io/instance: ${RELEASE}
+    app.kubernetes.io/component: test
+spec:
+  restartPolicy: Never
+  containers:
+    - name: console
+      image: ${IMAGE_REGISTRY}/flame-console:${IMAGE_TAG}
+      imagePullPolicy: ${IMAGE_PULL_POLICY}
+      command:
+        - /bin/bash
+        - -ec
+      args:
+        - |
+          source /usr/local/flame/sbin/flmenv.sh
+          mkdir -p /root/.flame
+          cp /etc/flame/flame.yaml /root/.flame/flame.yaml
+          export FLAME_ENDPOINT=http://${SESSION_SERVICE}:8080
+          export FLAME_CACHE_ENDPOINT=grpc://${CACHE_SERVICE}:9090
+          flmctl --config /root/.flame/flame.yaml list -a
+          flmctl --config /root/.flame/flame.yaml list -n
+          flmping -t ${FLMPING_TASKS}
+      volumeMounts:
+        - name: client-config
+          mountPath: /etc/flame/flame.yaml
+          subPath: flame.yaml
+          readOnly: true
+  volumes:
+    - name: client-config
+      configMap:
+        name: ${CONFIG_MAP}
+EOF
+
+if ! kubectl -n "$NAMESPACE" wait --for=jsonpath='{.status.phase}'=Succeeded "pod/${E2E_POD}" --timeout="$TIMEOUT"; then
+    log "Console e2e pod failed"
+    kubectl -n "$NAMESPACE" logs "$E2E_POD" --all-containers --tail=500 || true
+    exit 1
+fi
+
+kubectl -n "$NAMESPACE" logs "$E2E_POD" --all-containers
+log "Kubernetes e2e completed"

--- a/ci/k8s/e2e.sh
+++ b/ci/k8s/e2e.sh
@@ -12,6 +12,8 @@ IMAGE_PULL_POLICY="${IMAGE_PULL_POLICY:-IfNotPresent}"
 OBJECT_CACHE_REPLICAS="${OBJECT_CACHE_REPLICAS:-2}"
 TIMEOUT="${TIMEOUT:-10m}"
 FLMPING_TASKS="${FLMPING_TASKS:-3}"
+PI_NUM_BATCHES="${PI_NUM_BATCHES:-2}"
+PI_SAMPLES_PER_BATCH="${PI_SAMPLES_PER_BATCH:-1000}"
 E2E_POD="${E2E_POD:-${RELEASE}-console-e2e}"
 
 log() {
@@ -130,6 +132,10 @@ spec:
           flmctl --config /root/.flame/flame.yaml list -a
           flmctl --config /root/.flame/flame.yaml list -n
           flmping -t ${FLMPING_TASKS}
+          cd /usr/local/flame/examples/pi/python
+          export PI_NUM_BATCHES=${PI_NUM_BATCHES}
+          export PI_SAMPLES_PER_BATCH=${PI_SAMPLES_PER_BATCH}
+          uv run main.py
       volumeMounts:
         - name: client-config
           mountPath: /etc/flame/flame.yaml

--- a/ci/k8s/e2e.sh
+++ b/ci/k8s/e2e.sh
@@ -90,6 +90,12 @@ SESSION_SERVICE="$(kubectl -n "$NAMESPACE" get service \
 CACHE_SERVICE="$(kubectl -n "$NAMESPACE" get service \
     -l "app.kubernetes.io/instance=${RELEASE},app.kubernetes.io/component=object-cache" \
     -o jsonpath='{.items[0].metadata.name}')"
+SESSION_FRONTEND_PORT="$(kubectl -n "$NAMESPACE" get service "$SESSION_SERVICE" \
+    -o jsonpath='{.spec.ports[?(@.name=="frontend")].port}')"
+CACHE_FLIGHT_PORT="$(kubectl -n "$NAMESPACE" get service "$CACHE_SERVICE" \
+    -o jsonpath='{.spec.ports[?(@.name=="flight")].port}')"
+: "${SESSION_FRONTEND_PORT:?missing frontend port on service ${SESSION_SERVICE}}"
+: "${CACHE_FLIGHT_PORT:?missing flight port on service ${CACHE_SERVICE}}"
 
 log "Running in-cluster console e2e pod"
 kubectl -n "$NAMESPACE" delete pod "$E2E_POD" --ignore-not-found=true >/dev/null
@@ -116,8 +122,8 @@ spec:
           source /usr/local/flame/sbin/flmenv.sh
           mkdir -p /root/.flame
           cp /etc/flame/flame.yaml /root/.flame/flame.yaml
-          export FLAME_ENDPOINT=http://${SESSION_SERVICE}:8080
-          export FLAME_CACHE_ENDPOINT=grpc://${CACHE_SERVICE}:9090
+          export FLAME_ENDPOINT=http://${SESSION_SERVICE}:${SESSION_FRONTEND_PORT}
+          export FLAME_CACHE_ENDPOINT=grpc://${CACHE_SERVICE}:${CACHE_FLIGHT_PORT}
           flmctl --config /root/.flame/flame.yaml list -a
           flmctl --config /root/.flame/flame.yaml list -n
           flmping -t ${FLMPING_TASKS}

--- a/ci/k8s/e2e.sh
+++ b/ci/k8s/e2e.sh
@@ -9,6 +9,7 @@ CHART_DIR="${CHART_DIR:-${ROOT_DIR}/charts/flame}"
 IMAGE_REGISTRY="${IMAGE_REGISTRY:-xflops}"
 IMAGE_TAG="${IMAGE_TAG:-ci}"
 IMAGE_PULL_POLICY="${IMAGE_PULL_POLICY:-IfNotPresent}"
+OBJECT_CACHE_REPLICAS="${OBJECT_CACHE_REPLICAS:-2}"
 TIMEOUT="${TIMEOUT:-10m}"
 FLMPING_TASKS="${FLMPING_TASKS:-3}"
 E2E_POD="${E2E_POD:-${RELEASE}-console-e2e}"
@@ -57,6 +58,7 @@ helm template "$RELEASE" "$CHART_DIR" \
     --set "global.imagePullPolicy=${IMAGE_PULL_POLICY}" \
     --set sessionManager.persistence.enabled=false \
     --set objectCache.persistence.enabled=false \
+    --set "objectCache.replicas=${OBJECT_CACHE_REPLICAS}" \
     --set executorManager.replicas=1 \
     "$@" >/tmp/flame-k8s-e2e-rendered.yaml
 
@@ -71,6 +73,7 @@ helm upgrade --install "$RELEASE" "$CHART_DIR" \
     --set "global.imagePullPolicy=${IMAGE_PULL_POLICY}" \
     --set sessionManager.persistence.enabled=false \
     --set objectCache.persistence.enabled=false \
+    --set "objectCache.replicas=${OBJECT_CACHE_REPLICAS}" \
     --set executorManager.replicas=1 \
     "$@"
 

--- a/docs/designs/RFE478-helm-install/FS.md
+++ b/docs/designs/RFE478-helm-install/FS.md
@@ -1,0 +1,958 @@
+---
+Issue: #478
+Author: Flame Team
+Date: 2026-05-29
+---
+
+# RFE478: Helm Install for Flame
+
+GitHub issue: https://github.com/xflops/flame/issues/478
+
+## Summary
+
+Add a first-party Helm chart for installing a static Flame cluster on
+Kubernetes. The chart packages the same core components that are currently
+deployed by `flmadm` and `docker compose`:
+
+- `flame-session-manager`
+- `flame-object-cache`
+- `flame-executor-manager`
+
+The first version is a static deployment: Kubernetes schedules the Flame
+control plane, object cache, and a configured number of executor-manager pods.
+It does not implement the future Kubernetes provider that creates workload pods
+or autoscales executors per application demand.
+
+## 1. Motivation
+
+**Background:**
+
+Flame currently has two supported cluster install paths:
+
+- `flmadm`, which installs Flame binaries, configuration, data directories, and
+  systemd services on bare metal or VMs.
+- `docker compose`, which starts the session manager, object cache, executor
+  managers, and a console container for local development.
+
+Many users run production and shared development infrastructure on Kubernetes.
+For those users, `flmadm` is not a natural packaging boundary, and
+`docker compose` is not an operational deployment mechanism. They need a chart
+that can be installed, upgraded, configured, and rolled back with standard Helm
+and Kubernetes workflows.
+
+**Target:**
+
+Provide a Helm chart under `charts/flame` that:
+
+1. Deploys a usable Flame cluster with one `helm install`.
+2. Maps existing Flame component configuration into Kubernetes ConfigMaps,
+   Secrets, Services, Deployments, StatefulSets, and PVCs.
+3. Supports static worker capacity through a configurable executor-manager
+   replica count.
+4. Supports persistent storage for the session-manager state and object-cache
+   data.
+5. Supports optional TLS using existing Kubernetes Secrets.
+6. Keeps the initial chart independent from the future Kubernetes provider and
+   autoscaling work.
+
+Success criteria:
+
+- A user can run:
+
+  ```bash
+  helm install flame ./charts/flame --namespace flame --create-namespace
+  ```
+
+- The install creates a session manager reachable inside the cluster at:
+
+  ```text
+  http://flame-session-manager:8080
+  ```
+
+- The install creates an object cache reachable inside the cluster at:
+
+  ```text
+  grpc://flame-object-cache:9090
+  ```
+
+- The configured executor-manager replicas register as Flame nodes and execute
+  sessions without manual pod creation.
+- `helm upgrade` applies configuration changes through normal Kubernetes
+  rollouts.
+
+## 2. Function Specification
+
+### Configuration
+
+The chart is configured through `values.yaml`. Defaults prioritize a working
+single-namespace development install while allowing production overrides.
+
+```yaml
+global:
+  imageRegistry: xflops
+  imageTag: latest
+  imagePullPolicy: IfNotPresent
+
+nameOverride: ""
+fullnameOverride: ""
+
+cluster:
+  name: flame
+  resreq: "cpu=1,mem=2g"
+  policies:
+    - priority
+    - drf
+    - gang
+  scheduleInterval: 100
+  storage: "sqlite:///var/lib/flame/session/flame.db"
+  executors:
+    shim: host
+  limits:
+    maxSessions: 1000
+    maxExecutors: 128
+  recovery:
+    session:
+      retryLimits: 5
+
+sessionManager:
+  enabled: true
+  image:
+    repository: flame-session-manager
+    tag: ""
+  replicas: 1
+  service:
+    type: ClusterIP
+    frontendPort: 8080
+    backendPort: 8081
+  persistence:
+    enabled: true
+    storageClassName: ""
+    size: 10Gi
+  resources: {}
+
+objectCache:
+  enabled: true
+  image:
+    repository: flame-object-cache
+    tag: ""
+  service:
+    type: ClusterIP
+    port: 9090
+  networkInterface: eth0
+  storage: "/var/lib/flame/cache"
+  persistence:
+    enabled: true
+    storageClassName: ""
+    size: 100Gi
+  eviction:
+    policy: lru
+    maxMemory: 1G
+    maxObjects: null
+  resources: {}
+
+executorManager:
+  enabled: true
+  image:
+    repository: flame-executor-manager
+    tag: ""
+  replicas: 3
+  runtimeStorage:
+    medium: ""
+    sizeLimit: ""
+  resources: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  extraEnv: []
+  extraVolumes: []
+  extraVolumeMounts: []
+
+tls:
+  enabled: false
+  mountPath: /etc/flame/certs
+  cluster:
+    secretName: ""
+    certKey: tls.crt
+    privateKeyKey: tls.key
+    caKey: ca.crt
+  cache:
+    secretName: ""
+    certKey: tls.crt
+    privateKeyKey: tls.key
+    caKey: ca.crt
+
+serviceAccount:
+  create: true
+  name: ""
+
+podSecurityContext: {}
+securityContext: {}
+
+clientConfig:
+  enabled: true
+```
+
+Image resolution:
+
+- Component-specific `image.tag` overrides `global.imageTag`.
+- Component image names are rendered as:
+
+  ```text
+  <global.imageRegistry>/<component.image.repository>:<tag>
+  ```
+
+Rendered cluster configuration:
+
+```yaml
+cluster:
+  name: flame
+  endpoint: "http://flame-session-manager:8080"
+  resreq: "cpu=1,mem=2g"
+  policies:
+    - priority
+    - drf
+    - gang
+  storage: "sqlite:///var/lib/flame/session/flame.db"
+  schedule_interval: 100
+  executors:
+    shim: host
+  limits:
+    max_sessions: 1000
+    max_executors: 128
+  recovery:
+    session:
+      retry_limits: 5
+cache:
+  endpoint: "grpc://flame-object-cache:9090"
+  network_interface: "eth0"
+  storage: "/var/lib/flame/cache"
+  eviction:
+    policy: "lru"
+    max_memory: "1G"
+```
+
+When TLS is enabled, the chart changes endpoint schemes and renders explicit
+TLS sections:
+
+```yaml
+cluster:
+  endpoint: "https://flame-session-manager:8080"
+  tls:
+    cert_file: "/etc/flame/certs/cluster/tls.crt"
+    key_file: "/etc/flame/certs/cluster/tls.key"
+    ca_file: "/etc/flame/certs/cluster/ca.crt"
+cache:
+  endpoint: "grpcs://flame-object-cache:9090"
+  tls:
+    cert_file: "/etc/flame/certs/cache/tls.crt"
+    key_file: "/etc/flame/certs/cache/tls.key"
+    ca_file: "/etc/flame/certs/cache/ca.crt"
+```
+
+TLS validation rules:
+
+- If `tls.enabled=true`, both `tls.cluster.secretName` and
+  `tls.cache.secretName` are required.
+- The chart must not synthesize production certificates.
+- A development-only self-signed certificate helper is out of scope for this
+  RFE.
+- The chart-level TLS settings are convenience values only; they are rendered
+  into the existing `cluster.tls` and `cache.tls` config sections rather than
+  changing Flame's runtime config schema.
+
+### Kubernetes Resources
+
+The chart creates the following resources by default:
+
+| Resource | Kind | Purpose |
+|----------|------|---------|
+| `flame-config` | ConfigMap | Renders `flame-cluster.yaml` and optional in-cluster `flame.yaml`. |
+| `flame-session-manager` | Deployment | Runs the Flame control plane. |
+| `flame-session-manager` | Service | Exposes frontend port `8080` and backend port `8081`. |
+| `flame-session-manager-data` | PVC | Stores SQLite database and event directory when persistence is enabled. |
+| `flame-object-cache` | StatefulSet | Runs the standalone object-cache server. |
+| `flame-object-cache` | Service | Exposes Arrow Flight port `9090`. |
+| `flame-object-cache-data` | VolumeClaimTemplate/PVC | Stores object-cache data when persistence is enabled. |
+| `flame-executor-manager` | Deployment | Runs static worker capacity. |
+| `flame` | ServiceAccount | Shared service account for pods. |
+
+The object cache is a `StatefulSet` because it owns persistent cache data. The
+session manager remains a single-replica `Deployment` for this RFE because Flame
+does not yet define active-active session-manager semantics.
+
+The executor manager is a `Deployment` with configurable replicas. Each pod
+registers as a Flame node using the pod hostname detected by the runtime. This
+matches the static scope: Kubernetes provides pod placement, while Flame's
+scheduler assigns sessions to the already-running executor-manager pods.
+
+### API
+
+No Flame API changes are required.
+
+The chart uses existing component entrypoints and the existing
+`flame-cluster.yaml` configuration schema. The session manager continues to
+serve:
+
+- Frontend gRPC API on `cluster.endpoint` port, default `8080`.
+- Backend gRPC API on `cluster.endpoint + 1`, default `8081`.
+
+The object cache continues to serve Arrow Flight on `cache.endpoint`, default
+port `9090`.
+
+### CLI
+
+Install:
+
+```bash
+helm install flame ./charts/flame \
+  --namespace flame \
+  --create-namespace
+```
+
+Upgrade:
+
+```bash
+helm upgrade flame ./charts/flame \
+  --namespace flame \
+  --values values.yaml
+```
+
+Uninstall:
+
+```bash
+helm uninstall flame --namespace flame
+```
+
+Local access through port forwarding:
+
+```bash
+kubectl -n flame port-forward svc/flame-session-manager 8080:8080
+kubectl -n flame port-forward svc/flame-object-cache 9090:9090
+```
+
+Client environment for port-forwarded access:
+
+```bash
+export FLAME_ENDPOINT=http://127.0.0.1:8080
+export FLAME_CACHE_ENDPOINT=grpc://127.0.0.1:9090
+```
+
+Port forwarding is intended for local inspection, `flmctl list`, and simple
+health checks. Application deployment commands that write package URLs for
+executor-manager pods, such as `flmctl deploy` and Runner package upload, must
+use a cache endpoint that is reachable by both the client and the executor
+pods. For the default ClusterIP install, run those clients inside the cluster or
+expose the object-cache Service through an operator-managed network path.
+
+TLS install with existing Secrets:
+
+```bash
+helm install flame ./charts/flame \
+  --namespace flame \
+  --create-namespace \
+  --set tls.enabled=true \
+  --set tls.cluster.secretName=flame-session-manager-tls \
+  --set tls.cache.secretName=flame-object-cache-tls
+```
+
+### Other Interfaces
+
+If `clientConfig.enabled=true`, the chart renders a client-facing `flame.yaml`
+ConfigMap for in-cluster clients:
+
+```yaml
+current-context: flame
+contexts:
+  - name: flame
+    cluster:
+      endpoint: "http://flame-session-manager:8080"
+    cache:
+      endpoint: "grpc://flame-object-cache:9090"
+    package:
+      excludes:
+        - "*.log"
+        - "*.pkl"
+        - "*.tmp"
+```
+
+`NOTES.txt` prints both in-cluster endpoints and port-forward instructions.
+
+### Scope
+
+**In Scope:**
+
+- Helm chart scaffolding under `charts/flame`.
+- Static Kubernetes deployment for session manager, object cache, and executor
+  managers.
+- ConfigMap rendering for `flame-cluster.yaml`.
+- Optional in-cluster client config rendering for `flame.yaml`.
+- ClusterIP Services for internal component communication.
+- PVC-backed persistence for session manager and object cache.
+- Optional TLS Secret mounts and endpoint scheme rendering.
+- Helm tests that verify the core Services are reachable.
+- Documentation for install, upgrade, uninstall, TLS, and troubleshooting.
+
+**Out of Scope:**
+
+- Kubernetes provider implementation in `session_manager/src/provider/k8s.rs`.
+- Application pod creation, per-application sidecars, or sidecar shim support.
+- Autoscaling based on sessions, tasks, queues, or custom metrics.
+- Horizontal high availability for the session manager.
+- Ingress, Gateway API, or cloud load balancer configuration beyond standard
+  Service values.
+- Certificate generation, cert-manager integration, or mTLS.
+- Publishing the chart to an OCI chart registry.
+- Building or publishing component images.
+
+**Limitations:**
+
+- Session manager is single-replica.
+- Object cache is single-replica and bound to one PVC.
+- Executor capacity is static and changes only when
+  `executorManager.replicas` changes.
+- Executor-manager pods report runtime-detected CPU, memory, and GPU capacity.
+  Kubernetes resource requests and limits still control pod scheduling, but
+  this RFE does not add a Flame-specific resource override mechanism.
+- No Kubernetes RBAC permissions are required for the static chart because
+  Flame does not watch or mutate Kubernetes objects in this version.
+- The chart does not add a stable object-cache advertised endpoint. The current
+  object-cache server derives metadata endpoints from its runtime network
+  interface, which is suitable for in-cluster pod networking but not a complete
+  external-access story.
+
+### Feature Interaction
+
+**Related Features:**
+
+- `flmadm` installation profiles: define the same component split that the
+  chart deploys as containers.
+- Docker Compose deployment: provides current container names, mounted
+  configuration, ports, and cache persistence behavior.
+- RFE234 TLS: defines `cluster.tls`, `cache.tls`, and endpoint scheme
+  conventions.
+- RFE318 Object Cache: defines the standalone object-cache service and storage
+  behavior.
+- RFE420 Application Installer: defines executor-manager package installation
+  behavior and Python/`uv` runtime expectations.
+- RFE429 Object Cache Upload/Download: defines object-cache package URLs using
+  `grpc://` and `grpcs://`.
+- RFE384 Recovery: defines restart and reconnection behavior used when pods
+  restart or roll during upgrades.
+- RFE323 Runner v2: defines session-level `autoscale` behavior. That behavior
+  allocates Flame executors from already-registered worker capacity in this
+  static chart; Kubernetes pod autoscaling remains future provider work.
+- RFE458 `flmctl deploy`: depends on the object-cache endpoint being reachable
+  from clients and executor-manager pods.
+
+**Updates Required:**
+
+- Add chart files under `charts/flame`.
+- Add chart documentation under `charts/flame/README.md` or
+  `docs/tutorials/helm-install.md`.
+- Add CI chart validation with `helm lint` and `helm template`.
+- Optionally add a Kind-based smoke test that installs the chart and verifies
+  the Services and pods become ready.
+
+**Integration Points:**
+
+- Pods mount `flame-cluster.yaml` from a ConfigMap at
+  `/usr/local/flame/conf/flame-cluster.yaml`.
+- Pods set `FLAME_HOME=/usr/local/flame` and `RUST_LOG=info` by default.
+- Component commands run with:
+
+  ```text
+  /usr/local/flame/bin/flame-session-manager --config /usr/local/flame/conf/flame-cluster.yaml
+  /usr/local/flame/bin/flame-object-cache --config /usr/local/flame/conf/flame-cluster.yaml
+  /usr/local/flame/bin/flame-executor-manager --config /usr/local/flame/conf/flame-cluster.yaml
+  ```
+
+- The session-manager and object-cache pods use `/usr/local/flame` as their
+  working directory. This preserves relative paths such as SQLite migrations
+  under `migrations/sqlite`.
+- The executor-manager pod uses `/usr/local/flame/work` as its working
+  directory, matching the existing worker service behavior.
+- Executor-manager pods connect to the session-manager backend by deriving port
+  `8081` from the rendered `cluster.endpoint`.
+- Clients and deployed applications use the rendered object-cache Service on
+  port `9090`.
+
+**Compatibility:**
+
+- Existing `flmadm` and Docker Compose deployment paths continue unchanged.
+- Existing Flame client configuration remains valid; users can point clients at
+  the Helm-installed endpoints.
+- Existing TLS configuration semantics remain unchanged.
+
+**Breaking Changes:**
+
+- None.
+
+## 3. Implementation Detail
+
+### Architecture
+
+```text
+                 Kubernetes namespace: flame
+
+  Client / flmctl / SDK
+          |
+          | http(s)://flame-session-manager:8080
+          v
+  +-----------------------------+
+  | Service: flame-session-     |
+  | manager                     |
+  | ports: 8080, 8081           |
+  +-------------+---------------+
+                |
+                v
+  +-----------------------------+       sqlite/events PVC
+  | Deployment: flame-session-  |------ /var/lib/flame/session
+  | manager replicas: 1         |
+  |                             |------ /usr/local/flame/events
+  +-----------------------------+
+                ^
+                |
+                | backend gRPC, port 8081
+                |
+  +-------------+---------------+
+  | Deployment: flame-executor- |
+  | manager replicas: N         |
+  +-------------+---------------+
+                |
+                | grpc(s)://flame-object-cache:9090
+                v
+  +-----------------------------+       cache PVC
+  | StatefulSet: flame-object-  |------ /var/lib/flame/cache
+  | cache replicas: 1           |
+  +-----------------------------+
+```
+
+### Components
+
+**Chart Metadata (`charts/flame/Chart.yaml`):**
+
+- `apiVersion: v2`
+- `type: application`
+- `appVersion`: Flame release version
+- `version`: chart version
+
+**Values (`charts/flame/values.yaml`):**
+
+- Provides the documented defaults.
+- Keeps component-specific overrides separate from shared global defaults.
+- Uses lower camelCase for chart values and renders snake_case fields expected
+  by Flame config.
+
+**Values Schema (`charts/flame/values.schema.json`):**
+
+- Validates common mistakes before install:
+  - `sessionManager.replicas` must be `1`.
+  - `objectCache` must not set replicas above `1`.
+  - `executorManager.replicas` must be `>= 0`.
+  - Service ports must be valid TCP ports.
+  - TLS Secrets are required when `tls.enabled=true`.
+
+**ConfigMap Templates:**
+
+- Render `flame-cluster.yaml` for server components.
+- Render optional `flame.yaml` for in-cluster clients.
+- Include checksums as pod template annotations so ConfigMap changes trigger
+  rollouts.
+
+**Session Manager Templates:**
+
+- Deployment with one replica.
+- Mounts the shared config.
+- Mounts persistent data at `/var/lib/flame/session` for SQLite state when
+  enabled.
+- Mounts the same persistent volume at `/usr/local/flame/events` for the event
+  directory written relative to the service working directory.
+- Sets `workingDir: /usr/local/flame`.
+- Exposes named ports:
+  - `frontend`: `8080`
+  - `backend`: `8081`
+- Uses TCP startup/readiness probes on the frontend port until Flame exposes a
+  dedicated health endpoint.
+
+**Object Cache Templates:**
+
+- StatefulSet with one replica.
+- Mounts the shared config.
+- Mounts persistent data at `/var/lib/flame/cache` when enabled.
+- Sets `workingDir: /usr/local/flame`.
+- Exposes named port `flight` on `9090`.
+- Uses TCP startup/readiness probes on the Flight port.
+
+**Executor Manager Templates:**
+
+- Deployment with configurable replicas.
+- Mounts the shared config.
+- Supports `nodeSelector`, `affinity`, and `tolerations` for static placement.
+- Supports `extraEnv`, `extraVolumes`, and `extraVolumeMounts` for site-specific
+  GPU, model-cache, or package-cache setup.
+- Does not expose a Service because executor managers initiate outbound
+  connections to the session manager.
+- Sets `workingDir: /usr/local/flame/work`.
+- Mounts writable `emptyDir` volumes for runtime paths that host-shim and app
+  installation code write to:
+
+  | Path | Purpose |
+  |------|---------|
+  | `/usr/local/flame/work` | Per-executor working directories. |
+  | `/usr/local/flame/data/apps` | Installed application releases. |
+  | `/usr/local/flame/data/cache` | `uv` and package caches. |
+  | `/usr/local/flame/logs` | Install and service logs when files are used. |
+  | `/tmp/flame` | Executor-manager shim scratch directory. |
+  | `/var/flame` | Host-shim Unix socket directory. |
+
+  These volumes are pod-local in the static chart. Durable app-install caches
+  can be added later with an optional PVC, but they are not required for a
+  functional first version.
+
+**TLS Secret Mounts:**
+
+- Mount session-manager TLS material under
+  `/etc/flame/certs/cluster`.
+- Mount object-cache TLS material under `/etc/flame/certs/cache`.
+- Mount CA files in executor-manager pods because they act as clients for both
+  the session manager and object cache.
+
+**Helm Test Pod:**
+
+- Runs a small connectivity check.
+- Verifies the session-manager Service port `8080` is reachable.
+- Verifies the object-cache Service port `9090` is reachable.
+- If a client image with `flmctl` is configured for tests, optionally runs:
+
+  ```bash
+  flmctl --config /etc/flame/flame.yaml list -a
+  ```
+
+### Data Structures
+
+Rendered `flame-cluster.yaml` is the main data contract. The chart must map
+values to Flame's existing config structure without requiring runtime changes:
+
+| Chart value | Rendered config |
+|-------------|-----------------|
+| `cluster.name` | `cluster.name` |
+| `cluster.resreq` | `cluster.resreq` |
+| `cluster.policies` | `cluster.policies` |
+| `cluster.scheduleInterval` | `cluster.schedule_interval` |
+| `cluster.storage` | `cluster.storage` |
+| `cluster.executors.shim` | `cluster.executors.shim` |
+| `cluster.limits.maxSessions` | `cluster.limits.max_sessions` |
+| `cluster.limits.maxExecutors` | `cluster.limits.max_executors` |
+| `cluster.recovery.session.retryLimits` | `cluster.recovery.session.retry_limits` |
+| `objectCache.networkInterface` | `cache.network_interface` |
+| `objectCache.storage` | `cache.storage` |
+| `objectCache.eviction.maxMemory` | `cache.eviction.max_memory` |
+| `objectCache.eviction.maxObjects` | `cache.eviction.max_objects` |
+
+The chart should centralize name and endpoint construction in helper templates:
+
+```text
+flame.fullname
+flame.sessionManager.name
+flame.objectCache.name
+flame.clusterEndpoint
+flame.cacheEndpoint
+flame.image
+```
+
+### Algorithms
+
+**Endpoint Rendering:**
+
+1. Resolve the session-manager Service DNS name.
+2. Use `http://` when `tls.enabled=false`; use `https://` when
+   `tls.enabled=true`.
+3. Render `cluster.endpoint` with the frontend port.
+4. Resolve the object-cache Service DNS name.
+5. Use `grpc://` when `tls.enabled=false`; use `grpcs://` when
+   `tls.enabled=true`.
+6. Render `cache.endpoint` with the object-cache port.
+
+**Config Rollout:**
+
+1. Render `flame-cluster.yaml` in a ConfigMap.
+2. Compute a checksum of the rendered ConfigMap content.
+3. Put the checksum in each pod template annotation.
+4. Let Kubernetes perform a rolling restart when configuration changes.
+
+**Static Executor Scaling:**
+
+1. User changes `executorManager.replicas`.
+2. Kubernetes scales the executor-manager Deployment.
+3. New pods start `flame-executor-manager`.
+4. Each executor manager registers as a Flame node through the backend API.
+5. Removed pods stop heartbeating; existing recovery logic releases stale
+   executors and retries tasks according to the configured recovery policy.
+
+**Install Validation:**
+
+1. `values.schema.json` catches structural value errors.
+2. Template `required` and `fail` calls catch cross-field errors, especially
+   TLS Secret requirements.
+3. `helm lint` validates chart syntax.
+4. `helm template` validates renderability without cluster access.
+5. Optional Kind smoke tests validate Kubernetes resource admission and basic
+   service readiness.
+
+### System Considerations
+
+**Performance:**
+
+- The chart introduces no new runtime data path.
+- ClusterIP Services add standard Kubernetes service routing between clients,
+  executor managers, session manager, and object cache.
+- Users should set CPU and memory requests for executor-manager pods so
+  Kubernetes places static capacity predictably.
+
+**Scalability:**
+
+- Executor capacity scales horizontally by changing
+  `executorManager.replicas`.
+- Session-manager and object-cache scale-up are vertical only in this RFE.
+- Future Kubernetes-provider work can add per-application pod scaling without
+  changing this chart's core control-plane resources.
+
+**Reliability:**
+
+- Kubernetes restarts failed pods.
+- Session-manager persistence should be enabled for non-ephemeral clusters.
+- Object-cache persistence should be enabled when cached objects must survive
+  pod restarts.
+- Rolling config changes restart pods through checksum annotations.
+- Executor-manager reconnection and Flame recovery handle pod restarts at the
+  Flame control-plane layer.
+
+**Resource Usage:**
+
+- Session manager needs persistent storage for SQLite and event files when
+  `cluster.storage` is not `none`; the chart mounts both the SQLite directory
+  and the relative event directory.
+- Object cache storage size should be chosen based on expected package and
+  object-cache volume.
+- Object-cache `eviction.maxMemory` should be less than the pod memory limit.
+- Executor-manager pod-local `emptyDir` storage must be large enough for app
+  packages, installed dependencies, working directories, and Unix sockets.
+- GPU workloads require Kubernetes GPU scheduling configuration outside this
+  chart, plus executor-manager pod placement on GPU-capable nodes.
+
+**Security:**
+
+- Plaintext is the default for local development.
+- Production installations should enable TLS and provide existing Secrets.
+- The static chart does not require Kubernetes API write privileges.
+- Pods should run with restrictive `securityContext` values where the runtime
+  environment permits it.
+- External exposure should be done deliberately through Service overrides,
+  Ingress, or Gateway resources outside this first chart scope.
+
+**Observability:**
+
+- Logs are emitted to stdout/stderr and collected by Kubernetes logging.
+- `RUST_LOG` defaults to `info` and is configurable with `extraEnv`.
+- TCP probes validate process-level readiness until HTTP/gRPC health endpoints
+  are available.
+- Future chart versions can add ServiceMonitor resources after Flame exposes
+  metrics or a stable profiling endpoint policy.
+
+**Operational:**
+
+- `helm upgrade` is the supported upgrade path.
+- PVC retention follows Kubernetes and Helm defaults; uninstalling the chart
+  should not silently delete persistent data unless users delete PVCs.
+- `NOTES.txt` must include commands for checking pods, port-forwarding, and
+  configuring local clients.
+- The chart should include a documented "ephemeral development" mode with
+  persistence disabled and a "persistent static cluster" mode with PVCs enabled.
+
+### Dependencies
+
+External:
+
+- Kubernetes with `apps/v1` Deployments and StatefulSets.
+- Helm v3.
+- A StorageClass when persistence is enabled.
+- Container images for:
+  - `xflops/flame-session-manager`
+  - `xflops/flame-object-cache`
+  - `xflops/flame-executor-manager`
+
+Internal:
+
+- `common/src/ctx.rs` for `flame-cluster.yaml` schema.
+- `session_manager` frontend and backend server port behavior.
+- `object_cache` Arrow Flight endpoint and storage behavior.
+- `executor_manager` WatchNode registration and recovery behavior.
+- Existing Dockerfiles and Compose deployment for image and volume conventions.
+
+### Verification Plan
+
+Static validation:
+
+- `helm lint charts/flame`
+- `helm template flame charts/flame`
+- `helm template flame charts/flame --set tls.enabled=true --set tls.cluster.secretName=cluster-tls --set tls.cache.secretName=cache-tls`
+  to verify TLS rendering and validation.
+- `helm template flame charts/flame --set sessionManager.persistence.enabled=false --set objectCache.persistence.enabled=false`
+  to verify ephemeral development mode.
+- `helm template flame charts/flame --set executorManager.runtimeStorage.medium=Memory`
+  to verify runtime `emptyDir` rendering.
+- Validate rendered manifests with the repository's chosen Kubernetes schema
+  validator if one is added to CI.
+
+Chart unit checks:
+
+- Default values render one session-manager Deployment, one object-cache
+  StatefulSet, one executor-manager Deployment, and the expected Services.
+- Rendered `flame-cluster.yaml` uses service DNS names and expected ports.
+- TLS-enabled values render `https://` and `grpcs://` endpoints plus Secret
+  mounts.
+- ConfigMap checksum annotations change when `flame-cluster.yaml` changes.
+- Session-manager and object-cache pods render `workingDir: /usr/local/flame`.
+- Executor-manager pods render `workingDir: /usr/local/flame/work` and writable
+  runtime volumes.
+- `values.schema.json` rejects unsupported session-manager or object-cache
+  replica counts.
+
+Kind smoke test:
+
+1. Create a Kind cluster with the existing `ci/kind.yaml`.
+2. Load or pull the three Flame component images.
+3. Install the chart with default values.
+4. Wait for session-manager, object-cache, and executor-manager pods.
+5. Run the Helm test pod to verify service reachability.
+6. Run `flmctl list -a` from an in-cluster client container using the rendered
+   `flame.yaml`.
+
+Manual verification:
+
+- Scale `executorManager.replicas` up and down and confirm Flame node count
+  follows the static pod count.
+- Restart the session-manager pod with persistence enabled and confirm
+  applications and sessions recover according to existing recovery behavior.
+- Restart the object-cache pod with persistence enabled and confirm cached
+  objects survive.
+- Install with TLS Secrets and confirm plaintext clients fail while TLS clients
+  succeed.
+
+## 4. Use Cases
+
+### Example 1: Local Kind Cluster
+
+Description:
+
+Run Flame on a local Kind cluster for development and SDK testing.
+
+Workflow:
+
+1. Build or load Flame images into Kind.
+2. Install the chart with default values.
+3. Wait for pods to become ready.
+4. Port-forward the session manager and object cache.
+5. Run `flmctl list -a` from the local machine.
+
+Expected outcome:
+
+- One session-manager pod is running.
+- One object-cache pod is running.
+- Three executor-manager pods are running by default.
+- Local clients can inspect cluster state through port-forwarded endpoints.
+
+### Example 2: Static Shared Development Cluster
+
+Description:
+
+Run a persistent namespace-scoped Flame cluster with fixed worker capacity.
+
+Workflow:
+
+1. Create a namespace, StorageClass, and optional image pull secret.
+2. Set persistent volume sizes for session manager and object cache.
+3. Set `executorManager.replicas` to the desired static capacity.
+4. Install or upgrade the chart.
+5. Give users the rendered in-cluster `flame.yaml` or external endpoints.
+
+Expected outcome:
+
+- Flame state survives pod restarts.
+- Object-cache data survives object-cache pod restarts.
+- Executor capacity remains fixed until an operator changes the replica count.
+
+### Example 3: TLS-Enabled Cluster
+
+Description:
+
+Install Flame with encrypted traffic between clients, executor managers,
+session manager, and object cache.
+
+Workflow:
+
+1. Create TLS Secrets for the session manager and object cache.
+2. Install the chart with `tls.enabled=true`.
+3. Verify rendered endpoints use `https://` and `grpcs://`.
+4. Configure clients with the CA certificate.
+
+Expected outcome:
+
+- Session-manager frontend and backend use server-side TLS.
+- Object cache uses TLS for Arrow Flight.
+- Executor managers mount CA files and connect to TLS endpoints.
+
+### Example 4: Scale Static Workers
+
+Description:
+
+Increase static worker capacity for a busy development namespace.
+
+Workflow:
+
+1. Update `executorManager.replicas` from `3` to `10`.
+2. Run `helm upgrade`.
+3. Wait for new executor-manager pods to run.
+4. Confirm Flame node count increases.
+
+Expected outcome:
+
+- Kubernetes creates seven additional executor-manager pods.
+- The new executor managers register as Flame nodes.
+- New sessions can be scheduled onto the added static capacity.
+
+## 5. References
+
+**Related Documents:**
+
+- [RFE234 TLS](../RFE234-tls/FS.md)
+- [RFE318 Object Cache](../RFE318-cache/FS.md)
+- [RFE420 Application Installer](../RFE420-app-installer/FS.md)
+- [RFE429 Object Cache Upload/Download](../RFE429-cache-upload-download/FS.md)
+- [RFE333 flmadm](../RFE333-flmadm/FS.md)
+- [RFE384 Flame Recovery](../RFE384-flame-recovery/FS.md)
+- [RFE323 Runner v2](../RFE323-runner-v2/FS.md)
+- [RFE458 flmctl deploy](../RFE458-flmctl-deploy/FS.md)
+- [README](../../../README.md)
+- [Local Development Tutorial](../../tutorials/local-development.md)
+
+**External References:**
+
+- [GitHub issue #478](https://github.com/xflops/flame/issues/478)
+
+**Implementation References:**
+
+- `compose.yaml`
+- `ci/flame-cluster.yaml`
+- `ci/flame.yaml`
+- `ci/kind.yaml`
+- `docker/Dockerfile.fsm`
+- `docker/Dockerfile.foc`
+- `docker/Dockerfile.fem`
+- `flmadm/src/types.rs`
+- `flmadm/src/managers/config.rs`
+- `flmadm/src/managers/systemd.rs`
+- `common/src/ctx.rs`
+- `session_manager/src/apiserver/mod.rs`
+- `object_cache/src/cache.rs`
+- `executor_manager/src/stream_handler.rs`

--- a/docs/designs/RFE478-helm-install/FS.md
+++ b/docs/designs/RFE478-helm-install/FS.md
@@ -842,6 +842,8 @@ Kind smoke test:
 5. Run the Helm test pod to verify service reachability.
 6. Run `flmctl list -a` from an in-cluster client container using the rendered
    `flame.yaml`.
+7. Run `flmping` and the Python Pi Runner example from the in-cluster
+   `flame-console` image.
 
 Manual verification:
 

--- a/docs/designs/RFE478-helm-install/FS.md
+++ b/docs/designs/RFE478-helm-install/FS.md
@@ -135,6 +135,7 @@ objectCache:
   image:
     repository: flame-object-cache
     tag: ""
+  replicas: 1
   service:
     type: ClusterIP
     port: 9090
@@ -270,15 +271,16 @@ The chart creates the following resources by default:
 | `flame-session-manager` | Deployment | Runs the Flame control plane. |
 | `flame-session-manager` | Service | Exposes frontend port `8080` and backend port `8081`. |
 | `flame-session-manager-data` | PVC | Stores SQLite database and event directory when persistence is enabled. |
-| `flame-object-cache` | StatefulSet | Runs the standalone object-cache server. |
+| `flame-object-cache` | StatefulSet | Runs one or more standalone object-cache servers. |
 | `flame-object-cache` | Service | Exposes Arrow Flight port `9090`. |
-| `flame-object-cache-data` | VolumeClaimTemplate/PVC | Stores object-cache data when persistence is enabled. |
+| `flame-object-cache-data` | VolumeClaimTemplate/PVC | Stores per-replica object-cache data when persistence is enabled. |
 | `flame-executor-manager` | Deployment | Runs static worker capacity. |
 | `flame` | ServiceAccount | Shared service account for pods. |
 
-The object cache is a `StatefulSet` because it owns persistent cache data. The
-session manager remains a single-replica `Deployment` for this RFE because Flame
-does not yet define active-active session-manager semantics.
+The object cache is a `StatefulSet` because each replica owns cache data and
+needs stable pod lifecycle semantics. The session manager remains a
+single-replica `Deployment` for this RFE because Flame does not yet define
+active-active session-manager semantics.
 
 The executor manager is a `Deployment` with configurable replicas. Each pod
 registers as a Flame node using the pod hostname detected by the runtime. This
@@ -407,7 +409,8 @@ contexts:
 **Limitations:**
 
 - Session manager is single-replica.
-- Object cache is single-replica and bound to one PVC.
+- Object-cache replicas are static and change only when `objectCache.replicas`
+  changes. With persistence enabled, each StatefulSet replica gets its own PVC.
 - Executor capacity is static and changes only when
   `executorManager.replicas` changes.
 - Executor-manager pods report runtime-detected CPU, memory, and GPU capacity.
@@ -523,7 +526,7 @@ contexts:
                 v
   +-----------------------------+       cache PVC
   | StatefulSet: flame-object-  |------ /var/lib/flame/cache
-  | cache replicas: 1           |
+  | cache replicas: M           |
   +-----------------------------+
 ```
 
@@ -547,7 +550,7 @@ contexts:
 
 - Validates common mistakes before install:
   - `sessionManager.replicas` must be `1`.
-  - `objectCache` must not set replicas above `1`.
+  - `objectCache.replicas` must be `>= 1`.
   - `executorManager.replicas` must be `>= 0`.
   - Service ports must be valid TCP ports.
   - TLS Secrets are required when `tls.enabled=true`.
@@ -644,6 +647,7 @@ values to Flame's existing config structure without requiring runtime changes:
 | `cluster.limits.maxSessions` | `cluster.limits.max_sessions` |
 | `cluster.limits.maxExecutors` | `cluster.limits.max_executors` |
 | `cluster.recovery.session.retryLimits` | `cluster.recovery.session.retry_limits` |
+| `objectCache.replicas` | StatefulSet `spec.replicas` |
 | `objectCache.networkInterface` | `cache.network_interface` |
 | `objectCache.storage` | `cache.storage` |
 | `objectCache.eviction.maxMemory` | `cache.eviction.max_memory` |
@@ -689,6 +693,15 @@ flame.image
 5. Removed pods stop heartbeating; existing recovery logic releases stale
    executors and retries tasks according to the configured recovery policy.
 
+**Static Object-Cache Scaling:**
+
+1. User changes `objectCache.replicas`.
+2. Kubernetes scales the object-cache StatefulSet.
+3. Each replica starts with the same rendered cache endpoint config and serves
+   through the object-cache Service.
+4. When persistence is enabled, each replica receives its own PVC from the
+   StatefulSet volume claim template.
+
 **Install Validation:**
 
 1. `values.schema.json` catches structural value errors.
@@ -713,7 +726,9 @@ flame.image
 
 - Executor capacity scales horizontally by changing
   `executorManager.replicas`.
-- Session-manager and object-cache scale-up are vertical only in this RFE.
+- Object-cache serving capacity scales horizontally by changing
+  `objectCache.replicas`; cache storage remains per replica by default.
+- Session-manager scale-up is vertical only in this RFE.
 - Future Kubernetes-provider work can add per-application pod scaling without
   changing this chart's core control-plane resources.
 
@@ -821,7 +836,7 @@ Chart unit checks:
 Kind smoke test:
 
 1. Create a Kind cluster with the existing `ci/kind.yaml`.
-2. Load or pull the three Flame component images.
+2. Load or pull the Flame component and console images.
 3. Install the chart with default values.
 4. Wait for session-manager, object-cache, and executor-manager pods.
 5. Run the Helm test pod to verify service reachability.
@@ -832,6 +847,8 @@ Manual verification:
 
 - Scale `executorManager.replicas` up and down and confirm Flame node count
   follows the static pod count.
+- Scale `objectCache.replicas` up and down and confirm the object-cache
+  StatefulSet reaches the requested ready replica count.
 - Restart the session-manager pod with persistence enabled and confirm
   applications and sessions recover according to existing recovery behavior.
 - Restart the object-cache pod with persistence enabled and confirm cached

--- a/examples/pi/python/README.md
+++ b/examples/pi/python/README.md
@@ -31,7 +31,8 @@ The Pi example demonstrates how to use the `flamepy.Runner` API to perform a dis
 ### Files
 
 - **`main.py`**: Contains the batch estimator and distributed orchestration. It submits batches to the Flame cluster, collects results, and prints the final estimate.
-- **`pyproject.toml`**: Defines the package and dependencies, including `flamepy`.
+- **`pyproject.toml`**: Defines the package and third-party dependencies. The
+  Flame environment provides `flamepy`.
 - **`README.md`**: This file; explains the motivation, approach, usage, and output of the example.
 
 ### Key Benefits

--- a/examples/pi/python/main.py
+++ b/examples/pi/python/main.py
@@ -6,9 +6,11 @@ randomly sampling points in a unit square and checking if they fall inside
 a quarter circle.
 """
 
-from flamepy.runner import Runner
-import numpy as np
 import math
+import os
+
+import numpy as np
+from flamepy.runner import Runner
 
 
 def estimate_batch(num_samples: int) -> int:
@@ -35,8 +37,12 @@ def main():
     print("=" * 60)
 
     # Configuration
-    num_batches = 10
-    samples_per_batch = 1_000_000
+    num_batches = int(os.getenv("PI_NUM_BATCHES", "10"))
+    samples_per_batch = int(os.getenv("PI_SAMPLES_PER_BATCH", "1000000"))
+    if num_batches <= 0:
+        raise ValueError("PI_NUM_BATCHES must be greater than 0")
+    if samples_per_batch <= 0:
+        raise ValueError("PI_SAMPLES_PER_BATCH must be greater than 0")
     total_samples = num_batches * samples_per_batch
 
     print(f"\nConfiguration:")

--- a/examples/pi/python/pyproject.toml
+++ b/examples/pi/python/pyproject.toml
@@ -5,11 +5,5 @@ description = "Monte Carlo Estimation of π by flamepy.Runner"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "flamepy",
     "numpy"
 ]
-
-
-
-[tool.uv.sources]
-flamepy = { path = "/usr/local/flame/sdk/python" }

--- a/flmadm/src/managers/installation.rs
+++ b/flmadm/src/managers/installation.rs
@@ -843,6 +843,17 @@ mod tests {
             fs::create_dir_all(&pi_dir).unwrap();
             fs::write(pi_dir.join("README.md"), "readme").unwrap();
 
+            let python_pi_dir = src_dir.join("examples/pi/python");
+            fs::create_dir_all(&python_pi_dir).unwrap();
+            fs::write(python_pi_dir.join(".python-version"), "3.12").unwrap();
+            fs::write(python_pi_dir.join("README.md"), "readme").unwrap();
+            fs::write(python_pi_dir.join("main.py"), "print('pi')").unwrap();
+            fs::write(
+                python_pi_dir.join("pyproject.toml"),
+                "[project]\nname = \"pi\"\n",
+            )
+            .unwrap();
+
             let example_dir = src_dir.join("examples/candle/based");
             fs::create_dir_all(&example_dir).unwrap();
             fs::write(
@@ -870,6 +881,11 @@ mod tests {
             assert!(paths.examples.join("pi/rust/pi-service").exists());
             assert!(paths.examples.join("pi/rust/README.md").exists());
             assert!(!paths.examples.join("pi/rust/deploy.sh").exists());
+            assert!(paths.examples.join("pi/python/.python-version").exists());
+            assert!(paths.examples.join("pi/python/README.md").exists());
+            assert!(paths.examples.join("pi/python/main.py").exists());
+            assert!(paths.examples.join("pi/python/pyproject.toml").exists());
+            assert!(!paths.examples.join("pi/python/pi").exists());
 
             assert!(paths
                 .examples

--- a/flmadm/src/types.rs
+++ b/flmadm/src/types.rs
@@ -94,6 +94,13 @@ const EXAMPLES: &[ExampleSpec] = &[
         assets: &["README.md"],
     },
     ExampleSpec {
+        name: "pi/python",
+        package: "pi-python",
+        relative_dir: "pi/python",
+        binaries: &[],
+        assets: &[".python-version", "README.md", "main.py", "pyproject.toml"],
+    },
+    ExampleSpec {
         name: "candle/based",
         package: "candle-based-example",
         relative_dir: "candle/based",


### PR DESCRIPTION
## Summary

- Backport PR #479 onto `release-0.6`.
- Add the Helm chart, Kubernetes e2e workflow/script, RFE478 design doc, and Python Pi e2e updates from the merged PR.
- Address PR #480 review feedback by failing fast on failed e2e pods, expanding values schema coverage, guarding Helm tests when the session manager is disabled, restoring `flamepy` as a Python Pi dependency, and deriving the session-manager backend port from the frontend port.

## Notes

This branch intentionally does not cherry-pick the separate 0.6 release-note commits. The PR diff is limited to the Helm/Kubernetes backport plus review fixes.

## Verification

- `git diff --check`
- `bash -n ci/k8s/e2e.sh`
- `python3 -m json.tool charts/flame/values.schema.json`
- Ruby YAML parsing for `.github/workflows/e2e-k8s.yaml`, `charts/flame/Chart.yaml`, and `charts/flame/values.yaml`
- TOML parse for `examples/pi/python/pyproject.toml`
- `python3 -m py_compile examples/pi/python/main.py`
- `cargo fmt --check`
- `cargo test -p flmadm copies_all_example_binaries_to_examples_dir`