### PR TITLE
gang: track incomplete_tasks on-demand via bind/unbind hooks

### DIFF
--- a/session_manager/src/scheduler/plugins/gang.rs
+++ b/session_manager/src/scheduler/plugins/gang.rs
@@ -154,6 +154,7 @@ impl Plugin for GangPlugin {
     fn on_session_bind(&mut self, ssn: SessionInfoPtr) {
         if let Some(state) = self.ssn_state.get_mut(&ssn.id) {
             state.bound += 1;
+            state.incomplete_tasks = state.incomplete_tasks.saturating_sub(1);
         }
     }
 
@@ -166,6 +167,7 @@ impl Plugin for GangPlugin {
     fn on_session_unbind(&mut self, ssn: SessionInfoPtr) {
         if let Some(state) = self.ssn_state.get_mut(&ssn.id) {
             state.bound = state.bound.saturating_sub(1);
+            state.incomplete_tasks = state.incomplete_tasks.saturating_add(1);
         }
     }
 }


### PR DESCRIPTION
## Summary

Update GangPlugin to track `incomplete_tasks` dynamically via bind/unbind hooks instead of relying solely on the snapshot value from `setup()`.

## Changes

- Decrement `incomplete_tasks` in `on_session_bind()` when a task is bound to an executor
- Increment `incomplete_tasks` in `on_session_unbind()` when an executor is unbound

## Motivation

The `incomplete_tasks` value was previously calculated once in `setup()` and remained static throughout the scheduling cycle. This could become stale as tasks are bound/unbound during the cycle. By updating it on-demand via hooks, the gang scheduling decisions (`is_ready`/`is_fulfilled`) now reflect the current state.

## Testing

All 21 gang plugin tests pass.