### PR TITLE
Backport PR #488 to release-0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5571,7 +5571,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stdng"
-version = "0.1.0"
+version = "0.1.8"
 dependencies = [
  "rand 0.9.4",
  "thiserror 2.0.18",

--- a/charts/flame/values.yaml
+++ b/charts/flame/values.yaml
@@ -11,11 +11,10 @@ cluster:
   name: flame
   resreq: "cpu=1,mem=2g"
   policies:
-    - priority
     - drf
     - gang
   scheduleInterval: 100
-  storage: "sqlite:///var/lib/flame/session/flame.db"
+  storage: "fs:///var/lib/flame/session"
   executors:
     shim: host
   limits:

--- a/ci/k8s/e2e.sh
+++ b/ci/k8s/e2e.sh
@@ -10,12 +10,26 @@ IMAGE_REGISTRY="${IMAGE_REGISTRY:-xflops}"
 IMAGE_TAG="${IMAGE_TAG:-ci}"
 IMAGE_PULL_POLICY="${IMAGE_PULL_POLICY:-IfNotPresent}"
 OBJECT_CACHE_REPLICAS="${OBJECT_CACHE_REPLICAS:-2}"
+SESSION_MANAGER_STORAGE="${SESSION_MANAGER_STORAGE:-fs:///var/lib/flame/session}"
 TIMEOUT="${TIMEOUT:-10m}"
 FLMPING_TASKS="${FLMPING_TASKS:-3}"
 RUNNER_E2E_TASKS="${RUNNER_E2E_TASKS:-3}"
 PI_NUM_BATCHES="${PI_NUM_BATCHES:-2}"
 PI_SAMPLES_PER_BATCH="${PI_SAMPLES_PER_BATCH:-1000}"
 E2E_POD="${E2E_POD:-${RELEASE}-console-e2e}"
+
+HELM_E2E_ARGS=(
+    --set "global.imageRegistry=${IMAGE_REGISTRY}"
+    --set "global.imageTag=${IMAGE_TAG}"
+    --set "global.imagePullPolicy=${IMAGE_PULL_POLICY}"
+    --set "cluster.storage=${SESSION_MANAGER_STORAGE}"
+    --set "cluster.policies[0]=drf"
+    --set "cluster.policies[1]=gang"
+    --set sessionManager.persistence.enabled=false
+    --set objectCache.persistence.enabled=false
+    --set "objectCache.replicas=${OBJECT_CACHE_REPLICAS}"
+    --set executorManager.replicas=1
+)
 
 log() {
     printf '[k8s-e2e] %s\n' "$*"
@@ -51,18 +65,12 @@ wait_rollout() {
 trap 'rc=$?; if [ "$rc" -ne 0 ]; then dump_debug; fi' EXIT
 
 log "Linting chart"
-helm lint "$CHART_DIR"
+helm lint "$CHART_DIR" "${HELM_E2E_ARGS[@]}" "$@"
 
 log "Rendering chart"
 helm template "$RELEASE" "$CHART_DIR" \
     --namespace "$NAMESPACE" \
-    --set "global.imageRegistry=${IMAGE_REGISTRY}" \
-    --set "global.imageTag=${IMAGE_TAG}" \
-    --set "global.imagePullPolicy=${IMAGE_PULL_POLICY}" \
-    --set sessionManager.persistence.enabled=false \
-    --set objectCache.persistence.enabled=false \
-    --set "objectCache.replicas=${OBJECT_CACHE_REPLICAS}" \
-    --set executorManager.replicas=1 \
+    "${HELM_E2E_ARGS[@]}" \
     "$@" >/tmp/flame-k8s-e2e-rendered.yaml
 
 log "Installing chart into namespace ${NAMESPACE}"
@@ -71,13 +79,7 @@ helm upgrade --install "$RELEASE" "$CHART_DIR" \
     --create-namespace \
     --wait \
     --timeout "$TIMEOUT" \
-    --set "global.imageRegistry=${IMAGE_REGISTRY}" \
-    --set "global.imageTag=${IMAGE_TAG}" \
-    --set "global.imagePullPolicy=${IMAGE_PULL_POLICY}" \
-    --set sessionManager.persistence.enabled=false \
-    --set objectCache.persistence.enabled=false \
-    --set "objectCache.replicas=${OBJECT_CACHE_REPLICAS}" \
-    --set executorManager.replicas=1 \
+    "${HELM_E2E_ARGS[@]}" \
     "$@"
 
 wait_rollout deployment session-manager

--- a/executor_manager/src/main.rs
+++ b/executor_manager/src/main.rs
@@ -27,7 +27,7 @@ mod stream_handler;
 #[derive(Parser)]
 #[command(name = "flame-executor-manager")]
 #[command(author = "XFLOPS <support@xflops.io>")]
-#[command(version = "0.5.0")]
+#[command(version)]
 #[command(about = "Flame Executor Manager", long_about = None)]
 struct Cli {
     #[arg(long)]

--- a/flmctl/src/main.rs
+++ b/flmctl/src/main.rs
@@ -33,8 +33,8 @@ mod view;
 
 #[derive(Parser)]
 #[command(name = "flmctl")]
-#[command(author = "Klaus Ma <klaus1982.cn@gmail.com>")]
-#[command(version = "0.5.0")]
+#[command(author = "XFLOPS <support@xflops.io>")]
+#[command(version)]
 #[command(about = "Flame command line", long_about = None)]
 pub struct Cli {
     /// The configuration of flmctl

--- a/flmexec/src/client.rs
+++ b/flmexec/src/client.rs
@@ -26,8 +26,8 @@ use flame_rs::client::SessionOptions;
 
 #[derive(Parser)]
 #[command(name = "flmexec")]
-#[command(author = "Klaus Ma <klaus1982.cn@gmail.com>")]
-#[command(version = "0.5.0")]
+#[command(author = "XFLOPS <support@xflops.io>")]
+#[command(version)]
 #[command(about = "Flame Executor CLI", long_about = None)]
 struct Cli {
     #[arg(short, long)]

--- a/flmping/src/client.rs
+++ b/flmping/src/client.rs
@@ -31,8 +31,8 @@ use flame_rs::{self as flame};
 
 #[derive(Parser)]
 #[command(name = "flmping")]
-#[command(author = "Xflops <support@xflops.io>")]
-#[command(version = "0.5.0")]
+#[command(author = "XFLOPS <support@xflops.io>")]
+#[command(version)]
 #[command(about = "Flame Ping", long_about = None)]
 struct Cli {
     /// The number of tasks to run

--- a/object_cache/src/main.rs
+++ b/object_cache/src/main.rs
@@ -23,6 +23,8 @@ mod storage;
 
 #[derive(Parser)]
 #[command(name = "flame-object-cache")]
+#[command(author = "XFLOPS <support@xflops.io>")]
+#[command(version)]
 #[command(about = "Standalone object cache server for Flame")]
 struct Args {
     #[arg(short, long)]

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -10,8 +10,8 @@ license-file = "../../LICENSE"
 readme = "README.md"
 
 [dependencies]
-stdng = { path = "../../stdng" }
-flame-rs-macros = { path = "macros", optional = true }
+stdng = { path = "../../stdng", version = "0.1.8" }
+flame-rs-macros = { path = "macros", version = "0.6.0", optional = true }
 
 tower = { workspace = true }
 prost = { workspace = true, features = ["derive"] }

--- a/session_manager/src/main.rs
+++ b/session_manager/src/main.rs
@@ -29,8 +29,8 @@ mod storage;
 
 #[derive(Parser)]
 #[command(name = "flame-session-manager")]
-#[command(author = "Klaus Ma <klaus@xflops.cn>")]
-#[command(version = "0.5.0")]
+#[command(author = "XFLOPS <support@xflops.io>")]
+#[command(version)]
 #[command(about = "Flame Session Manager", long_about = None)]
 struct Cli {
     #[arg(long)]

--- a/stdng/Cargo.toml
+++ b/stdng/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "stdng"
-version = "0.1.0"
+version = "0.1.8"
 edition = "2024"
+description = "An enhancement for Rust standard library"
+repository = "https://github.com/xflops/flame"
+license = "Apache-2.0"
 
 [dependencies]
 thiserror = { workspace = true }


### PR DESCRIPTION
## Summary
- cherry-pick #488 onto release-0.6
- use package-derived CLI versions and XFLOPS author metadata
- add Rust SDK/stdng publish metadata
- use filesystem session-manager storage and only drf/gang policies for the Helm chart and Kubernetes e2e

## Source
- Source PR: #488
- Source commits: bc1d359f, 5ebb99a4, 72753195
- Cherry-pick commits: 550c2efb, 732a6cde, ba2c4e94

## Verification
- git diff --check upstream/release-0.6..HEAD
- bash -n ci/k8s/e2e.sh
- Ruby YAML parse/assertions for chart values and workflow YAML
- python3 -m json.tool charts/flame/values.schema.json
- cargo fmt --check
- cargo check -p stdng
- cargo check -p flame-rs --features macros
- cargo build -p flame-session-manager -p flame-executor-manager -p flmctl -p flmping -p flmexec -p flame-object-cache
- --version smoke checks for all six CLI binaries
- git range-diff against the #488 source commit range