### PR TITLE
[codex] Revert direct merge of PR 482

### DIFF
--- a/sdk/python/src/flamepy/runner/storage.py
+++ b/sdk/python/src/flamepy/runner/storage.py
@@ -15,15 +15,11 @@ import logging
 import os
 import shutil
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
 import requests
 
 from flamepy.core.types import FlameError, FlameErrorCode
-
-if TYPE_CHECKING:
-    from flamepy.core.cache import ObjectRef
 
 logger = logging.getLogger(__name__)
 
@@ -318,13 +314,6 @@ class CacheStorage(StorageBackend):
 
         self._endpoint = f"{self._scheme}://{self._host}:{self._port}"
 
-    @staticmethod
-    def _package_url_from_ref(ref: "ObjectRef") -> str:
-        endpoint = ref.endpoint
-        if endpoint.startswith("grpc+tls://"):
-            endpoint = endpoint.replace("grpc+tls://", "grpcs://", 1)
-        return f"{endpoint.rstrip('/')}/{ref.key.lstrip('/')}"
-
     def upload(self, local_path: str, filename: str) -> str:
         from flamepy.core.cache import upload_object
 
@@ -334,7 +323,7 @@ class CacheStorage(StorageBackend):
         try:
             key = f"{self._app_name}/pkg/{filename}"
             ref = upload_object(key, local_path)
-            url = self._package_url_from_ref(ref)
+            url = f"{self._scheme}://{self._host}:{self._port}/{ref.key}"
             logger.debug(f"Uploaded package to cache: {url}")
             return url
         except Exception as e:

--- a/sdk/python/tests/test_runner.py
+++ b/sdk/python/tests/test_runner.py
@@ -83,38 +83,6 @@ class TestCacheStorage:
 
         assert url == "grpc://host:9090/myapp/pkg/myapp-1.0.0.tar.gz"
 
-    def test_upload_uses_object_ref_endpoint(self, monkeypatch, tmp_path):
-        from flamepy.core.cache import ObjectRef
-
-        test_file = tmp_path / "myapp-1.0.0.tar.gz"
-        test_file.write_bytes(b"package content")
-
-        def mock_upload_object(key, file_path):
-            return ObjectRef(endpoint="grpc://10.244.3.2:9090", key=key, version=1)
-
-        monkeypatch.setattr("flamepy.core.cache.upload_object", mock_upload_object)
-
-        storage = CacheStorage("grpc://flame-object-cache:9090", app_name="myapp")
-        url = storage.upload(str(test_file), "myapp-1.0.0.tar.gz")
-
-        assert url == "grpc://10.244.3.2:9090/myapp/pkg/myapp-1.0.0.tar.gz"
-
-    def test_upload_normalizes_tls_object_ref_endpoint(self, monkeypatch, tmp_path):
-        from flamepy.core.cache import ObjectRef
-
-        test_file = tmp_path / "myapp-1.0.0.tar.gz"
-        test_file.write_bytes(b"package content")
-
-        def mock_upload_object(key, file_path):
-            return ObjectRef(endpoint="grpc+tls://10.244.3.2:9090", key=key, version=1)
-
-        monkeypatch.setattr("flamepy.core.cache.upload_object", mock_upload_object)
-
-        storage = CacheStorage("grpcs://flame-object-cache:9090", app_name="myapp")
-        url = storage.upload(str(test_file), "myapp-1.0.0.tar.gz")
-
-        assert url == "grpcs://10.244.3.2:9090/myapp/pkg/myapp-1.0.0.tar.gz"
-
     def test_download(self, monkeypatch, tmp_path):
         dest_file = tmp_path / "downloaded.tar.gz"
 


### PR DESCRIPTION
## Summary
- Revert merge commit 572dd3f5, which merged PR #482 directly into release-0.6.
- Restore release-0.6 to the pre-#482 state so the Runner fix can be reapplied through a dedicated cherry-pick PR.

## Why
PR #482 should be brought to release-0.6 through an explicit cherry-pick PR workflow. Since the direct merge already landed, this revert creates the clean base needed for that follow-up PR.

## Verification
- uv run -n pytest tests/test_runner.py -q
- python3 -m py_compile sdk/python/src/flamepy/runner/storage.py sdk/python/tests/test_runner.py
- git diff --check upstream/release-0.6...HEAD