### PR TITLE
[codex] Use uploaded cache endpoint for Runner packages

### DIFF
--- a/sdk/python/src/flamepy/runner/storage.py
+++ b/sdk/python/src/flamepy/runner/storage.py
@@ -15,11 +15,15 @@ import logging
 import os
 import shutil
 from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
 import requests
 
 from flamepy.core.types import FlameError, FlameErrorCode
+
+if TYPE_CHECKING:
+    from flamepy.core.cache import ObjectRef
 
 logger = logging.getLogger(__name__)
 
@@ -314,6 +318,13 @@ class CacheStorage(StorageBackend):
 
         self._endpoint = f"{self._scheme}://{self._host}:{self._port}"
 
+    @staticmethod
+    def _package_url_from_ref(ref: "ObjectRef") -> str:
+        endpoint = ref.endpoint
+        if endpoint.startswith("grpc+tls://"):
+            endpoint = endpoint.replace("grpc+tls://", "grpcs://", 1)
+        return f"{endpoint.rstrip('/')}/{ref.key.lstrip('/')}"
+
     def upload(self, local_path: str, filename: str) -> str:
         from flamepy.core.cache import upload_object
 
@@ -323,7 +334,7 @@ class CacheStorage(StorageBackend):
         try:
             key = f"{self._app_name}/pkg/{filename}"
             ref = upload_object(key, local_path)
-            url = f"{self._scheme}://{self._host}:{self._port}/{ref.key}"
+            url = self._package_url_from_ref(ref)
             logger.debug(f"Uploaded package to cache: {url}")
             return url
         except Exception as e:

--- a/sdk/python/tests/test_runner.py
+++ b/sdk/python/tests/test_runner.py
@@ -83,6 +83,38 @@ class TestCacheStorage:
 
         assert url == "grpc://host:9090/myapp/pkg/myapp-1.0.0.tar.gz"
 
+    def test_upload_uses_object_ref_endpoint(self, monkeypatch, tmp_path):
+        from flamepy.core.cache import ObjectRef
+
+        test_file = tmp_path / "myapp-1.0.0.tar.gz"
+        test_file.write_bytes(b"package content")
+
+        def mock_upload_object(key, file_path):
+            return ObjectRef(endpoint="grpc://10.244.3.2:9090", key=key, version=1)
+
+        monkeypatch.setattr("flamepy.core.cache.upload_object", mock_upload_object)
+
+        storage = CacheStorage("grpc://flame-object-cache:9090", app_name="myapp")
+        url = storage.upload(str(test_file), "myapp-1.0.0.tar.gz")
+
+        assert url == "grpc://10.244.3.2:9090/myapp/pkg/myapp-1.0.0.tar.gz"
+
+    def test_upload_normalizes_tls_object_ref_endpoint(self, monkeypatch, tmp_path):
+        from flamepy.core.cache import ObjectRef
+
+        test_file = tmp_path / "myapp-1.0.0.tar.gz"
+        test_file.write_bytes(b"package content")
+
+        def mock_upload_object(key, file_path):
+            return ObjectRef(endpoint="grpc+tls://10.244.3.2:9090", key=key, version=1)
+
+        monkeypatch.setattr("flamepy.core.cache.upload_object", mock_upload_object)
+
+        storage = CacheStorage("grpcs://flame-object-cache:9090", app_name="myapp")
+        url = storage.upload(str(test_file), "myapp-1.0.0.tar.gz")
+
+        assert url == "grpcs://10.244.3.2:9090/myapp/pkg/myapp-1.0.0.tar.gz"
+
     def test_download(self, monkeypatch, tmp_path):
         dest_file = tmp_path / "downloaded.tar.gz"
 


### PR DESCRIPTION
## Summary
- Preserve the object-cache endpoint returned by package upload when Runner builds package URLs.
- Normalize grpc+tls:// endpoints to grpcs:// for executor-manager downloads.
- Add Runner storage tests for returned pod endpoints and TLS endpoint normalization.

## Root Cause
Runner uploaded packages through object-cache, but rebuilt the package URL from the configured cache service endpoint instead of the returned ObjectRef endpoint. With multiple object-cache pods behind one ClusterIP service, executor-manager could download from a different cache pod and fail to find the package.

## Verification
- uv run -n pytest tests/test_runner.py -q
- python3 -m py_compile sdk/python/src/flamepy/runner/storage.py sdk/python/tests/test_runner.py
- git diff --check