### PR TITLE
[codex] Add 0.6 release notes to main

### DIFF
--- a/docs/releases/v0.6.0.md
+++ b/docs/releases/v0.6.0.md
@@ -1,0 +1,162 @@
+# Flame 0.6.0 Release Notes
+
+Source tag: `v0.6.0` at `12432449a82079a7773ea833f2a9ac15d9ce3c3f` (verified June 4, 2026)
+Release branch: `release-0.6` at the same commit
+
+These notes cover the changes between `v0.5.0` and `v0.6.0`.
+
+Compare: https://github.com/xflops/flame/compare/v0.5.0...v0.6.0
+
+## Release Status
+
+- Source tag: `v0.6.0` at `12432449a82079a7773ea833f2a9ac15d9ce3c3f`, matching the `release-0.6` branch snapshot previously tagged `v0.6.0-rc2`.
+- `flamepy 0.6.0` is published on PyPI: https://pypi.org/project/flamepy/0.6.0/.
+- Verified PyPI artifact hashes:
+  - `flamepy-0.6.0-py3-none-any.whl`: `sha256:0b4b34152b1d27d14ba1313d3970379822967fbc26a0aa5cf096ef1163ec7c54`
+  - `flamepy-0.6.0.tar.gz`: `sha256:63c9b56bf4d499d78258cb715387322238e8ca437da8c05bbe3273a58d03c7a5`
+- Final Docker image tags are published as multi-arch manifests for `linux/amd64` and `linux/arm64`:
+  - `docker.io/xflops/flame-session-manager:v0.6.0`
+    - `linux/amd64`: `sha256:5f2e9c56d09bf50bd838781e753597bc8a49289a97a578a0c2603166f506dbbb`
+    - `linux/arm64`: `sha256:37b7bbd16ee1364f871ca6ecf3243dd516b6b3c9fffe67f3c46443b087d10fa6`
+  - `docker.io/xflops/flame-object-cache:v0.6.0`
+    - `linux/amd64`: `sha256:b2e51c024d87036bb699f07532046012150295c9c22b64d9ec034adf0d06f834`
+    - `linux/arm64`: `sha256:c0cbd77e89cc8dba8d572fc826453064d590b08a00864550fda66a7f8ce8665c`
+  - `docker.io/xflops/flame-executor-manager:v0.6.0`
+    - `linux/amd64`: `sha256:f9bef1492cefd61b130c5208aca3ed626d9ae5436600188e392663aa01972477`
+    - `linux/arm64`: `sha256:c437b356038dad5e84737229ddb5c7b519d458a355c1c18d678d6a0a6552450c`
+  - `docker.io/xflops/flame-console:v0.6.0`
+    - `linux/amd64`: `sha256:af71b1f26b72dea82520b88eed0a8fcea925063ea13a67ea6f8884a649f732ab`
+    - `linux/arm64`: `sha256:03b4709db914ba0f3b66d58065a72ebcbdbc9eb20f836f6e67fc197d2413bc2d`
+- The `latest` Docker tags have not been moved for `0.6.0`.
+- Rust crate status: `stdng 0.1.8`, `flame-rs-macros 0.6.0`, and `flame-rs 0.6.0` are published on crates.io.
+- No remaining gap for the versioned source, PyPI, Rust crate, or Docker `v0.6.0` artifacts.
+
+## Highlights
+
+- Added the Python Runner API for packaging local Python projects and exposing functions, classes, or object instances as Flame services.
+- Added `flmrun`, a built-in Runner template application used by Runner-managed services.
+- Fixed Runner package downloads for multi-object-cache deployments by preserving the cache endpoint returned from package upload.
+- Reworked the Python SDK around synchronous client APIs, object-cache helpers, service sessions, and the `flamepy.runner` module.
+- Simplified the Rust SDK with top-level connection/session helpers, typed task messages, host-service helpers, object-cache helpers, and service macros.
+- Added a standalone object cache with versioned object references, pluggable storage, upload/download support, incremental object fetch, and fast paths for tabular/numpy/Arrow data.
+- Added `flmadm` installation profiles and support for installing Flame components, SDKs, examples, and multiple Python SDK versions.
+- Added `flmctl deploy` and object helper commands for application deployment and object-cache workflows.
+- Added a Helm chart and Kind-based Kubernetes E2E workflow for static Flame installs on Kubernetes.
+- Updated Helm/Kubernetes defaults for filesystem session-manager storage and the `drf`/`gang` policy set.
+- Fixed Flame CLI version metadata so binaries report their package version.
+- Added scheduler policy work for priority scheduling, GPU-aware DRF, dynamic policy configuration, gang/batch flows, and resource requirements.
+- Added session/runtime reliability improvements including TLS, executor recovery, session bind failure recovery, task watching, node/executor persistence, and notifier-based wakeups.
+- Expanded system, E2E, Runner, cache, Python SDK, Rust SDK, and storage test coverage.
+
+## Upgrade Notes
+
+- Python SDK packaging is now versioned as `0.6.0`, requires Python 3.9 or newer, and advertises Python 3.9 through 3.12.
+- Runner imports should use `flamepy.runner`; older `flamepy.rl` naming was replaced.
+- `flmadm install` now requires an explicit profile flag such as `--all`, `--control-plane`, `--worker`, `--cache`, or `--client`.
+- Cluster policy configuration now supports multiple policies through the `policies` list.
+- The Helm chart defaults now configure session-manager storage as `fs:///var/lib/flame/session` and enable only the `drf` and `gang` policies.
+- Object cache references are versioned. Clients can use `get_object`, `update_object`, `patch_object`, `upload_object`, and `download_object` instead of passing raw object payloads through sessions.
+- `flmexec` supports explicit runtime selection for scripts, including Python runtime selection through `FLAME_PYTHON_VERSION`. Its default Python runtime policy is owned by `flmexec` rather than the Rust SDK.
+
+## Python SDK And Runner
+
+- Added `flamepy.Runner` and `flamepy.runner` to package local projects and run Python execution objects remotely ([#298](https://github.com/xflops/flame/pull/298), [#341](https://github.com/xflops/flame/pull/341), [#342](https://github.com/xflops/flame/pull/342)).
+- Added Runner helpers for waiting, selecting, resolving object references, and fetching result objects ([#300](https://github.com/xflops/flame/pull/300), [#363](https://github.com/xflops/flame/pull/363)).
+- Added explicit Runner defaults for stateless functions/classes and stateful object instances ([#474](https://github.com/xflops/flame/pull/474)).
+- Fixed Runner packaging for ad hoc scripts and dependency metadata generation ([#471](https://github.com/xflops/flame/pull/471)).
+- Fixed Runner package URL generation to use the returned object-cache endpoint, so executor-manager downloads packages from the cache pod that stored them in multi-cache deployments ([#482](https://github.com/xflops/flame/pull/482)).
+- Added support for Runner dependencies and Python-version selection in Runner/flmexec workflows ([#468](https://github.com/xflops/flame/pull/468), [#469](https://github.com/xflops/flame/pull/469), [#473](https://github.com/xflops/flame/pull/473)).
+- Added `flmrun` as a built-in application template for Runner services ([#285](https://github.com/xflops/flame/pull/285)).
+- Added Python service-session helpers and renamed the FlamePy agent API to service sessions ([#454](https://github.com/xflops/flame/pull/454)).
+- Added custom session IDs and `open_session` enhancements for Python clients and Runner services ([#351](https://github.com/xflops/flame/pull/351), [#353](https://github.com/xflops/flame/pull/353), [#354](https://github.com/xflops/flame/pull/354)).
+- Added `Session.list_tasks` and task watching improvements for Python clients ([#359](https://github.com/xflops/flame/pull/359), [#371](https://github.com/xflops/flame/pull/371)).
+- Aligned `flamepy` package metadata for the 0.6 release, including `__version__`, Python 3.9+ tooling targets, and Python 3.12 classifier support ([#477](https://github.com/xflops/flame/pull/477)).
+
+## Rust SDK
+
+- Simplified the `flame-rs` API with direct helpers for connecting, creating/opening sessions, running typed tasks, and writing services ([#456](https://github.com/xflops/flame/pull/456)).
+- Added typed service macros and typed task payload support through `FlameMessage` ([#456](https://github.com/xflops/flame/pull/456)).
+- Added Rust object-cache helpers for putting, getting, updating, patching, uploading, downloading, and deleting objects ([#427](https://github.com/xflops/flame/pull/427), [#430](https://github.com/xflops/flame/pull/430), [#456](https://github.com/xflops/flame/pull/456)).
+- Kept `flmexec` Python runtime default policy local to `flmexec` and removed that default from the public Rust SDK surface ([#475](https://github.com/xflops/flame/pull/475)).
+- Fixed Rust SDK logger initialization when `RUST_LOG` is unset ([#343](https://github.com/xflops/flame/pull/343)).
+
+## Object Cache And Storage
+
+- Added the standalone `flame-object-cache` service and object-cache client helpers ([#244](https://github.com/xflops/flame/pull/244), [#321](https://github.com/xflops/flame/pull/321)).
+- Added common-data/object-cache integration and object references for shared session state ([#258](https://github.com/xflops/flame/pull/258), [#259](https://github.com/xflops/flame/pull/259), [#269](https://github.com/xflops/flame/pull/269), [#296](https://github.com/xflops/flame/pull/296)).
+- Added LRU eviction and per-application cache behavior ([#367](https://github.com/xflops/flame/pull/367), [#358](https://github.com/xflops/flame/pull/358)).
+- Added pluggable cache storage backends, object versioning, and a standalone cache binary ([#419](https://github.com/xflops/flame/pull/419), [#427](https://github.com/xflops/flame/pull/427)).
+- Added cache upload/download support with multi-scheme downloaders ([#430](https://github.com/xflops/flame/pull/430)).
+- Added incremental object get, native tabular cache path, and fast-path serialization for numpy/Arrow data ([#444](https://github.com/xflops/flame/pull/444), [#446](https://github.com/xflops/flame/pull/446), [#464](https://github.com/xflops/flame/pull/464)).
+- Added filesystem, HTTP, and none storage engines for session manager and package/cache workflows ([#339](https://github.com/xflops/flame/pull/339), [#344](https://github.com/xflops/flame/pull/344), [#377](https://github.com/xflops/flame/pull/377), [#395](https://github.com/xflops/flame/pull/395)).
+
+## Scheduling And Runtime Management
+
+- Added batch-session support and gang-related E2E coverage ([#401](https://github.com/xflops/flame/pull/401), [#407](https://github.com/xflops/flame/pull/407)).
+- Added priority scheduling and dynamic scheduler policy configuration ([#428](https://github.com/xflops/flame/pull/428), [#432](https://github.com/xflops/flame/pull/432)).
+- Added GPU-aware DRF scheduling with resource requirements ([#434](https://github.com/xflops/flame/pull/434)).
+- Added resource requirement support in the priority plugin ([#442](https://github.com/xflops/flame/pull/442)).
+- Added configurable scheduling interval and moved executor limits into `limits` ([#373](https://github.com/xflops/flame/pull/373), [#396](https://github.com/xflops/flame/pull/396)).
+- Added application URL support, installer metadata, and application cache-key improvements ([#287](https://github.com/xflops/flame/pull/287), [#421](https://github.com/xflops/flame/pull/421), [#425](https://github.com/xflops/flame/pull/425)).
+
+## CLI, Installation, And Local Development
+
+- Added `flmadm` for installation, profile-based component selection, systemd integration, user-local installs, examples, and uninstall flows ([#334](https://github.com/xflops/flame/pull/334), [#338](https://github.com/xflops/flame/pull/338), [#421](https://github.com/xflops/flame/pull/421), [#468](https://github.com/xflops/flame/pull/468)).
+- Added `flmctl deploy` and object helper commands ([#459](https://github.com/xflops/flame/pull/459)).
+- Added JSON output for session commands and improved CLI display behavior ([#215](https://github.com/xflops/flame/pull/215), [#439](https://github.com/xflops/flame/pull/439)).
+- Changed Flame CLI metadata to derive `--version` output from package versions and use `XFLOPS <support@xflops.io>` as the author ([#488](https://github.com/xflops/flame/pull/488)).
+- Added Podman support and local development helpers ([#212](https://github.com/xflops/flame/pull/212)).
+- Added Docker, compose, and local system-test workflows for multi-component clusters ([#345](https://github.com/xflops/flame/pull/345), [#347](https://github.com/xflops/flame/pull/347), [#466](https://github.com/xflops/flame/pull/466), [#470](https://github.com/xflops/flame/pull/470), [#472](https://github.com/xflops/flame/pull/472)).
+
+## Kubernetes And Helm
+
+- Added `charts/flame`, a static Helm chart for installing Flame's session manager, executor manager, object cache, client configuration, ServiceAccount, services, persistent volumes, and Helm test resources ([#479](https://github.com/xflops/flame/pull/479)).
+- Added chart values and schema coverage for images, service ports, storage, runtime volumes, TLS Secret mounting, client config, component enablement, and static object-cache replica counts ([#479](https://github.com/xflops/flame/pull/479)).
+- Updated chart defaults and Kubernetes E2E overrides to use filesystem session-manager storage and only the `drf` and `gang` scheduler policies ([#488](https://github.com/xflops/flame/pull/488)).
+- Added a Kind-based Kubernetes E2E workflow that builds Flame images, installs the Helm chart, runs Helm tests, and verifies `flmctl`, `flmping`, and the Python Pi Runner example from an in-cluster console pod ([#479](https://github.com/xflops/flame/pull/479)).
+
+## Reliability, Recovery, And Observability
+
+- Added TLS support and certificate-generation fixes ([#388](https://github.com/xflops/flame/pull/388), [#411](https://github.com/xflops/flame/pull/411)).
+- Added Flame recovery flows and fixed executor state recovery behavior ([#386](https://github.com/xflops/flame/pull/386), [#403](https://github.com/xflops/flame/pull/403), [#465](https://github.com/xflops/flame/pull/465)).
+- Added node/executor persistence for `flmctl` and session-manager recovery paths ([#383](https://github.com/xflops/flame/pull/383)).
+- Added notifier-based wakeups to reduce busy waiting ([#417](https://github.com/xflops/flame/pull/417)).
+- Added task/event management and task event recording in Rust and Python services ([#238](https://github.com/xflops/flame/pull/238), [#239](https://github.com/xflops/flame/pull/239), [#241](https://github.com/xflops/flame/pull/241), [#242](https://github.com/xflops/flame/pull/242)).
+- Improved executor working-directory validation, stdout/stderr log placement, and cleanup on release ([#360](https://github.com/xflops/flame/pull/360), [#361](https://github.com/xflops/flame/pull/361), [#362](https://github.com/xflops/flame/pull/362)).
+
+## Examples And Documentation
+
+- Added API reference pages, SDK guides, Runner setup guide, Rust API tutorial, and local-development guide ([#451](https://github.com/xflops/flame/pull/451), [#461](https://github.com/xflops/flame/pull/461)).
+- Added and updated examples for Python/Rust Pi, OpenAI agents, LangChain agents, SRA, crawler, Candle, RL, replay buffer, and TorchRL DQN ([#264](https://github.com/xflops/flame/pull/264), [#299](https://github.com/xflops/flame/pull/299), [#424](https://github.com/xflops/flame/pull/424), [#441](https://github.com/xflops/flame/pull/441), [#450](https://github.com/xflops/flame/pull/450), [#453](https://github.com/xflops/flame/pull/453), [#462](https://github.com/xflops/flame/pull/462)).
+- Added the Python Pi example to `flmadm --with-examples` installs and made its workload configurable for fast E2E validation ([#479](https://github.com/xflops/flame/pull/479)).
+- Added design documents for the major 0.6 feature areas, including Runner, cache, storage, scheduler, TLS, recovery, app installer, Helm installation, and SDK simplification.
+- Updated README positioning to "A Distributed Engine for AI" and refreshed project badges ([#443](https://github.com/xflops/flame/pull/443)).
+
+## Testing
+
+- Added Python SDK unit coverage for cache, core, Runner, and service behavior.
+- Added Runner storage regression coverage for returned object-cache endpoints and TLS endpoint normalization ([#482](https://github.com/xflops/flame/pull/482)).
+- Added Rust SDK tests for typed services, macros, object cache, and integration flows.
+- Added E2E coverage for sessions, cache, Runner, `flmexec`, applications, system flows, and scheduler behavior.
+- Added Kubernetes install coverage for the Helm chart, multi-replica object cache, in-cluster client configuration, and Runner-based Python Pi execution ([#479](https://github.com/xflops/flame/pull/479)).
+- Added release-branch E2E coverage for the Python Runner command path ([#485](https://github.com/xflops/flame/pull/485)).
+- Added daily system tests and aligned the system workflow with the CI job format ([#466](https://github.com/xflops/flame/pull/466), [#470](https://github.com/xflops/flame/pull/470), [#472](https://github.com/xflops/flame/pull/472)).
+
+## Fixes
+
+- Fixed fair-share allocation and priority-plugin session desired values ([#276](https://github.com/xflops/flame/pull/276), [#436](https://github.com/xflops/flame/pull/436)).
+- Fixed cache/session state updates, local instance behavior, task failure reporting, and shutdown queue handling ([#214](https://github.com/xflops/flame/pull/214), [#235](https://github.com/xflops/flame/pull/235), [#243](https://github.com/xflops/flame/pull/243), [#315](https://github.com/xflops/flame/pull/315)).
+- Fixed package/dependency caching through `UV_CACHE_DIR` and Runner dependency handling ([#356](https://github.com/xflops/flame/pull/356), [#357](https://github.com/xflops/flame/pull/357)).
+- Fixed Runner package downloads in multi-replica object-cache deployments by using the uploaded object's returned cache endpoint ([#482](https://github.com/xflops/flame/pull/482)).
+- Fixed Docker image rebuild behavior and added missing tooling to the executor-manager image ([#348](https://github.com/xflops/flame/pull/348), [#385](https://github.com/xflops/flame/pull/385)).
+- Fixed Unix socket path length handling for host shim communication ([#405](https://github.com/xflops/flame/pull/405)).
+- Fixed `flmping` output and README/example drift ([#217](https://github.com/xflops/flame/pull/217), [#256](https://github.com/xflops/flame/pull/256), [#328](https://github.com/xflops/flame/pull/328)).
+
+## Contributors
+
+Thanks to everyone who contributed changes in this release cycle:
+
+- Klaus Ma ([@k82cn](https://github.com/k82cn))
+- Zhe Jin ([@jinzhejz](https://github.com/jinzhejz))
+- Shida Qiu ([@SataQiu](https://github.com/SataQiu))
+- Xavier Chang ([@Monokaix](https://github.com/Monokaix))


### PR DESCRIPTION
## Summary

Add the Flame 0.6.0 release notes to `main` under `docs/releases/v0.6.0.md`.

## Context

PR #476 was originally merged into `release-0.6`, but release notes should live on `main`. This PR carries the same final release-note content from #476 onto the main branch.

A separate cleanup PR removes the file from `release-0.6`.

## Validation

- Confirmed `upstream/main` did not already contain `docs/releases/v0.6.0.md`.
- Confirmed the added file is byte-identical to the final `docs/releases/v0.6.0.md` from PR #476.
- Confirmed the branch adds only `docs/releases/v0.6.0.md`.
- Ran `git diff --check` on the staged release-note diff.
