### PR TITLE
Document release process

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,6 +8,7 @@ ci/
 tmp/
 logs/
 certs/
+tasks/
 
 # Ignore logs
 **/*.log

--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ For more details, see the [flmadm README](flmadm/README.md).
 * [Rust API Tutorial](docs/tutorials/rust-api.md)
 * [Local Development](docs/tutorials/local-development.md)
 * [Runner Setup Guide](docs/tutorials/runner-setup.md)
+* [Release Process](docs/release-process.md)
 * [Design Documents](docs/designs/)
 
 ## API Reference

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,0 +1,432 @@
+# Flame Release Process
+
+This runbook is written for a release agent. Follow it as a checklist and record
+the exact versions, commit SHAs, registry URLs, and verification results before
+calling the release complete.
+
+## Release Inputs
+
+Set these values at the start of every release:
+
+```shell
+export RELEASE_TAG=v0.6.0-rc1
+export CARGO_VERSION=0.6.0-rc1
+export PYTHON_VERSION=0.6.0rc1
+export STDNG_VERSION=0.1.8
+export DOCKER_TAG="${RELEASE_TAG}"
+export RELEASE_BRANCH=release-0.6
+export IMAGE_REGISTRY=docker.io/xflops
+export RELEASE_NOTES_FILE=/tmp/flame-${RELEASE_TAG}-notes.md
+```
+
+Version conventions:
+
+- GitHub release tags and Docker tags use the leading `v`: `v0.6.0-rc1`.
+- Cargo package versions omit the leading `v`: `0.6.0-rc1`.
+- PyPI versions follow PEP 440: `0.6.0rc1` instead of `0.6.0-rc1`.
+- Stable releases use `v0.6.0`, `0.6.0`, and `0.6.0`.
+- Published Cargo and PyPI versions are immutable. If one artifact has already
+  been published incorrectly, bump the next release candidate and document the
+  mapping instead of overwriting.
+
+## Required Access
+
+Confirm source and package credentials before changing versions:
+
+```shell
+git fetch upstream --tags --prune
+git status --short
+gh auth status
+cargo owner --list flame-rs
+test -f ~/.pypirc || test -n "${UV_PUBLISH_TOKEN:-}" || test -n "${UV_PUBLISH_PASSWORD:-}"
+```
+
+Confirm container image credentials with the tool selected for the image publish
+step:
+
+```shell
+# Podman path:
+podman login --get-login docker.io || podman login docker.io
+# Docker path:
+docker login docker.io
+```
+
+Required permissions:
+
+- Push access to `upstream` and the release branch.
+- GitHub release/tag permission for `xflops/flame`.
+- crates.io publish permission for `stdng`, `flame-rs-macros`, and `flame-rs`.
+- PyPI publish permission for `flamepy`.
+- Docker Hub publish permission for `xflops/flame-*` repositories.
+
+Keep local `tasks/` notes out of commits and container build contexts.
+`.dockerignore` should include `tasks/`.
+
+## Source Readiness
+
+1. Start from the release branch or create it from the intended base:
+
+   ```shell
+   git switch "${RELEASE_BRANCH}"
+   git pull --ff-only upstream "${RELEASE_BRANCH}"
+   ```
+
+2. Confirm all required source PRs have landed on `main` first. Release branch
+   changes should usually be cherry-picks from main, not release-only feature
+   work.
+
+3. For each backport PR, verify cherry-pick hygiene:
+
+   ```shell
+   git range-diff <source-sha>^..<source-sha> <backport-sha>^..<backport-sha>
+   git show <source-sha> -- | git patch-id --stable
+   git show <backport-sha> -- | git patch-id --stable
+   ```
+
+   The backport should contain only the intended cherry-picked commits plus the
+   standard cherry-pick trailer. Do not mix release notes or unrelated fixes into
+   a mechanical backport PR.
+
+4. Verify CI is green for the release branch. At minimum, inspect GitHub checks
+   for the final release commit and confirm Kubernetes E2E passed when the
+   release includes Helm or image changes.
+
+## Version Metadata
+
+Update the release versions in the files that apply to the release:
+
+- `sdk/python/pyproject.toml`: `project.version = "<PYTHON_VERSION>"`
+- `sdk/python/src/flamepy/__init__.py`: `__version__ = "<PYTHON_VERSION>"`
+- `sdk/python/README.md`: install examples or version references, if present
+- `sdk/rust/macros/Cargo.toml`: `version = "<CARGO_VERSION>"`
+- `stdng/Cargo.toml`: bump only when publishing stdng changes
+- `sdk/rust/Cargo.toml`: `version = "<CARGO_VERSION>"`
+- `sdk/rust/Cargo.toml`: dependency versions for `stdng` and
+  `flame-rs-macros`
+- `charts/flame/Chart.yaml`: `appVersion` for the Flame release
+- `Cargo.lock`: refresh after Cargo metadata changes
+
+Publish order matters for Rust:
+
+1. `stdng`, if its version changed.
+2. `flame-rs-macros`.
+3. `flame-rs`, after its registry dependencies exist.
+
+Do not publish `flame-rs` with duplicated helper code if the helpers belong in
+`stdng`; publish the required `stdng` version first and depend on it from
+`sdk/rust/Cargo.toml`.
+
+## Release Notes
+
+Create the release notes before publishing so package and GitHub metadata use
+the same wording. The notes should include:
+
+- The source comparison range, previous release tag, and target commit.
+- User-facing highlights, breaking changes, and upgrade notes.
+- Package, crate, Docker image, and Helm chart version values.
+- Known gaps, such as local smoke tests that could not be run.
+- Links to source PRs. Backport PRs should be cited only when the backport
+  itself has user-facing behavior.
+
+Write the final body to `${RELEASE_NOTES_FILE}` and use that same file for the
+GitHub release.
+
+## Local Verification
+
+Run the focused checks before publishing anything:
+
+```shell
+cargo fmt --check
+cargo check -p stdng
+cargo check -p flame-rs --features macros
+cargo package --manifest-path stdng/Cargo.toml --allow-dirty
+cargo package --manifest-path sdk/rust/macros/Cargo.toml --allow-dirty
+cargo package --manifest-path sdk/rust/Cargo.toml --allow-dirty --features macros
+```
+
+Python package verification:
+
+```shell
+cd sdk/python
+uv run -n pytest tests/test_runner_e2e.py tests/test_runner.py -q
+uv run -n python -c 'import flamepy; print(flamepy.__version__)'
+uv build --out-dir /tmp/flamepy-${PYTHON_VERSION}-dist
+cd -
+```
+
+Repository checks:
+
+```shell
+git diff --check
+bash -n ci/k8s/e2e.sh
+python3 -m json.tool charts/flame/values.schema.json
+```
+
+If `helm` and a local Kubernetes backend are available, also run:
+
+```shell
+helm lint charts/flame
+helm template flame charts/flame --set global.imageTag="${DOCKER_TAG}"
+```
+
+## Publish Python Package
+
+Build artifacts from `sdk/python` and publish exactly those files:
+
+```shell
+cd sdk/python
+uv build --out-dir /tmp/flamepy-${PYTHON_VERSION}-dist
+uv publish /tmp/flamepy-${PYTHON_VERSION}-dist/*
+cd -
+```
+
+If `uv publish` cannot find credentials, set `UV_PUBLISH_USERNAME` and
+`UV_PUBLISH_PASSWORD` from a secure source. Do not print tokens or `.pypirc`
+contents in logs.
+
+Verify PyPI:
+
+```shell
+curl -fsSL "https://pypi.org/pypi/flamepy/${PYTHON_VERSION}/json" \
+  | python3 -m json.tool
+curl -fsSL "https://pypi.org/simple/flamepy/" | rg "${PYTHON_VERSION}"
+```
+
+For release candidates, PyPI may keep the project-level latest version on the
+latest stable release. That is expected.
+
+## Publish Rust Crates
+
+Publish crates in dependency order. Skip the `stdng` publish command if the
+required `${STDNG_VERSION}` already exists on crates.io and no stdng changes are
+part of the release.
+
+```shell
+cargo publish --manifest-path stdng/Cargo.toml --allow-dirty
+cargo publish --manifest-path sdk/rust/macros/Cargo.toml --allow-dirty
+cargo publish --manifest-path sdk/rust/Cargo.toml --allow-dirty --features macros
+```
+
+After each publish, wait for the registry to expose the version before publishing
+the dependent crate:
+
+```shell
+curl -fsSL "https://crates.io/api/v1/crates/stdng/${STDNG_VERSION}" \
+  | python3 -m json.tool
+curl -fsSL "https://crates.io/api/v1/crates/flame-rs-macros/${CARGO_VERSION}" \
+  | python3 -m json.tool
+curl -fsSL "https://crates.io/api/v1/crates/flame-rs/${CARGO_VERSION}" \
+  | python3 -m json.tool
+```
+
+For `flame-rs`, also verify the crates.io dependency list includes the expected
+published `stdng` and `flame-rs-macros` versions.
+
+## Build And Publish Docker Images
+
+Release Docker images as multi-arch manifest tags for `linux/amd64` and
+`linux/arm64`. The public repositories are:
+
+- `xflops/flame-session-manager`
+- `xflops/flame-object-cache`
+- `xflops/flame-executor-manager`
+- `xflops/flame-console`
+
+Do not move `latest` for release candidates. For stable releases, move `latest`
+only after the versioned tag has been pushed and verified.
+
+Use either Podman or Docker Buildx. Both paths must publish a multi-arch tag
+that contains `linux/amd64` and `linux/arm64`.
+
+Podman prerequisites:
+
+```shell
+podman info
+podman login --get-login docker.io || podman login docker.io
+```
+
+With Podman, build both platforms into each manifest:
+
+```shell
+podman build --platform linux/amd64 \
+  --manifest "${IMAGE_REGISTRY}/flame-session-manager:${DOCKER_TAG}" \
+  -f docker/Dockerfile.fsm .
+podman build --platform linux/arm64 \
+  --manifest "${IMAGE_REGISTRY}/flame-session-manager:${DOCKER_TAG}" \
+  -f docker/Dockerfile.fsm .
+
+podman build --platform linux/amd64 \
+  --manifest "${IMAGE_REGISTRY}/flame-object-cache:${DOCKER_TAG}" \
+  -f docker/Dockerfile.foc .
+podman build --platform linux/arm64 \
+  --manifest "${IMAGE_REGISTRY}/flame-object-cache:${DOCKER_TAG}" \
+  -f docker/Dockerfile.foc .
+
+podman build --platform linux/amd64 \
+  --manifest "${IMAGE_REGISTRY}/flame-executor-manager:${DOCKER_TAG}" \
+  -f docker/Dockerfile.fem .
+podman build --platform linux/arm64 \
+  --manifest "${IMAGE_REGISTRY}/flame-executor-manager:${DOCKER_TAG}" \
+  -f docker/Dockerfile.fem .
+
+podman build --platform linux/amd64 \
+  --manifest "${IMAGE_REGISTRY}/flame-console:${DOCKER_TAG}" \
+  -f docker/Dockerfile.console .
+podman build --platform linux/arm64 \
+  --manifest "${IMAGE_REGISTRY}/flame-console:${DOCKER_TAG}" \
+  -f docker/Dockerfile.console .
+```
+
+Inspect local Podman manifests before pushing:
+
+```shell
+podman manifest inspect "${IMAGE_REGISTRY}/flame-session-manager:${DOCKER_TAG}"
+podman manifest inspect "${IMAGE_REGISTRY}/flame-object-cache:${DOCKER_TAG}"
+podman manifest inspect "${IMAGE_REGISTRY}/flame-executor-manager:${DOCKER_TAG}"
+podman manifest inspect "${IMAGE_REGISTRY}/flame-console:${DOCKER_TAG}"
+```
+
+Push the Podman manifest lists:
+
+```shell
+podman manifest push "${IMAGE_REGISTRY}/flame-session-manager:${DOCKER_TAG}" \
+  "docker://${IMAGE_REGISTRY}/flame-session-manager:${DOCKER_TAG}"
+podman manifest push "${IMAGE_REGISTRY}/flame-object-cache:${DOCKER_TAG}" \
+  "docker://${IMAGE_REGISTRY}/flame-object-cache:${DOCKER_TAG}"
+podman manifest push "${IMAGE_REGISTRY}/flame-executor-manager:${DOCKER_TAG}" \
+  "docker://${IMAGE_REGISTRY}/flame-executor-manager:${DOCKER_TAG}"
+podman manifest push "${IMAGE_REGISTRY}/flame-console:${DOCKER_TAG}" \
+  "docker://${IMAGE_REGISTRY}/flame-console:${DOCKER_TAG}"
+```
+
+Docker Buildx prerequisites:
+
+```shell
+docker info
+docker login docker.io
+docker buildx ls
+```
+
+With Docker Buildx, build and push both platforms directly:
+
+```shell
+docker buildx build --platform linux/amd64,linux/arm64 \
+  -t "${IMAGE_REGISTRY}/flame-session-manager:${DOCKER_TAG}" \
+  -f docker/Dockerfile.fsm --push .
+docker buildx build --platform linux/amd64,linux/arm64 \
+  -t "${IMAGE_REGISTRY}/flame-object-cache:${DOCKER_TAG}" \
+  -f docker/Dockerfile.foc --push .
+docker buildx build --platform linux/amd64,linux/arm64 \
+  -t "${IMAGE_REGISTRY}/flame-executor-manager:${DOCKER_TAG}" \
+  -f docker/Dockerfile.fem --push .
+docker buildx build --platform linux/amd64,linux/arm64 \
+  -t "${IMAGE_REGISTRY}/flame-console:${DOCKER_TAG}" \
+  -f docker/Dockerfile.console --push .
+```
+
+Verify the registry exposes both architectures with Podman:
+
+```shell
+podman manifest inspect "docker://${IMAGE_REGISTRY}/flame-session-manager:${DOCKER_TAG}"
+podman manifest inspect "docker://${IMAGE_REGISTRY}/flame-object-cache:${DOCKER_TAG}"
+podman manifest inspect "docker://${IMAGE_REGISTRY}/flame-executor-manager:${DOCKER_TAG}"
+podman manifest inspect "docker://${IMAGE_REGISTRY}/flame-console:${DOCKER_TAG}"
+```
+
+Verify the registry exposes both architectures with Docker:
+
+```shell
+docker buildx imagetools inspect "${IMAGE_REGISTRY}/flame-session-manager:${DOCKER_TAG}"
+docker buildx imagetools inspect "${IMAGE_REGISTRY}/flame-object-cache:${DOCKER_TAG}"
+docker buildx imagetools inspect "${IMAGE_REGISTRY}/flame-executor-manager:${DOCKER_TAG}"
+docker buildx imagetools inspect "${IMAGE_REGISTRY}/flame-console:${DOCKER_TAG}"
+```
+
+If Docker Hub times out while pulling base images, retry the base image pull for
+the affected platform before rebuilding. Use the matching tool for the selected
+build path:
+
+```shell
+podman pull --platform linux/amd64 docker.io/library/rust:1.95
+podman pull --platform linux/arm64 docker.io/library/rust:1.95
+podman pull --platform linux/amd64 docker.io/library/ubuntu:24.04
+podman pull --platform linux/arm64 docker.io/library/ubuntu:24.04
+docker pull --platform linux/amd64 docker.io/library/rust:1.95
+docker pull --platform linux/arm64 docker.io/library/rust:1.95
+docker pull --platform linux/amd64 docker.io/library/ubuntu:24.04
+docker pull --platform linux/arm64 docker.io/library/ubuntu:24.04
+```
+
+## Kubernetes And Helm Verification
+
+The Helm chart defaults to:
+
+- `global.imageRegistry: xflops`
+- `global.imageTag: latest`
+- component repositories matching the Docker Hub names above
+
+For release validation, install with the versioned tag:
+
+```shell
+helm template flame charts/flame --set global.imageTag="${DOCKER_TAG}"
+helm install flame charts/flame \
+  --namespace flame --create-namespace \
+  --set global.imageTag="${DOCKER_TAG}"
+helm test flame --namespace flame
+```
+
+For Kind-based validation, load or pull the four versioned images and run:
+
+```shell
+IMAGE_REGISTRY="${IMAGE_REGISTRY}" IMAGE_TAG="${DOCKER_TAG}" ci/k8s/e2e.sh
+```
+
+Capture the `helm test`, `flmctl list`, `flmctl list -n`, `flmping`, and Python
+Pi example output when reporting the result.
+
+## Git Tag And GitHub Release
+
+Tag only the final verified release commit:
+
+```shell
+git status --short
+git tag -a "${RELEASE_TAG}" -m "Release ${RELEASE_TAG}"
+git push upstream "${RELEASE_TAG}"
+```
+
+Create the GitHub release after package and image URLs are verified:
+
+```shell
+gh release create "${RELEASE_TAG}" \
+  --repo xflops/flame \
+  --target "${RELEASE_BRANCH}" \
+  --title "${RELEASE_TAG}" \
+  --notes-file "${RELEASE_NOTES_FILE}" \
+  --prerelease
+```
+
+Omit `--prerelease` for stable releases.
+
+## Final Verification
+
+Before declaring the release complete, record:
+
+- Git tag and commit SHA.
+- GitHub release URL.
+- PyPI `flamepy` version URL and uploaded files.
+- crates.io URLs for `stdng`, `flame-rs-macros`, and `flame-rs`.
+- Docker Hub tag URLs and manifest digests for all four images.
+- CI run URLs for the final release commit.
+- Helm/Kubernetes smoke-test output or the reason it was not run locally.
+
+The release is not complete until every intended artifact has a verified remote
+URL or the missing artifact is explicitly documented as blocked.
+
+## Failure Rules
+
+- Do not overwrite Cargo or PyPI versions. Publish a new release candidate.
+- Do not force-push public release tags without release-owner approval.
+- Do not move `latest` for release candidates.
+- Do not reduce E2E coverage to make a release pass.
+- If a release branch needs a fix, land the source change on `main` first when
+  practical, then create a dedicated cherry-pick PR to the release branch.


### PR DESCRIPTION
## Summary

- Add `docs/release-process.md` as an agent-followable release checklist.
- Link the release runbook from the README documentation list.
- Ignore local `tasks/` notes in Docker build contexts.
- Add publish metadata for `stdng` and registry version requirements for the Rust SDK path dependencies.

## Notes

This intentionally excludes release-version bumps for `flamepy`, `flame-rs`, `flame-rs-macros`, and `Cargo.lock`.

The Rust SDK dependency versions match the current main-branch package versions (`stdng 0.1.0`, `flame-rs-macros 0.6.0`). Full `cargo package` for `flame-rs` will require `flame-rs-macros 0.6.0` to exist on crates.io first.

## Verification

- `git diff --cached --check`
- ASCII scan for changed text files
- trailing-whitespace scan for changed text files
- `test -f docs/release-process.md`
- `cargo check -p stdng`
- `cargo check -p flame-rs --features macros`
- `cargo package --manifest-path stdng/Cargo.toml --allow-dirty`
- `cargo package --manifest-path sdk/rust/Cargo.toml --allow-dirty --features macros` failed at registry resolution because crates.io does not yet expose `flame-rs-macros 0.6.0`
